### PR TITLE
small fixes

### DIFF
--- a/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
+++ b/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
@@ -677,6 +677,12 @@ void AppleseedDisneyMtl::SetAmbient(Color c, TimeValue t)
 
 void AppleseedDisneyMtl::SetDiffuse(Color c, TimeValue t)
 {
+    Point3 p;
+    Interval iv;
+    m_pblock->SetValue( ParamIdBaseColor, t, Point3(c.r,c.g,c.b));
+
+    m_pblock->GetValue( ParamIdBaseColor, t, p, iv );
+    m_base_color = Color(p.x,p.y,p.z);
 }
 
 void AppleseedDisneyMtl::SetSpecular(Color c, TimeValue t)

--- a/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
+++ b/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
@@ -677,12 +677,12 @@ void AppleseedDisneyMtl::SetAmbient(Color c, TimeValue t)
 
 void AppleseedDisneyMtl::SetDiffuse(Color c, TimeValue t)
 {
-    Point3 p;
+    Color nc;
     Interval iv;
-    m_pblock->SetValue( ParamIdBaseColor, t, Point3(c.r,c.g,c.b));
+    m_pblock->SetValue(ParamIdBaseColor, t, c);
 
-    m_pblock->GetValue( ParamIdBaseColor, t, p, iv );
-    m_base_color = Color(p.x,p.y,p.z);
+    m_pblock->GetValue(ParamIdBaseColor, t, nc, iv );
+    m_base_color = nc;
 }
 
 void AppleseedDisneyMtl::SetSpecular(Color c, TimeValue t)

--- a/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.cpp
+++ b/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.cpp
@@ -54,6 +54,7 @@
 #include <iparamm2.h>
 #include <stdmat.h>
 #include <strclass.h>
+#include <hsv.h>
 
 // Windows headers.
 #include <tchar.h>
@@ -591,7 +592,8 @@ float AppleseedGlassMtl::GetShinStr(int mtlNum, BOOL backFace)
 
 float AppleseedGlassMtl::GetXParency(int mtlNum, BOOL backFace)
 {
-    return 0.0f;
+    Color hsv = RGBtoHSV (m_refraction_tint);
+    return hsv.b;
 }
 
 void AppleseedGlassMtl::SetAmbient(Color c, TimeValue t)

--- a/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.cpp
+++ b/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.cpp
@@ -51,10 +51,10 @@
 // 3ds Max headers.
 #include <AssetManagement/AssetUser.h>
 #include <color.h>
+#include <hsv.h>
 #include <iparamm2.h>
 #include <stdmat.h>
 #include <strclass.h>
-#include <hsv.h>
 
 // Windows headers.
 #include <tchar.h>
@@ -592,7 +592,7 @@ float AppleseedGlassMtl::GetShinStr(int mtlNum, BOOL backFace)
 
 float AppleseedGlassMtl::GetXParency(int mtlNum, BOOL backFace)
 {
-    Color hsv = RGBtoHSV (m_refraction_tint);
+    const Color hsv = RGBtoHSV (m_refraction_tint);
     return hsv.b;
 }
 

--- a/src/appleseed-max-impl/utilities.cpp
+++ b/src/appleseed-max-impl/utilities.cpp
@@ -171,18 +171,23 @@ std::string insert_texture_and_instance(
     }
 
     const std::string texture_name = wide_to_utf8(bitmap_tex->GetName());
-    base_group.textures().insert(
-        asr::DiskTexture2dFactory::static_create(
+    if (base_group.textures().get_by_name(texture_name.c_str()) == nullptr)
+    {
+        base_group.textures().insert(
+            asr::DiskTexture2dFactory::static_create(
             texture_name.c_str(),
             texture_params,
             asf::SearchPaths()));
+    }
 
     const std::string texture_instance_name = texture_name + "_inst";
-    base_group.texture_instances().insert(
-        asr::TextureInstanceFactory::create(
+    if (base_group.texture_instances().get_by_name(texture_instance_name.c_str()) == nullptr)
+    {
+        base_group.texture_instances().insert(
+            asr::TextureInstanceFactory::create(
             texture_instance_name.c_str(),
             texture_instance_params,
             texture_name.c_str()));
-
+    }
     return texture_instance_name;
 }

--- a/src/appleseed-max-impl/utilities.cpp
+++ b/src/appleseed-max-impl/utilities.cpp
@@ -191,3 +191,4 @@ std::string insert_texture_and_instance(
     }
     return texture_instance_name;
 }
+


### PR DESCRIPTION
Hi,
this fixes changing diffuse colors from the multi-material's color swatches, makes glass material transparent in viewports and also "fixes" duplicated textures error. 
"Fixes" duplicated textures in the sense that it avoids adding textures with the same name, but in max it is possible to have different texture with the same name. 
It could be possible to track max's map instances in the same way as materials are collected. But textures are created from each material class and I didn't know if I should add another map for the textures to the populate_assembly and pass it to each material.
