### PR TITLE
Compile for 3ds max 2016

### DIFF
--- a/src/appleseed-max-impl/appleseed-max2016-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2016-impl.vcxproj
@@ -1,0 +1,250 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Ship|x64">
+      <Configuration>Ship</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{62C41566-DBCB-49D3-943A-4DD53222269E}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>appleseedmax</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v110</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v110</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v110</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>appleseed-max2015-impl</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>appleseed-max2015-impl</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>appleseed-max2015-impl</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>WIN32;WIN64;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;BOOST_FILESYSTEM_VERSION=3;BOOST_FILESYSTEM_NO_DEPRECATED;APPLESEED_WITH_OIIO;OIIO_STATIC_BUILD;APPLESEED_WITH_OSL;OSL_STATIC_LIBRARY;APPLESEED_WITH_DISNEY_MATERIAL;APPLESEED_WITH_NORMALIZED_DIFFUSION_BSSRDF;XERCES_STATIC_LIBRARY;BOOST_PYTHON_STATIC_LIB;APPLESEED_X86;APPLESEED_USE_SSE;DEBUG;APPLESEED_ENABLE_IMATH_INTEROP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(ProjectDir);C:\Program Files\Autodesk\3ds Max 2016 SDK\maxsdk\include;$(SolutionDir)..\..\boost_1_55_0;$(SolutionDir)..\..\appleseed\src\appleseed;$(SolutionDir)..\..\appleseed-deps\stage\vc11\ilmbase-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc11\openexr-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc11\oiio-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc11\osl-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc11\SeExpr-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc11\SeExpr-release\include</AdditionalIncludeDirectories>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <MinimalRebuild>false</MinimalRebuild>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2016 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\v110\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc11;$(SolutionDir)..\..\boost_1_55_0\stage\lib</AdditionalLibraryDirectories>
+      <AdditionalDependencies>wininet.lib;bmm.lib;core.lib;geom.lib;maxutil.lib;mesh.lib;Paramblk2.lib;Pathcch.lib;appleseed.lib;ilmbase-debug\lib\Half.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <DelayLoadDLLs>
+      </DelayLoadDLLs>
+    </Link>
+    <PostBuildEvent>
+      <Command>mkdir "$(SolutionDir)..\bin\appleseed-max2016\$(Platform)\$(Configuration)" 2&gt;nul
+
+copy /Y "$(TargetPath)" "$(SolutionDir)..\bin\appleseed-max2016\$(Platform)\$(Configuration)\"
+copy /Y "$(SolutionDir)..\..\appleseed\build\vc11\src\appleseed\$(ConfigurationName)\appleseed.dll" "$(SolutionDir)..\bin\appleseed-max2016\$(Platform)\$(Configuration)\"
+
+copy /Y "$(TargetPath)" "$(SolutionDir)..\..\appleseed-max2016-plugin-folder\"
+copy /Y "$(SolutionDir)..\..\appleseed\build\vc11\src\appleseed\$(ConfigurationName)\appleseed.dll" "$(SolutionDir)..\..\appleseed-max2016-plugin-folder\"
+copy /Y "$(SolutionDir)..\..\appleseed\build\vc11\src\appleseed\$(ConfigurationName)\appleseed.pdb" "$(SolutionDir)..\..\appleseed-max2016-plugin-folder\"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>Full</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;WIN64;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;BOOST_FILESYSTEM_VERSION=3;BOOST_FILESYSTEM_NO_DEPRECATED;APPLESEED_WITH_OIIO;OIIO_STATIC_BUILD;APPLESEED_WITH_OSL;OSL_STATIC_LIBRARY;APPLESEED_WITH_DISNEY_MATERIAL;APPLESEED_WITH_NORMALIZED_DIFFUSION_BSSRDF;XERCES_STATIC_LIBRARY;BOOST_PYTHON_STATIC_LIB;APPLESEED_X86;APPLESEED_USE_SSE;APPLESEED_ENABLE_IMATH_INTEROP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(ProjectDir);C:\Program Files\Autodesk\3ds Max 2016 SDK\maxsdk\include;$(SolutionDir)..\..\appleseed\src\appleseed;$(SolutionDir)..\..\boost_1_55_0;$(SolutionDir)..\..\appleseed-deps\stage\vc11\ilmbase-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc11\openexr-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc11\oiio-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc11\osl-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc11\SeExpr-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc11\SeExpr-release\include</AdditionalIncludeDirectories>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <StringPooling>true</StringPooling>
+      <FunctionLevelLinking>false</FunctionLevelLinking>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2016 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\v110\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc11;$(SolutionDir)..\..\boost_1_55_0\stage\lib</AdditionalLibraryDirectories>
+      <AdditionalDependencies>wininet.lib;bmm.lib;core.lib;geom.lib;maxutil.lib;mesh.lib;Pathcch.lib;Paramblk2.lib;appleseed.lib;ilmbase-release\lib\Half.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>
+      </DelayLoadDLLs>
+    </Link>
+    <PostBuildEvent>
+      <Command>mkdir "$(SolutionDir)..\bin\appleseed-max2016\$(Platform)\$(Configuration)" 2&gt;nul
+
+copy /Y "$(TargetPath)" "$(SolutionDir)..\bin\appleseed-max2016\$(Platform)\$(Configuration)\"
+copy /Y "$(SolutionDir)..\..\appleseed\build\vc11\src\appleseed\$(ConfigurationName)\appleseed.dll" "$(SolutionDir)..\bin\appleseed-max2016\$(Platform)\$(Configuration)\"
+
+copy /Y "$(TargetPath)" "$(SolutionDir)..\..\appleseed-max2016-plugin-folder\"
+copy /Y "$(SolutionDir)..\..\appleseed\build\vc11\src\appleseed\$(ConfigurationName)\appleseed.dll" "$(SolutionDir)..\..\appleseed-max2016-plugin-folder\"
+copy /Y "$(SolutionDir)..\..\appleseed\build\vc11\src\appleseed\$(ConfigurationName)\appleseed.pdb" "$(SolutionDir)..\..\appleseed-max2016-plugin-folder\"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>Full</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;WIN64;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;BOOST_FILESYSTEM_VERSION=3;BOOST_FILESYSTEM_NO_DEPRECATED;APPLESEED_WITH_OIIO;OIIO_STATIC_BUILD;APPLESEED_WITH_OSL;OSL_STATIC_LIBRARY;APPLESEED_WITH_DISNEY_MATERIAL;APPLESEED_WITH_NORMALIZED_DIFFUSION_BSSRDF;XERCES_STATIC_LIBRARY;BOOST_PYTHON_STATIC_LIB;APPLESEED_X86;APPLESEED_USE_SSE;APPLESEED_ENABLE_IMATH_INTEROP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(ProjectDir);C:\Program Files\Autodesk\3ds Max 2016 SDK\maxsdk\include;$(SolutionDir)..\..\appleseed\src\appleseed;$(SolutionDir)..\..\boost_1_55_0;$(SolutionDir)..\..\appleseed-deps\stage\vc11\ilmbase-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc11\openexr-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc11\oiio-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc11\osl-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc11\SeExpr-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc11\SeExpr-release\include</AdditionalIncludeDirectories>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <StringPooling>true</StringPooling>
+      <FunctionLevelLinking>false</FunctionLevelLinking>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <DebugInformationFormat>None</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2016 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\v110\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc11;$(SolutionDir)..\..\boost_1_55_0\stage\lib</AdditionalLibraryDirectories>
+      <AdditionalDependencies>wininet.lib;bmm.lib;core.lib;geom.lib;maxutil.lib;mesh.lib;Pathcch.lib;Paramblk2.lib;appleseed.lib;ilmbase-release\lib\Half.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>
+      </DelayLoadDLLs>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+    </Link>
+    <PostBuildEvent>
+      <Command>mkdir "$(SolutionDir)..\bin\appleseed-max2016\$(Platform)\$(Configuration)" 2&gt;nul
+
+copy /Y "$(TargetPath)" "$(SolutionDir)..\bin\appleseed-max2016\$(Platform)\$(Configuration)\"
+copy /Y "$(SolutionDir)..\..\appleseed\build\vc11\src\appleseed\$(ConfigurationName)\appleseed.dll" "$(SolutionDir)..\bin\appleseed-max2016\$(Platform)\$(Configuration)\"
+
+copy /Y "$(TargetPath)" "$(SolutionDir)..\..\appleseed-max2016-plugin-folder\"
+copy /Y "$(SolutionDir)..\..\appleseed\build\vc11\src\appleseed\$(ConfigurationName)\appleseed.dll" "$(SolutionDir)..\..\appleseed-max2016-plugin-folder\"
+copy /Y "$(SolutionDir)..\..\appleseed\build\vc11\src\appleseed\$(ConfigurationName)\appleseed.pdb" "$(SolutionDir)..\..\appleseed-max2016-plugin-folder\"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="appleseeddisneymtl\appleseeddisneymtl.cpp" />
+    <ClCompile Include="appleseedglassmtl\appleseedglassmtl.cpp" />
+    <ClCompile Include="appleseedobjpropsmod\appleseedobjpropsmod.cpp" />
+    <ClCompile Include="iappleseedmtl.cpp" />
+    <ClCompile Include="appleseedlightmtl\appleseedlightmtl.cpp" />
+    <ClCompile Include="logtarget.cpp" />
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="plugin.cpp" />
+    <ClCompile Include="appleseedrenderer\appleseedrenderer.cpp" />
+    <ClCompile Include="appleseedrenderer\appleseedrendererparamdlg.cpp" />
+    <ClCompile Include="appleseedrenderer\maxsceneentities.cpp" />
+    <ClCompile Include="appleseedrenderer\projectbuilder.cpp" />
+    <ClCompile Include="appleseedrenderer\renderercontroller.cpp" />
+    <ClCompile Include="appleseedrenderer\renderersettings.cpp" />
+    <ClCompile Include="appleseedrenderer\tilecallback.cpp" />
+    <ClCompile Include="appleseedrenderer\updatechecker.cpp" />
+    <ClCompile Include="appleseedsssmtl\appleseedsssmtl.cpp" />
+    <ClCompile Include="utilities.cpp" />
+    <ClCompile Include="version.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="appleseedobjpropsmod\appleseedobjpropsmod.h" />
+    <ClInclude Include="appleseedobjpropsmod\resource.h" />
+    <ClInclude Include="bump\bumpparammapdlgproc.h" />
+    <ClInclude Include="bump\resource.h" />
+    <ClInclude Include="appleseeddisneymtl\appleseeddisneymtl.h" />
+    <ClInclude Include="appleseeddisneymtl\datachunks.h" />
+    <ClInclude Include="appleseeddisneymtl\resource.h" />
+    <ClInclude Include="appleseedglassmtl\appleseedglassmtl.h" />
+    <ClInclude Include="appleseedglassmtl\datachunks.h" />
+    <ClInclude Include="appleseedglassmtl\resource.h" />
+    <ClInclude Include="iappleseedmtl.h" />
+    <ClInclude Include="appleseedlightmtl\appleseedlightmtl.h" />
+    <ClInclude Include="appleseedlightmtl\datachunks.h" />
+    <ClInclude Include="appleseedlightmtl\resource.h" />
+    <ClInclude Include="logtarget.h" />
+    <ClInclude Include="main.h" />
+    <ClInclude Include="appleseedrenderer\appleseedrenderer.h" />
+    <ClInclude Include="appleseedrenderer\appleseedrendererparamdlg.h" />
+    <ClInclude Include="appleseedrenderer\datachunks.h" />
+    <ClInclude Include="appleseedrenderer\maxsceneentities.h" />
+    <ClInclude Include="appleseedrenderer\projectbuilder.h" />
+    <ClInclude Include="appleseedrenderer\renderercontroller.h" />
+    <ClInclude Include="appleseedrenderer\renderersettings.h" />
+    <ClInclude Include="appleseedrenderer\resource.h" />
+    <ClInclude Include="appleseedrenderer\tilecallback.h" />
+    <ClInclude Include="appleseedrenderer\updatechecker.h" />
+    <ClInclude Include="appleseedsssmtl\appleseedsssmtl.h" />
+    <ClInclude Include="appleseedsssmtl\datachunks.h" />
+    <ClInclude Include="appleseedsssmtl\resource.h" />
+    <ClInclude Include="utilities.h" />
+    <ClInclude Include="version.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="appleseedobjpropsmod\appleseedobjpropsmod.rc" />
+    <ResourceCompile Include="bump\bump.rc" />
+    <ResourceCompile Include="appleseeddisneymtl\appleseeddisneymtl.rc" />
+    <ResourceCompile Include="appleseedglassmtl\appleseedglassmtl.rc" />
+    <ResourceCompile Include="appleseedlightmtl\appleseedlightmtl.rc" />
+    <ResourceCompile Include="appleseedrenderer\appleseedrenderer.rc" />
+    <ResourceCompile Include="appleseedsssmtl\appleseedsssmtl.rc" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/appleseed-max-impl/appleseed-max2016-impl.vcxproj.filters
+++ b/src/appleseed-max-impl/appleseed-max2016-impl.vcxproj.filters
@@ -1,0 +1,181 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="appleseedrenderer\appleseedrenderer.cpp">
+      <Filter>appleseedrenderer</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedrenderer\appleseedrendererparamdlg.cpp">
+      <Filter>appleseedrenderer</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedrenderer\maxsceneentities.cpp">
+      <Filter>appleseedrenderer</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedrenderer\projectbuilder.cpp">
+      <Filter>appleseedrenderer</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedrenderer\renderercontroller.cpp">
+      <Filter>appleseedrenderer</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedrenderer\renderersettings.cpp">
+      <Filter>appleseedrenderer</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedrenderer\tilecallback.cpp">
+      <Filter>appleseedrenderer</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedrenderer\updatechecker.cpp">
+      <Filter>appleseedrenderer</Filter>
+    </ClCompile>
+    <ClCompile Include="iappleseedmtl.cpp" />
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="plugin.cpp" />
+    <ClCompile Include="utilities.cpp" />
+    <ClCompile Include="version.cpp" />
+    <ClCompile Include="appleseeddisneymtl\appleseeddisneymtl.cpp">
+      <Filter>appleseeddisneymtl</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedsssmtl\appleseedsssmtl.cpp">
+      <Filter>appleseedsssmtl</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedglassmtl\appleseedglassmtl.cpp">
+      <Filter>appleseedglassmtl</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedlightmtl\appleseedlightmtl.cpp">
+      <Filter>appleseedlightmtl</Filter>
+    </ClCompile>
+    <ClCompile Include="logtarget.cpp" />
+    <ClCompile Include="appleseedobjpropsmod\appleseedobjpropsmod.cpp">
+      <Filter>appleseedobjpropsmod</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="appleseedrenderer\appleseedrenderer.h">
+      <Filter>appleseedrenderer</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedrenderer\appleseedrendererparamdlg.h">
+      <Filter>appleseedrenderer</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedrenderer\datachunks.h">
+      <Filter>appleseedrenderer</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedrenderer\maxsceneentities.h">
+      <Filter>appleseedrenderer</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedrenderer\projectbuilder.h">
+      <Filter>appleseedrenderer</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedrenderer\renderercontroller.h">
+      <Filter>appleseedrenderer</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedrenderer\renderersettings.h">
+      <Filter>appleseedrenderer</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedrenderer\resource.h">
+      <Filter>appleseedrenderer</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedrenderer\tilecallback.h">
+      <Filter>appleseedrenderer</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedrenderer\updatechecker.h">
+      <Filter>appleseedrenderer</Filter>
+    </ClInclude>
+    <ClInclude Include="iappleseedmtl.h" />
+    <ClInclude Include="main.h" />
+    <ClInclude Include="utilities.h" />
+    <ClInclude Include="version.h" />
+    <ClInclude Include="appleseeddisneymtl\appleseeddisneymtl.h">
+      <Filter>appleseeddisneymtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseeddisneymtl\datachunks.h">
+      <Filter>appleseeddisneymtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseeddisneymtl\resource.h">
+      <Filter>appleseeddisneymtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedsssmtl\appleseedsssmtl.h">
+      <Filter>appleseedsssmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedsssmtl\datachunks.h">
+      <Filter>appleseedsssmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedsssmtl\resource.h">
+      <Filter>appleseedsssmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedglassmtl\appleseedglassmtl.h">
+      <Filter>appleseedglassmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedglassmtl\datachunks.h">
+      <Filter>appleseedglassmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedglassmtl\resource.h">
+      <Filter>appleseedglassmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedlightmtl\appleseedlightmtl.h">
+      <Filter>appleseedlightmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedlightmtl\datachunks.h">
+      <Filter>appleseedlightmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedlightmtl\resource.h">
+      <Filter>appleseedlightmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="logtarget.h" />
+    <ClInclude Include="bump\bumpparammapdlgproc.h">
+      <Filter>bump</Filter>
+    </ClInclude>
+    <ClInclude Include="bump\resource.h">
+      <Filter>bump</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedobjpropsmod\appleseedobjpropsmod.h">
+      <Filter>appleseedobjpropsmod</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedobjpropsmod\resource.h">
+      <Filter>appleseedobjpropsmod</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="appleseedrenderer\appleseedrenderer.rc">
+      <Filter>appleseedrenderer</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="appleseeddisneymtl\appleseeddisneymtl.rc">
+      <Filter>appleseeddisneymtl</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="appleseedsssmtl\appleseedsssmtl.rc">
+      <Filter>appleseedsssmtl</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="appleseedglassmtl\appleseedglassmtl.rc">
+      <Filter>appleseedglassmtl</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="appleseedlightmtl\appleseedlightmtl.rc">
+      <Filter>appleseedlightmtl</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="bump\bump.rc">
+      <Filter>bump</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="appleseedobjpropsmod\appleseedobjpropsmod.rc">
+      <Filter>appleseedobjpropsmod</Filter>
+    </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="bump">
+      <UniqueIdentifier>{4c69bf69-db56-4c6d-8518-49719a6c8f1b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="appleseeddisneymtl">
+      <UniqueIdentifier>{0f63c39e-3c84-4009-a32b-ae9dfec1dc15}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="appleseedglassmtl">
+      <UniqueIdentifier>{666a1c7e-ebcb-42b1-b62e-a57419733d4a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="appleseedlightmtl">
+      <UniqueIdentifier>{f7d6f5af-25a2-427e-bf28-a4e46d2ddaf2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="appleseedrenderer">
+      <UniqueIdentifier>{3b53d01d-35e2-4c3e-a0a4-6d9921c729a1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="appleseedsssmtl">
+      <UniqueIdentifier>{4e79312e-d35e-43b5-bc53-f2bd6ad9d984}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="appleseedobjpropsmod">
+      <UniqueIdentifier>{b8667bdc-4a40-4ccb-a847-c1a144ea8778}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+</Project>

--- a/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.rc
+++ b/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "windows.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -31,7 +31,7 @@ END
 
 2 TEXTINCLUDE 
 BEGIN
-    "#include ""afxres.h""\r\n"
+    "#include ""windows.h""\r\n"
     "\0"
 END
 

--- a/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.rc
+++ b/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "windows.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -31,7 +31,7 @@ END
 
 2 TEXTINCLUDE 
 BEGIN
-    "#include ""afxres.h""\r\n"
+    "#include ""windows.h""\r\n"
     "\0"
 END
 

--- a/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.rc
+++ b/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "windows.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -31,7 +31,7 @@ END
 
 2 TEXTINCLUDE 
 BEGIN
-    "#include ""afxres.h""\r\n"
+    "#include ""windows.h""\r\n"
     "\0"
 END
 

--- a/src/appleseed-max-impl/appleseedobjpropsmod/appleseedobjpropsmod.cpp
+++ b/src/appleseed-max-impl/appleseedobjpropsmod/appleseedobjpropsmod.cpp
@@ -37,7 +37,7 @@
 #include <modstack.h>
 #include <paramtype.h>
 
-#if MAX_RELEASE == MAX_RELEASE_R17
+#if MAX_RELEASE == MAX_RELEASE_R17 || MAX_RELEASE == MAX_RELEASE_R18
 #define TYPE_SINGLECHECKBOX TYPE_SINGLECHEKBOX
 #endif
 

--- a/src/appleseed-max-impl/appleseedobjpropsmod/appleseedobjpropsmod.rc
+++ b/src/appleseed-max-impl/appleseedobjpropsmod/appleseedobjpropsmod.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "windows.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -32,7 +32,7 @@ END
 
 2 TEXTINCLUDE 
 BEGIN
-    "#include ""afxres.h""\r\n"
+    "#include ""windows.h""\r\n"
     "\0"
 END
 

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.rc
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.rc
@@ -7,7 +7,8 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "windows.h"
+#define IDC_STATIC -1
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -32,7 +33,8 @@ END
 
 2 TEXTINCLUDE 
 BEGIN
-    "#include ""afxres.h""\r\n"
+    "#include ""windows.h""\r\n"
+    "#define IDC_STATIC -1\r\n"
     "\0"
 END
 

--- a/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
+++ b/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
@@ -678,7 +678,7 @@ asf::auto_release_ptr<asr::Material> AppleseedSSSMtl::create_material(asr::Assem
 
         const auto bssrdf_name = std::string(name) + "_bssrdf";
         assembly.bssrdfs().insert(
-            asr::NormalizedDiffusionBSSRDFFactory::static_create(bssrdf_name.c_str(), bssrdf_params));
+            asr::GaussianBSSRDFFactory::static_create(bssrdf_name.c_str(), bssrdf_params));
 
         material_params.insert("bssrdf", bssrdf_name);
     }

--- a/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
+++ b/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
@@ -678,7 +678,7 @@ asf::auto_release_ptr<asr::Material> AppleseedSSSMtl::create_material(asr::Assem
 
         const auto bssrdf_name = std::string(name) + "_bssrdf";
         assembly.bssrdfs().insert(
-            asr::GaussianBSSRDFFactory::static_create(bssrdf_name.c_str(), bssrdf_params));
+            asr::NormalizedDiffusionBSSRDFFactory::static_create(bssrdf_name.c_str(), bssrdf_params));
 
         material_params.insert("bssrdf", bssrdf_name);
     }

--- a/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.rc
+++ b/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "windows.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -31,7 +31,7 @@ END
 
 2 TEXTINCLUDE 
 BEGIN
-    "#include ""afxres.h""\r\n"
+    "#include ""windows.h""\r\n"
     "\0"
 END
 

--- a/src/appleseed-max-impl/bump/bump.rc
+++ b/src/appleseed-max-impl/bump/bump.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "windows.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -31,7 +31,7 @@ END
 
 2 TEXTINCLUDE 
 BEGIN
-    "#include ""afxres.h""\r\n"
+    "#include ""windows.h""\r\n"
     "\0"
 END
 

--- a/src/appleseed-max/appleseed-max2016.vcxproj
+++ b/src/appleseed-max/appleseed-max2016.vcxproj
@@ -1,0 +1,182 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Ship|x64">
+      <Configuration>Ship</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="plugin.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="main.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{F43B3C0E-2A72-4B30-9016-DEC6B022D135}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>appleseedmax</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v110</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v110</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v110</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>appleseed-max2015</TargetName>
+    <TargetExt>.dlr</TargetExt>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>appleseed-max2015</TargetName>
+    <TargetExt>.dlr</TargetExt>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>appleseed-max2015</TargetName>
+    <TargetExt>.dlr</TargetExt>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>WIN32;WIN64;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;BOOST_FILESYSTEM_VERSION=3;BOOST_FILESYSTEM_NO_DEPRECATED;APPLESEED_WITH_OIIO;OIIO_STATIC_BUILD;APPLESEED_WITH_OSL;OSL_STATIC_LIBRARY;APPLESEED_WITH_DISNEY_MATERIAL;APPLESEED_WITH_NORMALIZED_DIFFUSION_BSSRDF;XERCES_STATIC_LIBRARY;BOOST_PYTHON_STATIC_LIB;APPLESEED_X86;APPLESEED_USE_SSE;DEBUG;APPLESEED_ENABLE_IMATH_INTEROP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir);C:\Program Files\Autodesk\3ds Max 2016 SDK\maxsdk\include;$(SolutionDir)..\..\appleseed\src\appleseed</AdditionalIncludeDirectories>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <MinimalRebuild>false</MinimalRebuild>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2016 SDK\maxsdk\lib\x64\Release</AdditionalLibraryDirectories>
+      <AdditionalDependencies>wininet.lib;bmm.lib;core.lib;maxutil.lib;Paramblk2.lib;ShLwApi.Lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <DelayLoadDLLs>
+      </DelayLoadDLLs>
+    </Link>
+    <PostBuildEvent>
+      <Command>mkdir "$(SolutionDir)..\bin\appleseed-max2016\$(Platform)\$(Configuration)" 2&gt;nul
+copy /Y "$(TargetPath)" "$(SolutionDir)..\bin\appleseed-max2016\$(Platform)\$(Configuration)\"
+copy /Y "$(TargetPath)" "$(SolutionDir)..\..\appleseed-max2016-plugin-folder\"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>Full</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;WIN64;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;BOOST_FILESYSTEM_VERSION=3;BOOST_FILESYSTEM_NO_DEPRECATED;APPLESEED_WITH_OIIO;OIIO_STATIC_BUILD;APPLESEED_WITH_OSL;OSL_STATIC_LIBRARY;APPLESEED_WITH_DISNEY_MATERIAL;APPLESEED_WITH_NORMALIZED_DIFFUSION_BSSRDF;XERCES_STATIC_LIBRARY;BOOST_PYTHON_STATIC_LIB;APPLESEED_X86;APPLESEED_USE_SSE;APPLESEED_ENABLE_IMATH_INTEROP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir);C:\Program Files\Autodesk\3ds Max 2016 SDK\maxsdk\include;$(SolutionDir)..\..\appleseed\src\appleseed</AdditionalIncludeDirectories>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <StringPooling>true</StringPooling>
+      <FunctionLevelLinking>false</FunctionLevelLinking>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2016 SDK\maxsdk\lib\x64\Release</AdditionalLibraryDirectories>
+      <AdditionalDependencies>wininet.lib;bmm.lib;core.lib;maxutil.lib;Paramblk2.lib;ShLwApi.Lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>
+      </DelayLoadDLLs>
+    </Link>
+    <PostBuildEvent>
+      <Command>mkdir "$(SolutionDir)..\bin\appleseed-max2016\$(Platform)\$(Configuration)" 2&gt;nul
+copy /Y "$(TargetPath)" "$(SolutionDir)..\bin\appleseed-max2016\$(Platform)\$(Configuration)\"
+copy /Y "$(TargetPath)" "$(SolutionDir)..\..\appleseed-max2016-plugin-folder\"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>Full</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;WIN64;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;BOOST_FILESYSTEM_VERSION=3;BOOST_FILESYSTEM_NO_DEPRECATED;APPLESEED_WITH_OIIO;OIIO_STATIC_BUILD;APPLESEED_WITH_OSL;OSL_STATIC_LIBRARY;APPLESEED_WITH_DISNEY_MATERIAL;APPLESEED_WITH_NORMALIZED_DIFFUSION_BSSRDF;XERCES_STATIC_LIBRARY;BOOST_PYTHON_STATIC_LIB;APPLESEED_X86;APPLESEED_USE_SSE;APPLESEED_ENABLE_IMATH_INTEROP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir);C:\Program Files\Autodesk\3ds Max 2016 SDK\maxsdk\include;$(SolutionDir)..\..\appleseed\src\appleseed</AdditionalIncludeDirectories>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <StringPooling>true</StringPooling>
+      <FunctionLevelLinking>false</FunctionLevelLinking>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <DebugInformationFormat>None</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2016 SDK\maxsdk\lib\x64\Release</AdditionalLibraryDirectories>
+      <AdditionalDependencies>wininet.lib;bmm.lib;core.lib;maxutil.lib;Paramblk2.lib;ShLwApi.Lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>
+      </DelayLoadDLLs>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+    </Link>
+    <PostBuildEvent>
+      <Command>mkdir "$(SolutionDir)..\bin\appleseed-max2015\$(Platform)\$(Configuration)" 2&gt;nul
+copy /Y "$(TargetPath)" "$(SolutionDir)..\bin\appleseed-max2015\$(Platform)\$(Configuration)\"
+copy /Y "$(TargetPath)" "C:\Program Files\Autodesk\3ds Max 2015\plugins\appleseed\"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/appleseed-max/appleseed-max2016.vcxprojy.filters
+++ b/src/appleseed-max/appleseed-max2016.vcxprojy.filters
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="plugin.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="main.h" />
+  </ItemGroup>
+</Project>

--- a/src/appleseed-max/plugin.cpp
+++ b/src/appleseed-max/plugin.cpp
@@ -129,7 +129,7 @@ extern "C"
         if (load_relative_library(_T("appleseed.dll")) == nullptr)
             return FALSE;
 
-#if MAX_RELEASE == MAX_RELEASE_R17
+#if MAX_RELEASE == MAX_RELEASE_R17 || MAX_RELEASE == MAX_RELEASE_R18
         static const wchar_t PluginImplDLLFilename[] = _T("appleseed-max2015-impl.dll");
 #elif MAX_RELEASE == MAX_RELEASE_R19
         static const wchar_t PluginImplDLLFilename[] = _T("appleseed-max2017-impl.dll");

--- a/src/appleseed-max2016.sln
+++ b/src/appleseed-max2016.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "appleseed-max2016", "appleseed-max\appleseed-max2016.vcxproj", "{F43B3C0E-2A72-4B30-9016-DEC6B022D135}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "appleseed-max2016-impl", "appleseed-max-impl\appleseed-max2016-impl.vcxproj", "{62C41566-DBCB-49D3-943A-4DD53222269E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+		Ship|x64 = Ship|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F43B3C0E-2A72-4B30-9016-DEC6B022D135}.Debug|x64.ActiveCfg = Debug|x64
+		{F43B3C0E-2A72-4B30-9016-DEC6B022D135}.Debug|x64.Build.0 = Debug|x64
+		{F43B3C0E-2A72-4B30-9016-DEC6B022D135}.Release|x64.ActiveCfg = Release|x64
+		{F43B3C0E-2A72-4B30-9016-DEC6B022D135}.Release|x64.Build.0 = Release|x64
+		{F43B3C0E-2A72-4B30-9016-DEC6B022D135}.Ship|x64.ActiveCfg = Ship|x64
+		{F43B3C0E-2A72-4B30-9016-DEC6B022D135}.Ship|x64.Build.0 = Ship|x64
+		{62C41566-DBCB-49D3-943A-4DD53222269E}.Debug|x64.ActiveCfg = Debug|x64
+		{62C41566-DBCB-49D3-943A-4DD53222269E}.Debug|x64.Build.0 = Debug|x64
+		{62C41566-DBCB-49D3-943A-4DD53222269E}.Release|x64.ActiveCfg = Release|x64
+		{62C41566-DBCB-49D3-943A-4DD53222269E}.Release|x64.Build.0 = Release|x64
+		{62C41566-DBCB-49D3-943A-4DD53222269E}.Ship|x64.ActiveCfg = Ship|x64
+		{62C41566-DBCB-49D3-943A-4DD53222269E}.Ship|x64.Build.0 = Ship|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Hi,

I'm wondering if it is possible to merge this PR into master? I need those changes to compile for 2016 max sdk and I apply them after each master update. It would be very helpful to have them in master.

Changes in PR:

- project and solution files added for 2016
- preprocessor #if-s check against max 2016
- "afxres.h" replaced with "windows.h" to compile without mfc libraries
- NormalizedDiffusionBSSRDFFactory replaced with GaussianBSSRDFFactory because by default appleseed doesn't contain NormalizedDiffusionBSSRDFFactory (at least on my version)

Thanks,
Sergo
