### PR TITLE
Add environment map

### DIFF
--- a/src/appleseed-max-impl/appleseed-max2016-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2016-impl.vcxproj
@@ -205,6 +205,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\build\vc11\src\appleseed\$(ConfigurationN
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="appleseedenvmap\appleseedenvmap.h" />
+    <ClInclude Include="appleseedenvmap\datachunks.h" />
     <ClInclude Include="appleseedenvmap\resource.h" />
     <ClInclude Include="appleseedobjpropsmod\appleseedobjpropsmod.h" />
     <ClInclude Include="appleseedobjpropsmod\resource.h" />

--- a/src/appleseed-max-impl/appleseed-max2016-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2016-impl.vcxproj
@@ -183,6 +183,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\build\vc11\src\appleseed\$(ConfigurationN
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="appleseeddisneymtl\appleseeddisneymtl.cpp" />
+    <ClCompile Include="appleseedenvmap\appleseedenvmap.cpp" />
     <ClCompile Include="appleseedglassmtl\appleseedglassmtl.cpp" />
     <ClCompile Include="appleseedobjpropsmod\appleseedobjpropsmod.cpp" />
     <ClCompile Include="iappleseedmtl.cpp" />
@@ -203,6 +204,8 @@ copy /Y "$(SolutionDir)..\..\appleseed\build\vc11\src\appleseed\$(ConfigurationN
     <ClCompile Include="version.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="appleseedenvmap\appleseedenvmap.h" />
+    <ClInclude Include="appleseedenvmap\resource.h" />
     <ClInclude Include="appleseedobjpropsmod\appleseedobjpropsmod.h" />
     <ClInclude Include="appleseedobjpropsmod\resource.h" />
     <ClInclude Include="bump\bumpparammapdlgproc.h" />
@@ -236,6 +239,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\build\vc11\src\appleseed\$(ConfigurationN
     <ClInclude Include="version.h" />
   </ItemGroup>
   <ItemGroup>
+    <ResourceCompile Include="appleseedenvmap\appleseedenvmap.rc" />
     <ResourceCompile Include="appleseedobjpropsmod\appleseedobjpropsmod.rc" />
     <ResourceCompile Include="bump\bump.rc" />
     <ResourceCompile Include="appleseeddisneymtl\appleseeddisneymtl.rc" />

--- a/src/appleseed-max-impl/appleseed-max2016-impl.vcxproj.filters
+++ b/src/appleseed-max-impl/appleseed-max2016-impl.vcxproj.filters
@@ -46,6 +46,9 @@
     <ClCompile Include="appleseedobjpropsmod\appleseedobjpropsmod.cpp">
       <Filter>appleseedobjpropsmod</Filter>
     </ClCompile>
+    <ClCompile Include="appleseedenvmap\appleseedenvmap.cpp">
+      <Filter>appleseedenvmap</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="appleseedrenderer\appleseedrenderer.h">
@@ -131,6 +134,12 @@
     <ClInclude Include="appleseedobjpropsmod\resource.h">
       <Filter>appleseedobjpropsmod</Filter>
     </ClInclude>
+    <ClInclude Include="appleseedenvmap\appleseedenvmap.h">
+      <Filter>appleseedenvmap</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedenvmap\resource.h">
+      <Filter>appleseedenvmap</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="appleseedrenderer\appleseedrenderer.rc">
@@ -154,6 +163,9 @@
     <ResourceCompile Include="appleseedobjpropsmod\appleseedobjpropsmod.rc">
       <Filter>appleseedobjpropsmod</Filter>
     </ResourceCompile>
+    <ResourceCompile Include="appleseedenvmap\appleseedenvmap.rc">
+      <Filter>appleseedenvmap</Filter>
+    </ResourceCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="bump">
@@ -176,6 +188,9 @@
     </Filter>
     <Filter Include="appleseedobjpropsmod">
       <UniqueIdentifier>{b8667bdc-4a40-4ccb-a847-c1a144ea8778}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="appleseedenvmap">
+      <UniqueIdentifier>{e366da91-8f84-4832-886c-1a73dc7c4a22}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/src/appleseed-max-impl/appleseed-max2016-impl.vcxproj.filters
+++ b/src/appleseed-max-impl/appleseed-max2016-impl.vcxproj.filters
@@ -140,6 +140,9 @@
     <ClInclude Include="appleseedenvmap\resource.h">
       <Filter>appleseedenvmap</Filter>
     </ClInclude>
+    <ClInclude Include="appleseedenvmap\datachunks.h">
+      <Filter>appleseedenvmap</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="appleseedrenderer\appleseedrenderer.rc">

--- a/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.cpp
+++ b/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.cpp
@@ -1,0 +1,588 @@
+
+#include "renderer/modeling/environmentedf/hosekenvironmentedf.h"
+
+#include "appleseedenvmap.h"
+#include "appleseedenvmap/resource.h"
+#include "main.h"
+#include "utilities.h"
+
+namespace
+{
+    const TCHAR* AppleseedEnvMapFriendlyClassName = _T("appleseed Environment Map");
+}
+
+AppleseedEnvMapClassDesc g_appleseed_appleseedenvmap_classdesc;
+
+//
+// AppleseedEnvMap class implementation.
+//
+
+namespace
+{
+    enum { ParamBlockIdEnvMap };
+    enum { ParamBlockRefEnvMap };
+
+    enum ParamId 
+    {
+        ParamIdSunTheta             = 0,
+        ParamIdSunPhi               = 1,
+        ParamIdTurbidity            = 2,
+        ParamIdTurbidityMap         = 3,
+        ParamIdTurbidityMapOn       = 4,
+        ParamIdTurbMultiplier       = 5,
+        ParamIdLuminMultiplier      = 6,
+        ParamIdLuminGamma           = 7,
+        ParamIdSatMultiplier        = 8,
+        ParamIdHorizonShift         = 10,
+        ParamIdGroundAlbedo         = 11
+    };
+
+    enum TexmapId
+    {
+        TexmapIdTurbidity           = 0,
+        TexmapCount                 // keep last
+    };
+
+    const MSTR g_texmap_slot_names[TexmapCount] =
+    {
+        _T("Turbidity"),
+    };
+
+    const ParamId g_texmap_id_to_param_id[TexmapCount] =
+    {
+        ParamIdTurbidityMap
+    };
+
+    ParamBlockDesc2 g_block_desc(
+        ParamBlockIdEnvMap,
+        _T("appleseedEnvironmentMapParams"), 
+        0,
+        &g_appleseed_appleseedenvmap_classdesc,
+        P_AUTO_CONSTRUCT + P_AUTO_UI,
+
+         // --- P_AUTO_CONSTRUCT arguments ---
+        ParamBlockRefEnvMap,                     // parameter block's reference number
+
+        // --- P_AUTO_UI arguments for Disney rollup ---
+        IDD_ENVMAP_PANEL,                        // ID of the dialog template
+        IDS_ENVMAP_PARAMS,                  // ID of the dialog's title string
+        0,                                          // IParamMap2 creation/deletion flag mask
+        0,                                          // rollup creation flag
+        nullptr,   
+
+        // params
+        ParamIdSunTheta, _T("sun_theta"), TYPE_FLOAT, P_ANIMATABLE, IDS_THETA,
+            p_default, 45.0f,
+            p_range, 0.0f, 180.0f,
+            p_ui, TYPE_SPINNER, EDITTYPE_FLOAT, IDC_EDIT_THETA, IDC_SPIN_THETA, 0.01f,
+        p_end,
+
+        ParamIdSunPhi, _T("sun_phi"), TYPE_FLOAT, P_ANIMATABLE, IDS_PHI,
+            p_default, 0.0f,
+            p_range, 0.0f, 360.0f,
+            p_ui, TYPE_SPINNER, EDITTYPE_FLOAT, IDC_EDIT_PHI, IDC_SPIN_PHI, 0.01f,
+        p_end,
+
+        ParamIdTurbidity, _T("turbitidy"), TYPE_FLOAT, P_ANIMATABLE, IDS_TURBIDITY,
+            p_default, 1.0f,
+            p_range, 0.0f, 1.0f,
+            p_ui, TYPE_SPINNER, EDITTYPE_FLOAT, IDC_EDIT_TURBIDITY, IDC_SPIN_TURBIDITY, 0.01f,
+        p_end,
+
+        ParamIdTurbidityMap, _T("turbitidy_map"), TYPE_TEXMAP, 0, IDS_TURB_MAP,
+            p_subtexno, TexmapIdTurbidity,
+            p_ui, TYPE_TEXMAPBUTTON, IDC_PICK_TURB_TEXTURE,
+        p_end,
+
+        ParamIdTurbidityMapOn, _T("turbitidy_map_on"), TYPE_BOOL, 0, IDS_TURB_MAP_ON,
+            p_default, TRUE,
+            p_ui, TYPE_SINGLECHEKBOX, IDC_TURB_TEX_ON,
+        p_end,
+
+        ParamIdTurbMultiplier, _T("turbitidy_multiplier"), TYPE_FLOAT, P_ANIMATABLE, IDS_TURB_MULTIPLIER,
+            p_default, 2.0f,
+            p_range, 0.0f, 8.0f,
+            p_ui, TYPE_SPINNER, EDITTYPE_FLOAT, IDC_EDIT_TURB_MULTIPLIER, IDC_SPIN_TURB_MULTIPLIER, 0.01f,
+        p_end,
+
+        ParamIdLuminMultiplier, _T("luminance_multiplier"), TYPE_FLOAT, P_ANIMATABLE, IDS_LUMINANCE_MULTIPLIER,
+            p_default, 1.0f,
+            p_range, 0.0f, 10.0f,
+            p_ui, TYPE_SPINNER, EDITTYPE_FLOAT, IDC_EDIT_LUMIN_MULTIPLIER, IDC_SPIN_LUMIN_MULTIPLIER, 0.01f,
+        p_end,
+
+        ParamIdLuminGamma, _T("luminance_gamma"), TYPE_FLOAT, P_ANIMATABLE, IDS_LUMINANCE_GAMMA,
+            p_default, 1.0f,
+            p_range, 0.0f, 3.0f,
+            p_ui, TYPE_SPINNER, EDITTYPE_FLOAT, IDC_EDIT_LUMIN_GAMMA, IDC_SPIN_LUMIN_GAMMA, 0.01f,
+        p_end,
+
+        ParamIdSatMultiplier, _T("saturation_multiplier"), TYPE_FLOAT, P_ANIMATABLE, IDS_SAT_MULITPLIER,
+            p_default, 1.0f,
+            p_range, 0.0f, 10.0f,
+            p_ui, TYPE_SPINNER, EDITTYPE_FLOAT, IDC_EDIT_SATUR_MULTIPLIER, IDC_SPIN_SATUR_MULTIPLIER, 0.01f,
+        p_end,
+
+        ParamIdHorizonShift, _T("horizon_shift"), TYPE_FLOAT, P_ANIMATABLE, IDS_HORIZON_SHIFT,
+            p_default, 0.0f,
+            p_range, -10.0f, 10.0f,
+            p_ui, TYPE_SPINNER, EDITTYPE_FLOAT, IDC_EDIT_HORIZON_SHIFT, IDC_SPIN_HORIZON_SHIFT, 0.01f,
+        p_end,
+
+        ParamIdGroundAlbedo, _T("ground_albedo"), TYPE_FLOAT, P_ANIMATABLE, IDS_GROUND_ALBEDO,
+            p_default, 0.3f,
+            p_range, 0.0f, 1.0f,
+            p_ui, TYPE_SPINNER, EDITTYPE_FLOAT, IDC_EDIT_GROUND_ALBEDO, IDC_SPIN_GROUND_ALBEDO, 0.01f,
+        p_end,
+
+        p_end
+    );
+}
+
+Class_ID AppleseedEnvMap::get_class_id()
+{
+    return Class_ID(0x52848b4a, 0x5e6cb361);
+}
+
+AppleseedEnvMap::AppleseedEnvMap()
+    : m_pblock(nullptr)
+    , m_sun_theta(45.0f)
+    , m_sun_phi(90.0f)
+    , m_turbidity(1.0f)
+    , m_turbidity_map(nullptr)
+    , m_turbidity_map_on(true)
+    , m_turb_multiplier(2.0f)
+    , m_lumin_multiplier(1.0f)
+    , m_lumin_gamma(1.0f)
+    , m_sat_multiplier(1.0f)
+    , m_horizon_shift(0.0f)
+    , m_ground_albedo(0.3f)
+{
+    g_appleseed_appleseedenvmap_classdesc.MakeAutoParamBlocks(this);
+    Reset();
+}
+
+void AppleseedEnvMap::DeleteThis()
+{
+    delete this;
+}
+
+void AppleseedEnvMap::GetClassName(TSTR& s)
+{
+    s = _T("appleseedEnvMap");
+}
+
+SClass_ID AppleseedEnvMap::SuperClassID()
+{
+    return TEXMAP_CLASS_ID;
+}
+
+Class_ID AppleseedEnvMap::ClassID()
+{
+    return get_class_id();
+}
+
+int AppleseedEnvMap::NumSubs()
+{
+    return 2; //pblock + subtexture
+}
+
+Animatable* AppleseedEnvMap::SubAnim(int i)
+{
+    switch (i) {
+    case 0: return m_pblock;
+    case 1: return m_turbidity_map;
+    default: return nullptr;
+    }
+}
+
+TSTR AppleseedEnvMap::SubAnimName(int i)
+{
+    switch (i) {
+    case 0: return _T("Parameters");
+    case 1: return GetSubTexmapTVName(i - 1);
+    default: return nullptr;
+    }
+}
+
+int AppleseedEnvMap::SubNumToRefNum(int subNum)
+{
+    return subNum;
+}
+
+int AppleseedEnvMap::NumParamBlocks()
+{
+    return 1;
+}
+
+IParamBlock2* AppleseedEnvMap::GetParamBlock(int i)
+{
+    return i == 0 ? m_pblock : nullptr;
+}
+
+IParamBlock2* AppleseedEnvMap::GetParamBlockByID(BlockID id)
+{
+    return id == m_pblock->ID() ? m_pblock : nullptr;
+}
+
+int AppleseedEnvMap::NumRefs()
+{
+    return 2; //pblock + subtexture
+}
+
+RefTargetHandle AppleseedEnvMap::GetReference(int i)
+{
+    switch (i) {
+        case ParamBlockIdEnvMap: return m_pblock;
+        case 1: return m_turbidity_map;
+        default: return nullptr;
+    }
+}
+
+void AppleseedEnvMap::SetReference(int i, RefTargetHandle rtarg)
+{
+    switch (i) {
+        case ParamBlockIdEnvMap: m_pblock = (IParamBlock2 *)rtarg; break;
+        case 1: m_turbidity_map = (Texmap *)rtarg; break;
+    }
+}
+
+RefResult AppleseedEnvMap::NotifyRefChanged(const Interval& /*changeInt*/, RefTargetHandle hTarget, PartID& /*partID*/, RefMessage message, BOOL /*propagate*/)
+{
+    switch (message)
+    {
+        case REFMSG_TARGET_DELETED:
+            if (hTarget == m_pblock) 
+            { 
+                m_pblock = nullptr; 
+            }
+            else
+            {
+                if (m_turbidity_map == hTarget)
+                {
+                    m_turbidity_map = nullptr;
+                    break;
+                }
+            }
+            break;
+        case REFMSG_CHANGE:
+            m_params_validity.SetEmpty();
+            m_map_validity.SetEmpty();
+            if (hTarget == m_pblock)
+                g_block_desc.InvalidateUI(m_pblock->LastNotifyParamID());
+            break;
+    }
+    return(REF_SUCCEED);
+}
+
+RefTargetHandle AppleseedEnvMap::Clone(RemapDir &remap)
+{
+    AppleseedEnvMap *mnew = new AppleseedEnvMap();
+    *static_cast<MtlBase*>(mnew) = *static_cast<MtlBase*>(this);
+
+    mnew->ReplaceReference(0, remap.CloneRef(m_pblock));
+    mnew->ReplaceReference(1, remap.CloneRef(m_turbidity_map));
+
+    BaseClone(this, mnew, remap);
+    return (RefTargetHandle)mnew;
+}
+
+int AppleseedEnvMap::NumSubTexmaps()
+{
+    return TexmapCount;
+}
+
+Texmap* AppleseedEnvMap::GetSubTexmap(int i)
+{
+    return (i == 0) ? m_turbidity_map : nullptr;
+}
+
+void AppleseedEnvMap::SetSubTexmap(int i, Texmap* texmap)
+{
+    if (i > 0)
+      return;
+    ReplaceReference(i + 1, texmap);
+
+    const auto texmap_id = static_cast<TexmapId>(i);
+    const auto param_id = g_texmap_id_to_param_id[texmap_id];
+    m_pblock->SetValue(param_id, 0, texmap);
+    g_block_desc.InvalidateUI( param_id );
+    m_map_validity.SetEmpty();
+}
+
+int AppleseedEnvMap::MapSlotType(int i)
+{
+    return MAPSLOT_TEXTURE;
+}
+
+TSTR AppleseedEnvMap::GetSubTexmapSlotName(int i)
+{
+    const auto texmap_id = static_cast<TexmapId>(i);
+    return g_texmap_slot_names[texmap_id];
+}
+
+void AppleseedEnvMap::Update(TimeValue t, Interval& valid)
+{
+    if (!m_params_validity.InInterval(t))
+    {
+        m_params_validity.SetInfinite();
+
+        m_pblock->GetValue(ParamIdSunTheta, t, m_sun_theta, m_params_validity);
+        m_pblock->GetValue(ParamIdSunPhi, t, m_sun_phi, m_params_validity);
+
+        m_pblock->GetValue(ParamIdTurbidity, t, m_turbidity, m_params_validity);
+        m_pblock->GetValue(ParamIdTurbidityMap, t, m_turbidity_map, m_params_validity);
+        m_pblock->GetValue(ParamIdTurbidityMapOn, t, m_turbidity_map_on, m_params_validity);
+
+        m_pblock->GetValue(ParamIdTurbMultiplier, t, m_turb_multiplier, m_params_validity);
+        m_pblock->GetValue(ParamIdLuminMultiplier, t, m_lumin_multiplier, m_params_validity);
+        m_pblock->GetValue(ParamIdLuminGamma, t, m_lumin_gamma, m_params_validity);
+        m_pblock->GetValue(ParamIdSatMultiplier, t, m_sat_multiplier, m_params_validity);
+        m_pblock->GetValue(ParamIdHorizonShift, t, m_horizon_shift, m_params_validity);
+        m_pblock->GetValue(ParamIdGroundAlbedo, t, m_ground_albedo, m_params_validity);
+
+        NotifyDependents(FOREVER, PART_ALL, REFMSG_CHANGE);
+    }
+
+    if (!m_map_validity.InInterval(t))
+	{
+		m_map_validity.SetInfinite();
+	    if (m_turbidity_map)
+	        m_turbidity_map->Update(t,m_map_validity);
+	}
+
+    valid &= m_map_validity;
+    valid &= m_params_validity;
+}
+
+void AppleseedEnvMap::Reset()
+{
+    m_params_validity.SetEmpty();
+    m_map_validity.SetEmpty();
+}
+
+Interval AppleseedEnvMap::Validity(TimeValue t)
+{
+    Interval valid = FOREVER;
+    Update(t, valid);
+    return valid;
+}
+
+ParamDlg* AppleseedEnvMap::CreateParamDlg(HWND hwMtlEdit, IMtlParams* imp)
+{
+    IAutoMParamDlg* masterDlg = g_appleseed_appleseedenvmap_classdesc.CreateParamDlgs(hwMtlEdit, imp, this);
+    g_block_desc.SetUserDlgProc(new EnvMapParamMapDlgProc());
+
+    return masterDlg;
+}
+
+const USHORT ChunkFileFormatVersion                 = 0x0001;
+const USHORT ChunkMtlBase                           = 0x1000;
+const USHORT FileFormatVersion = 0x0001;
+
+IOResult AppleseedEnvMap::Save(ISave* isave)
+{
+    bool success = true;
+
+    isave->BeginChunk(ChunkFileFormatVersion);
+    success &= write(isave, &FileFormatVersion, sizeof(FileFormatVersion));
+    isave->EndChunk();
+
+    isave->BeginChunk(ChunkMtlBase);
+    success &= MtlBase::Save(isave) == IO_OK;
+    isave->EndChunk();
+
+    return success ? IO_OK : IO_ERROR;
+}
+
+IOResult AppleseedEnvMap::Load(ILoad* iload)
+{
+    IOResult result = IO_OK;
+
+    while (true)
+    {
+        result = iload->OpenChunk();
+        if (result == IO_END)
+            return IO_OK;
+        if (result != IO_OK)
+            break;
+
+        switch (iload->CurChunkID())
+        {
+          case ChunkFileFormatVersion:
+            {
+                USHORT version;
+                result = read<USHORT>(iload, &version);
+            }
+            break;
+
+          case ChunkMtlBase:
+            result = MtlBase::Load(iload);
+            break;
+        }
+
+        if (result != IO_OK)
+            break;
+
+        result = iload->CloseChunk();
+        if (result != IO_OK)
+            break;
+    }
+
+    return result;
+}
+
+AColor AppleseedEnvMap::EvalColor(ShadeContext& sc)
+{
+    Color basecolor (0.13f, 0.58f, 1.0f);
+    if (!sc.InMtlEditor())
+        return basecolor;
+
+    //render gradient for the thumbnail
+    Point3 p = sc.UVW(0);
+    Color white (1.0f, 1.0f, 1.0f);
+
+	return AColor((basecolor * (float)p.y) + (white * (float)(1.0-p.y)));
+}
+
+Point3 AppleseedEnvMap::EvalNormalPerturb(ShadeContext& /*sc*/)
+{
+    return Point3(0, 0, 0);
+}
+
+foundation::auto_release_ptr<renderer::EnvironmentEDF> AppleseedEnvMap::create_envmap(const char* name)
+{
+    renderer::ParamArray map_params;
+
+    map_params.insert("sun_theta", m_sun_theta);
+    map_params.insert("sun_phi", m_sun_phi);
+    map_params.insert("turbidity", m_turbidity);
+    map_params.insert("turbidity_multiplier", m_turb_multiplier);
+    map_params.insert("ground_albedo", m_ground_albedo);
+    map_params.insert("luminance_multiplier", m_lumin_multiplier);
+    map_params.insert("luminance_gamma", m_lumin_gamma);
+    map_params.insert("saturation_multiplier", m_sat_multiplier);
+    map_params.insert("horizon_shift", m_horizon_shift);
+
+    auto envmap = renderer::HosekEnvironmentEDFFactory::static_create(name, map_params);
+
+    return envmap;
+}
+//
+// AppleseedEnvMapBrowserEntryInfo class implementation.
+//
+
+const MCHAR* AppleseedEnvMapBrowserEntryInfo::GetEntryName() const
+{
+    return AppleseedEnvMapFriendlyClassName;
+}
+
+const MCHAR* AppleseedEnvMapBrowserEntryInfo::GetEntryCategory() const
+{
+    return _T("Maps\\appleseed");
+}
+
+Bitmap* AppleseedEnvMapBrowserEntryInfo::GetEntryThumbnail() const
+{
+    return nullptr;
+}
+
+//
+// EnvMapParamMapDlgProc class implementation.
+//
+
+INT_PTR EnvMapParamMapDlgProc::DlgProc(
+        TimeValue   t,
+        IParamMap2* map,
+        HWND        hwnd,
+        UINT        umsg,
+        WPARAM      wparam,
+        LPARAM      lparam)
+{
+    switch (umsg)
+    {
+    case WM_INITDIALOG:
+        enable_disable_controls(hwnd, map);
+        return TRUE;
+
+    case WM_COMMAND:
+        switch (LOWORD(wparam))
+        {
+        case IDC_COMBO_SKY_TYPE:
+            switch (HIWORD(wparam))
+            {
+            case CBN_SELCHANGE:
+                enable_disable_controls(hwnd, map);
+                return TRUE;
+
+            default:
+                return FALSE;
+            }
+
+        default:
+            return FALSE;
+        }
+
+    default:
+        return FALSE;
+    }
+}
+
+void EnvMapParamMapDlgProc::enable_disable_controls(HWND hwnd, IParamMap2* map)
+{
+    auto selected = SendMessage(GetDlgItem(hwnd, IDC_COMBO_SKY_TYPE), CB_GETCURSEL, 0, 0);
+	map->Enable(ParamIdGroundAlbedo, selected == 0 ? TRUE : FALSE);
+}
+
+//
+// AppleseedEnvMapClassDesc class implementation.
+//
+
+int AppleseedEnvMapClassDesc::IsPublic()
+{
+    return TRUE;
+}
+
+void* AppleseedEnvMapClassDesc::Create(BOOL loading)
+{
+    return new AppleseedEnvMap();
+}
+
+const MCHAR* AppleseedEnvMapClassDesc::ClassName()
+{
+    return AppleseedEnvMapFriendlyClassName;
+}
+
+SClass_ID AppleseedEnvMapClassDesc::SuperClassID()
+{
+    return TEXMAP_CLASS_ID;
+}
+
+Class_ID AppleseedEnvMapClassDesc::ClassID()
+{
+    return AppleseedEnvMap::get_class_id();
+}
+
+const MCHAR* AppleseedEnvMapClassDesc::Category()
+{
+    return _T("");
+}
+
+const MCHAR* AppleseedEnvMapClassDesc::InternalName()
+{
+    // Parsable name used by MAXScript.
+    return _T("appleseedEnvMap");
+}
+
+FPInterface* AppleseedEnvMapClassDesc::GetInterface(Interface_ID id)
+{
+    if (id == IMATERIAL_BROWSER_ENTRY_INFO_INTERFACE)
+        return &m_browser_entry_info;
+
+    return ClassDesc2::GetInterface(id);
+}
+
+HINSTANCE AppleseedEnvMapClassDesc::HInstance()
+{
+    return g_module;
+}

--- a/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.h
+++ b/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.h
@@ -1,0 +1,152 @@
+#pragma once
+
+// appleseed.foundation headers.
+#include "foundation/platform/windows.h"    // include before 3ds Max headers
+#include "foundation/utility/autoreleaseptr.h"
+#include "renderer/modeling/environmentedf/environmentedf.h"
+
+// 3ds Max headers.
+#include "appleseedenvmap/resource.h"
+#include <istdplug.h>
+#include <iparamb2.h>
+#include <iparamm2.h>
+#include <maxtypes.h>
+#include <stdmat.h>
+#include <imtl.h>
+#include <IMaterialBrowserEntryInfo.h>
+#undef base_type
+
+//namespace renderer  { class EnvironmentEDF; }
+
+class AppleseedEnvMap : public Texmap {
+public:
+    static Class_ID get_class_id();
+
+    // Constructor.
+    AppleseedEnvMap();
+
+    // Animatable methods.
+    virtual void DeleteThis() override;
+    virtual void GetClassName(TSTR& s) override;
+    virtual SClass_ID SuperClassID() override;
+    virtual Class_ID  ClassID() override;
+    virtual int NumSubs() override;
+    virtual Animatable* SubAnim(int i) override;
+    virtual TSTR SubAnimName(int i) override;
+    virtual int SubNumToRefNum(int subNum) override;
+    virtual int	NumParamBlocks() override;
+    virtual IParamBlock2* GetParamBlock(int i) override;
+    virtual IParamBlock2* GetParamBlockByID(BlockID id) override;
+
+    // ReferenceMaker methods.
+    virtual int NumRefs() override;
+    virtual RefTargetHandle GetReference(int i) override;
+    virtual RefResult NotifyRefChanged(
+        const Interval&     changeInt,
+        RefTargetHandle     hTarget,
+        PartID&             partID,
+        RefMessage          message,
+        BOOL                propagate) override;
+        
+    // ReferenceTarget methods.
+    virtual RefTargetHandle Clone(RemapDir &remap);
+    
+    // ISubMap methods.
+    virtual int NumSubTexmaps() override;
+    virtual Texmap* GetSubTexmap(int i) override;
+    virtual void SetSubTexmap(int i, Texmap* texmap) override;
+    virtual int MapSlotType(int i) override;
+    virtual MSTR GetSubTexmapSlotName(int i) override;
+
+    // MtlBase methods.
+    virtual void Update(TimeValue t, Interval& valid);
+    virtual void Reset();
+    virtual Interval Validity(TimeValue t);
+    virtual ParamDlg* CreateParamDlg(HWND hwMtlEdit, IMtlParams* imp);
+
+    // Loading/Saving
+    virtual IOResult Save(ISave *isave);
+    virtual IOResult Load(ILoad *iload);
+    
+    //From Texmap
+    virtual RGBA   EvalColor(ShadeContext& sc);
+    virtual Point3 EvalNormalPerturb(ShadeContext& sc);
+
+    virtual foundation::auto_release_ptr<renderer::EnvironmentEDF> create_envmap(const char* name);
+
+protected:
+    virtual void SetReference(int i, RefTargetHandle rtarg);
+
+private:
+    IParamBlock2*    m_pblock;          // ref 0
+    Interval         m_params_validity;
+    Interval         m_map_validity;
+
+    float m_sun_theta;
+    float m_sun_phi;
+    float m_turbidity;
+    Texmap* m_turbidity_map;
+    BOOL m_turbidity_map_on;
+    float m_turb_multiplier;
+    float m_lumin_multiplier;
+    float m_lumin_gamma;
+    float m_sat_multiplier;
+    float m_horizon_shift;
+    float m_ground_albedo;
+};
+
+
+class EnvMapParamMapDlgProc
+    : public ParamMap2UserDlgProc
+{
+public:
+    virtual void DeleteThis() override
+    {
+        delete this;
+    }
+
+    virtual INT_PTR DlgProc(
+        TimeValue   t,
+        IParamMap2* map,
+        HWND        hwnd,
+        UINT        umsg,
+        WPARAM      wparam,
+        LPARAM      lparam) override;
+private:
+    void enable_disable_controls(HWND hwnd, IParamMap2* map);
+};
+
+//
+// AppleseedEnvMap material browser info.
+//
+
+class AppleseedEnvMapBrowserEntryInfo
+    : public IMaterialBrowserEntryInfo
+{
+public:
+    virtual const MCHAR* GetEntryName() const override;
+    virtual const MCHAR* GetEntryCategory() const override;
+    virtual Bitmap* GetEntryThumbnail() const override;
+};
+
+class AppleseedEnvMapClassDesc
+    : public ClassDesc2
+{
+public:
+    virtual int IsPublic() override;
+    virtual void* Create(BOOL /*loading = FALSE*/) override;
+    virtual const TCHAR *	ClassName() override;
+    virtual SClass_ID SuperClassID() override;
+    virtual Class_ID ClassID() override;
+    virtual const TCHAR* Category() override;
+    virtual const TCHAR* InternalName() override;
+    virtual FPInterface* GetInterface(Interface_ID id) override;
+    virtual HINSTANCE HInstance() override;
+private:
+    AppleseedEnvMapBrowserEntryInfo m_browser_entry_info;
+};
+
+extern AppleseedEnvMapClassDesc g_appleseed_appleseedenvmap_classdesc;
+
+
+

--- a/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.h
+++ b/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.h
@@ -1,25 +1,54 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2017 Sergo Pogosyan, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
 #pragma once
 
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 #include "foundation/utility/autoreleaseptr.h"
+
+// appleseed.renderer headers.
 #include "renderer/modeling/environmentedf/environmentedf.h"
 
 // 3ds Max headers.
-#include "appleseedenvmap/resource.h"
-#include <istdplug.h>
+#include <IMaterialBrowserEntryInfo.h>
+#include <imtl.h>
 #include <iparamb2.h>
 #include <iparamm2.h>
+#include <istdplug.h>
 #include <maxtypes.h>
 #include <stdmat.h>
-#include <imtl.h>
-#include <IMaterialBrowserEntryInfo.h>
 #undef base_type
 
-//namespace renderer  { class EnvironmentEDF; }
-
-class AppleseedEnvMap : public Texmap {
-public:
+class AppleseedEnvMap 
+  : public Texmap 
+{
+  public:
     static Class_ID get_class_id();
 
     // Constructor.
@@ -34,7 +63,7 @@ public:
     virtual Animatable* SubAnim(int i) override;
     virtual TSTR SubAnimName(int i) override;
     virtual int SubNumToRefNum(int subNum) override;
-    virtual int	NumParamBlocks() override;
+    virtual int NumParamBlocks() override;
     virtual IParamBlock2* GetParamBlock(int i) override;
     virtual IParamBlock2* GetParamBlockByID(BlockID id) override;
 
@@ -69,42 +98,38 @@ public:
     virtual IOResult Load(ILoad *iload);
     
     //From Texmap
-    virtual RGBA   EvalColor(ShadeContext& sc);
+    virtual RGBA EvalColor(ShadeContext& sc);
     virtual Point3 EvalNormalPerturb(ShadeContext& sc);
 
     virtual foundation::auto_release_ptr<renderer::EnvironmentEDF> create_envmap(const char* name);
 
-protected:
+  protected:
     virtual void SetReference(int i, RefTargetHandle rtarg);
 
-private:
-    IParamBlock2*    m_pblock;          // ref 0
-    Interval         m_params_validity;
-    Interval         m_map_validity;
-
-    float m_sun_theta;
-    float m_sun_phi;
-    float m_turbidity;
-    Texmap* m_turbidity_map;
-    BOOL m_turbidity_map_on;
-    float m_turb_multiplier;
-    float m_lumin_multiplier;
-    float m_lumin_gamma;
-    float m_sat_multiplier;
-    float m_horizon_shift;
-    float m_ground_albedo;
+  private:
+    IParamBlock2*   m_pblock;          // ref 0
+    Interval        m_params_validity;
+    Interval        m_map_validity;
+    float           m_sun_theta;
+    float           m_sun_phi;
+    float           m_turbidity;
+    Texmap*         m_turbidity_map;
+    BOOL            m_turbidity_map_on;
+    float           m_turb_multiplier;
+    float           m_lumin_multiplier;
+    float           m_lumin_gamma;
+    float           m_sat_multiplier;
+    float           m_horizon_shift;
+    float           m_ground_albedo;
 };
 
 
 class EnvMapParamMapDlgProc
-    : public ParamMap2UserDlgProc
+  : public ParamMap2UserDlgProc
 {
-public:
-    virtual void DeleteThis() override
-    {
-        delete this;
-    }
 
+  public:
+    virtual void DeleteThis() override;
     virtual INT_PTR DlgProc(
         TimeValue   t,
         IParamMap2* map,
@@ -112,41 +137,41 @@ public:
         UINT        umsg,
         WPARAM      wparam,
         LPARAM      lparam) override;
-private:
+
+  private:
     void enable_disable_controls(HWND hwnd, IParamMap2* map);
 };
+
 
 //
 // AppleseedEnvMap material browser info.
 //
 
 class AppleseedEnvMapBrowserEntryInfo
-    : public IMaterialBrowserEntryInfo
+  : public IMaterialBrowserEntryInfo
 {
-public:
+  public:
     virtual const MCHAR* GetEntryName() const override;
     virtual const MCHAR* GetEntryCategory() const override;
     virtual Bitmap* GetEntryThumbnail() const override;
 };
 
 class AppleseedEnvMapClassDesc
-    : public ClassDesc2
+  : public ClassDesc2
 {
-public:
+  public:
     virtual int IsPublic() override;
     virtual void* Create(BOOL /*loading = FALSE*/) override;
-    virtual const TCHAR *	ClassName() override;
+    virtual const TCHAR* ClassName() override;
     virtual SClass_ID SuperClassID() override;
     virtual Class_ID ClassID() override;
     virtual const TCHAR* Category() override;
     virtual const TCHAR* InternalName() override;
     virtual FPInterface* GetInterface(Interface_ID id) override;
     virtual HINSTANCE HInstance() override;
-private:
+
+  private:
     AppleseedEnvMapBrowserEntryInfo m_browser_entry_info;
 };
 
 extern AppleseedEnvMapClassDesc g_appleseed_appleseedenvmap_classdesc;
-
-
-

--- a/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.rc
+++ b/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.rc
@@ -31,18 +31,18 @@ FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
     CONTROL         "",IDC_EDIT_THETA,"CustEdit",WS_TABSTOP,85,12,35,10
     CONTROL         "",IDC_SPIN_THETA,"SpinnerControl",0x0,121,12,7,10
-    LTEXT           "Theta angle:",IDC_STATIC,13,14,41,8
+    LTEXT           "Theta Angle:",IDC_STATIC,13,14,41,8
     GROUPBOX        "Sun",IDC_STATIC,7,3,203,41
     CONTROL         "",IDC_EDIT_PHI,"CustEdit",WS_TABSTOP,85,24,35,10
     CONTROL         "",IDC_SPIN_PHI,"SpinnerControl",0x0,121,24,7,10
-    LTEXT           "Phi angle:",IDC_STATIC,13,26,32,8
+    LTEXT           "Phi Angle:",IDC_STATIC,13,26,32,8
     GROUPBOX        "Sky",IDC_STATIC,7,45,203,76
     CONTROL         "",IDC_EDIT_TURBIDITY,"CustEdit",WS_TABSTOP,85,54,35,10
     CONTROL         "",IDC_SPIN_TURBIDITY,"SpinnerControl",0x0,121,54,7,10
     LTEXT           "Turbidity:",IDC_STATIC,13,56,30,8
     CONTROL         "",IDC_EDIT_TURB_MULTIPLIER,"CustEdit",WS_TABSTOP,85,67,35,10
     CONTROL         "",IDC_SPIN_TURB_MULTIPLIER,"SpinnerControl",0x0,121,67,7,10
-    LTEXT           "Tubidity Multiplier:",IDC_STATIC,13,68,57,8,SS_CENTERIMAGE
+    LTEXT           "Turbidity Multiplier:",IDC_STATIC,13,68,57,8,SS_CENTERIMAGE
     CONTROL         "",IDC_EDIT_LUMIN_MULTIPLIER,"CustEdit",WS_TABSTOP,85,80,35,10
     CONTROL         "",IDC_SPIN_LUMIN_MULTIPLIER,"SpinnerControl",0x0,121,80,7,10
     LTEXT           "Luminance Multiplier:",IDC_STATIC,13,81,67,8
@@ -128,11 +128,11 @@ BEGIN
     IDS_CLASS_NAME_CDESC    "appleseed Environment Map"
     IDS_THETA               "Sun Theta Angle"
     IDS_PHI                 "Sun Phi Angle"
-    IDS_TURBIDITY           "Tubidity"
-    IDS_TURB_MULTIPLIER     "Tubidity Multiplier"
-    IDS_TURB_MAP            "Tubidity Map"
+    IDS_TURBIDITY           "Turbidity"
+    IDS_TURB_MULTIPLIER     "Turbidity Multiplier"
+    IDS_TURB_MAP            "Turbidity Map"
     IDS_CATEGORY            "appleseed"
-    IDS_TURB_MAP_ON         "Tubidity Map On"
+    IDS_TURB_MAP_ON         "Turbidity Map On"
     IDS_LUMINANCE_MULTIPLIER "Luminance Multiplier"
     IDS_LUMINANCE_GAMMA     "Luminance Gamma"
 END
@@ -142,9 +142,6 @@ BEGIN
     IDS_SAT_MULITPLIER      "Saturation Multiplier"
     IDS_HORIZON_SHIFT       "Horizon Shift"
     IDS_GROUND_ALBEDO       "Ground Albedo"
-    IDS_SKY_TYPE            "Sky EDF Type"
-    IDS_SKY_TYPE_1          "Hosek-Wilkie Model"
-    IDS_SKY_TYPE_2          "Preetham Model"
 END
 
 #endif    // English (United States) resources

--- a/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.rc
+++ b/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.rc
@@ -1,0 +1,164 @@
+// Microsoft Visual C++ generated resource script.
+//
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "windows.h"
+#define IDC_STATIC -1
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// English (United States) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+#pragma code_page(1252)
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Dialog
+//
+
+IDD_ENVMAP_PANEL DIALOGEX 0, 0, 217, 166
+STYLE DS_SETFONT | WS_CHILD | WS_VISIBLE
+FONT 8, "MS Sans Serif", 0, 0, 0x0
+BEGIN
+    CONTROL         "",IDC_EDIT_THETA,"CustEdit",WS_TABSTOP,85,12,35,10
+    CONTROL         "",IDC_SPIN_THETA,"SpinnerControl",0x0,121,12,7,10
+    LTEXT           "Theta angle:",IDC_STATIC,13,14,41,8
+    GROUPBOX        "Sun",IDC_STATIC,7,3,203,41
+    CONTROL         "",IDC_EDIT_PHI,"CustEdit",WS_TABSTOP,85,24,35,10
+    CONTROL         "",IDC_SPIN_PHI,"SpinnerControl",0x0,121,24,7,10
+    LTEXT           "Phi angle:",IDC_STATIC,13,26,32,8
+    GROUPBOX        "Sky",IDC_STATIC,7,45,203,76
+    CONTROL         "",IDC_EDIT_TURBIDITY,"CustEdit",WS_TABSTOP,85,54,35,10
+    CONTROL         "",IDC_SPIN_TURBIDITY,"SpinnerControl",0x0,121,54,7,10
+    LTEXT           "Turbidity:",IDC_STATIC,13,56,30,8
+    CONTROL         "",IDC_EDIT_TURB_MULTIPLIER,"CustEdit",WS_TABSTOP,85,67,35,10
+    CONTROL         "",IDC_SPIN_TURB_MULTIPLIER,"SpinnerControl",0x0,121,67,7,10
+    LTEXT           "Tubidity Multiplier:",IDC_STATIC,13,68,57,8,SS_CENTERIMAGE
+    CONTROL         "",IDC_EDIT_LUMIN_MULTIPLIER,"CustEdit",WS_TABSTOP,85,80,35,10
+    CONTROL         "",IDC_SPIN_LUMIN_MULTIPLIER,"SpinnerControl",0x0,121,80,7,10
+    LTEXT           "Luminance Multiplier:",IDC_STATIC,13,81,67,8
+    CONTROL         "",IDC_EDIT_LUMIN_GAMMA,"CustEdit",WS_TABSTOP,85,93,35,10
+    CONTROL         "",IDC_SPIN_LUMIN_GAMMA,"SpinnerControl",0x0,121,93,7,10
+    LTEXT           "Luminance Gamma:",IDC_STATIC,13,94,64,8
+    CONTROL         "",IDC_EDIT_SATUR_MULTIPLIER,"CustEdit",WS_TABSTOP,85,106,35,10
+    CONTROL         "",IDC_SPIN_SATUR_MULTIPLIER,"SpinnerControl",0x0,121,106,7,10
+    LTEXT           "Saturation Multiplier:",IDC_STATIC,13,106,64,8
+    CONTROL         "None",IDC_PICK_TURB_TEXTURE,"CustButton",WS_TABSTOP,136,53,56,14
+    GROUPBOX        "Ground",IDC_STATIC,7,122,203,36
+    CONTROL         "",IDC_EDIT_HORIZON_SHIFT,"CustEdit",WS_TABSTOP,85,131,35,10
+    CONTROL         "",IDC_SPIN_HORIZON_SHIFT,"SpinnerControl",0x0,121,131,7,10
+    LTEXT           "Horizon Shift:",IDC_STATIC,13,133,43,8
+    CONTROL         "",IDC_EDIT_GROUND_ALBEDO,"CustEdit",WS_TABSTOP,85,144,35,10
+    CONTROL         "",IDC_SPIN_GROUND_ALBEDO,"SpinnerControl",0x0,121,144,7,10
+    LTEXT           "Ground Albedo:",IDC_STATIC,13,144,50,8
+    CONTROL         "Pick Sun Light",IDC_PICK_SUN,"CustButton",NOT WS_VISIBLE | WS_TABSTOP,136,12,68,14
+    CONTROL         "",IDC_TURB_TEX_ON,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,196,56,8,10
+END
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// DESIGNINFO
+//
+
+#ifdef APSTUDIO_INVOKED
+GUIDELINES DESIGNINFO
+BEGIN
+    IDD_ENVMAP_PANEL, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 210
+        VERTGUIDE, 13
+        VERTGUIDE, 85
+        VERTGUIDE, 128
+        TOPMARGIN, 7
+        BOTTOMMARGIN, 159
+        HORZGUIDE, 12
+    END
+END
+#endif    // APSTUDIO_INVOKED
+
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#include ""windows.h""\r\n"
+    "#define IDC_STATIC -1\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// String Table
+//
+
+STRINGTABLE
+BEGIN
+    IDS_LIBDESCRIPTION      "appleseed Environment Map"
+    IDS_CLASS_NAME          "appleseed Env Map"
+    IDS_ENVMAP_PARAMS       "appleseed Environment Map Parameters"
+    IDS_CLASS_NAME_CDESC    "appleseed Environment Map"
+    IDS_THETA               "Sun Theta Angle"
+    IDS_PHI                 "Sun Phi Angle"
+    IDS_TURBIDITY           "Tubidity"
+    IDS_TURB_MULTIPLIER     "Tubidity Multiplier"
+    IDS_TURB_MAP            "Tubidity Map"
+    IDS_CATEGORY            "appleseed"
+    IDS_TURB_MAP_ON         "Tubidity Map On"
+    IDS_LUMINANCE_MULTIPLIER "Luminance Multiplier"
+    IDS_LUMINANCE_GAMMA     "Luminance Gamma"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_SAT_MULITPLIER      "Saturation Multiplier"
+    IDS_HORIZON_SHIFT       "Horizon Shift"
+    IDS_GROUND_ALBEDO       "Ground Albedo"
+    IDS_SKY_TYPE            "Sky EDF Type"
+    IDS_SKY_TYPE_1          "Hosek-Wilkie Model"
+    IDS_SKY_TYPE_2          "Preetham Model"
+END
+
+#endif    // English (United States) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED
+

--- a/src/appleseed-max-impl/appleseedenvmap/datachunks.h
+++ b/src/appleseed-max-impl/appleseedenvmap/datachunks.h
@@ -1,0 +1,41 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2016-2017 Francois Beaune, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+// appleseed.foundation headers.
+#include "foundation/platform/windows.h"
+
+//
+// Changing the values of these constants WILL break compatibility
+// with 3ds Max files saved with older versions of the plugin.
+//
+
+const USHORT ChunkFileFormatVersion                 = 0x0001;
+
+const USHORT ChunkMtlBase                           = 0x1000;

--- a/src/appleseed-max-impl/appleseedenvmap/resource.h
+++ b/src/appleseed-max-impl/appleseedenvmap/resource.h
@@ -1,0 +1,62 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by appleseedenvmap.rc
+//
+#define IDS_COORDS                      8007
+#define IDD_ENVMAP_PANEL                8101
+#define IDC_CLOSEBUTTON                 8020
+#define IDC_DOSTUFF                     8020
+#define IDC_PICK_SUN                    8022
+#define IDC_BUTTON3                     8023
+#define IDC_PICK_TURB_TEXTURE           8024
+#define IDC_COMBO_SKY_TYPE              8025
+#define IDC_TURB_TEX_ON                 8026
+#define IDC_COLOR                       8456
+#define IDC_EDIT_THETA                  8490
+#define IDC_EDIT_PHI                    8491
+#define IDC_EDIT_TURBIDITY              8492
+#define IDC_EDIT_TURB_MULTIPLIER        8493
+#define IDC_EDIT_LUMIN_MULTIPLIER       8494
+#define IDC_EDIT_LUMIN_GAMMA            8495
+#define IDC_SPIN_THETA                  8496
+#define IDC_SPIN_PHI                    8497
+#define IDC_SPIN_TURBIDITY              8498
+#define IDC_SPIN_TURB_MULTIPLIER        8499
+#define IDC_SPIN_LUMIN_MULTIPLIER       8500
+#define IDC_SPIN_LUMIN_GAMMA            8501
+#define IDC_EDIT_SATUR_MULTIPLIER       8502
+#define IDC_SPIN_SATUR_MULTIPLIER       8503
+#define IDC_EDIT_HORIZON_SHIFT          8504
+#define IDC_SPIN_HORIZON_SHIFT          8505
+#define IDC_EDIT_GROUND_ALBEDO          8506
+#define IDC_SPIN_GROUND_ALBEDO          8507
+#define IDS_LIBDESCRIPTION              8001
+#define IDS_CLASS_NAME                  8003
+#define IDS_ENVMAP_PARAMS               8004
+#define IDS_CLASS_NAME_CDESC            8005
+#define IDS_THETA                       8006
+#define IDS_PHI                         8008
+#define IDS_TURBIDITY                   8009
+#define IDS_TURB_MULTIPLIER             8010
+#define IDS_TURB_MAP                    8011
+#define IDS_CATEGORY                    8012
+#define IDS_TURB_MAP_ON                 8013
+#define IDS_LUMINANCE_MULTIPLIER        8014
+#define IDS_LUMINANCE_GAMMA             8015
+#define IDS_SAT_MULITPLIER              8016
+#define IDS_HORIZON_SHIFT               8017
+#define IDS_GROUND_ALBEDO               8018
+#define IDS_SKY_TYPE                    8019
+#define IDS_SKY_TYPE_1                  8020
+#define IDS_SKY_TYPE_2                  8021
+
+// Next default values for new objects
+// 
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        102
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         1006
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif

--- a/src/appleseed-max-impl/appleseedenvmap/resource.h
+++ b/src/appleseed-max-impl/appleseedenvmap/resource.h
@@ -46,9 +46,6 @@
 #define IDS_SAT_MULITPLIER              8016
 #define IDS_HORIZON_SHIFT               8017
 #define IDS_GROUND_ALBEDO               8018
-#define IDS_SKY_TYPE                    8019
-#define IDS_SKY_TYPE_1                  8020
-#define IDS_SKY_TYPE_2                  8021
 
 // Next default values for new objects
 // 

--- a/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
@@ -30,6 +30,7 @@
 #include "projectbuilder.h"
 
 // appleseed-max headers.
+#include "appleseedenvmap/appleseedenvmap.h"
 #include "appleseedobjpropsmod/appleseedobjpropsmod.h"
 #include "appleseedrenderer/maxsceneentities.h"
 #include "appleseedrenderer/renderersettings.h"
@@ -904,76 +905,157 @@ namespace
     {
         if (rend_params.envMap != nullptr)
         {
-            const size_t TextureWidth = 512;
-            const size_t TextureHeight = 512;
+            std::string env_edf_name("environment_edf");
+            std::string env_shader_name("environment_shader");
+            std::string env_tex_name("environment_map");
+            std::string env_tex_instance_name("environment_map_inst");
 
-            // Render the environment map into a Max bitmap.
-            BitmapInfo bi;
-            bi.SetWidth(TextureWidth);
-            bi.SetHeight(TextureHeight);
-            bi.SetType(BMM_FLOAT_RGBA_32);
-            Bitmap* envmap_bitmap = TheManager->Create(&bi);
-            rend_params.envMap->RenderBitmap(time, envmap_bitmap, 1.0f, TRUE);
-
-            // Build an appleseed image from the Max bitmap.
-            asf::auto_release_ptr<asf::Image> envmap_image(
-                new asf::Image(
-                    TextureWidth, TextureHeight,    // image dimensions
-                    TextureWidth, TextureHeight,    // tile dimensions
-                    4,
-                    asf::PixelFormatFloat));
-            for (size_t y = 0; y < TextureHeight; ++y)
+            //insert textures
+            //in case of bitmap env map
+            if (rend_params.envMap->IsSubClassOf(Class_ID(BMTEX_CLASS_ID, 0)))
             {
-                for (size_t x = 0; x < TextureWidth; ++x)
+                auto bitmap_envmap = static_cast<BitmapTex*>(rend_params.envMap);
+                if (bitmap_envmap)
                 {
-                    BMM_Color_fl c;
-                    envmap_bitmap->GetLinearPixels(
-                        static_cast<int>(x),
-                        static_cast<int>(y),
-                        1,
-                        &c);
-                    envmap_image->set_pixel(x, y, c);
+				    auto tex_filename = wide_to_utf8(bitmap_envmap->GetMapName());
+                    env_tex_instance_name = make_unique_name(scene.texture_instances(), tex_filename + "_inst");
+
+                    scene.textures().insert(
+                        asf::auto_release_ptr<asr::Texture>(
+                            asr::DiskTexture2dFactory::static_create(
+                                env_tex_name.c_str(),
+                                asr::ParamArray()
+                                    .insert("color_space", "linear_rgb") //todo: exr and hdr should be linear, others should be srgb
+                                    .insert("filename", tex_filename),
+                                    asf::SearchPaths())));
+
+                    scene.texture_instances().insert(
+                        asf::auto_release_ptr<asr::TextureInstance>(
+                            asr::TextureInstanceFactory::create(
+                                env_tex_instance_name.c_str(),
+                                asr::ParamArray(),
+                                env_tex_name.c_str())));
                 }
             }
+            //in case of unknown class
+            else if (!rend_params.envMap->IsSubClassOf(AppleseedEnvMap::get_class_id()))
+            {
+                //proceed with rendering env map and applying it to background shader
+                const size_t TextureWidth = 512;
+                const size_t TextureHeight = 512;
 
-            // Destroy the Max bitmap.
-            envmap_bitmap->DeleteThis();
+                // Render the environment map into a Max bitmap.
+                BitmapInfo bi;
+                bi.SetWidth(TextureWidth);
+                bi.SetHeight(TextureHeight);
+                bi.SetType(BMM_FLOAT_RGBA_32);
+                Bitmap* envmap_bitmap = TheManager->Create(&bi);
+                rend_params.envMap->RenderBitmap(time, envmap_bitmap, 1.0f, TRUE);
 
-            scene.textures().insert(
-                asf::auto_release_ptr<asr::Texture>(
-                    asr::MemoryTexture2dFactory::static_create(
-                        "environment_map",
-                        asr::ParamArray()
-                            .insert("color_space", "linear_rgb"),
-                        envmap_image)));
+                // Build an appleseed image from the Max bitmap.
+                asf::auto_release_ptr<asf::Image> envmap_image(
+                    new asf::Image(
+                        TextureWidth, TextureHeight,    // image dimensions
+                        TextureWidth, TextureHeight,    // tile dimensions
+                        4,
+                        asf::PixelFormatFloat));
+                for (size_t y = 0; y < TextureHeight; ++y)
+                {
+                    for (size_t x = 0; x < TextureWidth; ++x)
+                    {
+                        BMM_Color_fl c;
+                        envmap_bitmap->GetLinearPixels(
+                            static_cast<int>(x),
+                            static_cast<int>(y),
+                            1,
+                            &c);
+                        envmap_image->set_pixel(x, y, c);
+                    }
+                }
 
-            scene.texture_instances().insert(
-                asf::auto_release_ptr<asr::TextureInstance>(
-                    asr::TextureInstanceFactory::create(
-                        "environment_map_inst",
-                        asr::ParamArray(),
-                        "environment_map")));
+                // Destroy the Max bitmap.
+                envmap_bitmap->DeleteThis();
 
-            scene.environment_edfs().insert(
-                asf::auto_release_ptr<asr::EnvironmentEDF>(
-                    asr::LatLongMapEnvironmentEDFFactory::static_create(
-                        "environment_edf",
-                        asr::ParamArray()
-                            .insert("radiance", "environment_map_inst"))));
+                env_tex_name = make_unique_name(scene.textures(), "environment_map");
+                env_tex_instance_name = make_unique_name(scene.texture_instances(), "environment_map_inst");
 
-            scene.environment_shaders().insert(
-                asr::BackgroundEnvironmentShaderFactory::static_create(
-                    "environment_shader",
+                scene.textures().insert(
+                    asf::auto_release_ptr<asr::Texture>(
+                        asr::MemoryTexture2dFactory::static_create(
+                            env_tex_name.c_str(),
+                            asr::ParamArray()
+                                .insert("color_space", "linear_rgb"),
+                            envmap_image)));
+
+                scene.texture_instances().insert(
+                    asf::auto_release_ptr<asr::TextureInstance>(
+                        asr::TextureInstanceFactory::create(
+                            env_tex_instance_name.c_str(),
+                            asr::ParamArray(),
+                            env_tex_name.c_str())));
+            }
+
+            //insert EDF
+            //in case of appleseed envmap
+            if (rend_params.envMap->IsSubClassOf(AppleseedEnvMap::get_class_id()))
+            {
+                auto appleseed_envmap = static_cast<AppleseedEnvMap*>(rend_params.envMap);
+                if (appleseed_envmap)
+                {
+                    scene.environment_edfs().insert(appleseed_envmap->create_envmap(env_edf_name.c_str()));
+                }
+            }
+            //in case of bitmap envmap and unknown class
+            else
+            {
+                //todo: translate UVoffset to lat/long parameters
+                scene.environment_edfs().insert(
+                    asf::auto_release_ptr<asr::EnvironmentEDF>(
+                        asr::LatLongMapEnvironmentEDFFactory::static_create(
+                            env_edf_name.c_str(),
+                            asr::ParamArray()
+                                .insert("radiance", env_tex_instance_name.c_str()))));
+            }
+
+            //insert shader
+            //in case of appleseed envmap and bitmap envmap
+            if (rend_params.envMap->IsSubClassOf(AppleseedEnvMap::get_class_id()) || rend_params.envMap->IsSubClassOf(Class_ID(BMTEX_CLASS_ID, 0)))
+            {
+                scene.environment_shaders().insert(
+                asr::EDFEnvironmentShaderFactory::static_create(
+                    env_shader_name.c_str(),
                     asr::ParamArray()
-                        .insert("color", "environment_map_inst")
-                        .insert("alpha", settings.m_background_alpha)));
+                        .insert("environment_edf", env_edf_name.c_str())
+                        .insert("alpha_value", settings.m_background_alpha)));
+            }
+            //in case of unknown class
+            else
+            {
+                scene.environment_shaders().insert(
+                    asr::BackgroundEnvironmentShaderFactory::static_create(
+                        env_shader_name.c_str(),
+                        asr::ParamArray()
+                            .insert("color", env_tex_instance_name.c_str())
+                            .insert("alpha", settings.m_background_alpha)));
+            }
 
-            scene.set_environment(
-                asr::EnvironmentFactory::create(
-                    "environment",
-                    asr::ParamArray()
-                        .insert("environment_edf", "environment_edf")
-                        .insert("environment_shader", "environment_shader")));
+            if (settings.m_background_emits_light)
+            {
+                scene.set_environment(
+                    asr::EnvironmentFactory::create(
+                        "environment",
+                        asr::ParamArray()
+                            .insert("environment_edf", env_edf_name.c_str())
+                            .insert("environment_shader", env_shader_name.c_str())));
+            }
+            else
+            {
+                scene.set_environment(
+                    asr::EnvironmentFactory::create(
+                        "environment",
+                        asr::ParamArray()
+                            .insert("environment_shader", env_shader_name.c_str())));
+            }
         }
         else
         {

--- a/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
@@ -910,8 +910,7 @@ namespace
             std::string env_tex_name("environment_map");
             std::string env_tex_instance_name("environment_map_inst");
 
-            //insert textures
-            //in case of bitmap env map
+            // Insert textures.
             if (rend_params.envMap->IsSubClassOf(Class_ID(BMTEX_CLASS_ID, 0)))
             {
                 auto bitmap_envmap = static_cast<BitmapTex*>(rend_params.envMap);
@@ -920,10 +919,9 @@ namespace
                     env_tex_instance_name = insert_texture_and_instance(scene, bitmap_envmap);
                 }
             }
-            //in case of unknown class
             else if (!rend_params.envMap->IsSubClassOf(AppleseedEnvMap::get_class_id()))
             {
-                //proceed with rendering env map and applying it to background shader
+                // Proceed with rendering env map and applying it to background shader.
                 const size_t TextureWidth = 512;
                 const size_t TextureHeight = 512;
 
@@ -978,8 +976,7 @@ namespace
                             env_tex_name.c_str())));
             }
 
-            //insert EDF
-            //in case of appleseed envmap
+            // Insert EDF.
             if (rend_params.envMap->IsSubClassOf(AppleseedEnvMap::get_class_id()))
             {
                 auto appleseed_envmap = static_cast<AppleseedEnvMap*>(rend_params.envMap);
@@ -988,7 +985,6 @@ namespace
                     scene.environment_edfs().insert(appleseed_envmap->create_envmap(env_edf_name.c_str()));
                 }
             }
-            //in case of bitmap envmap and unknown class
             else
             {
                 asr::ParamArray envParams;
@@ -997,8 +993,9 @@ namespace
                 if (envMap)
                 {
                     UVGen* uvg = envMap->GetTheUVGen();
-				    if (uvg && uvg->IsStdUVGen()) {
-					    StdUVGen *suvg = static_cast<StdUVGen*>(uvg);
+                    if (uvg && uvg->IsStdUVGen())
+                    {
+                        StdUVGen *suvg = static_cast<StdUVGen*>(uvg);
                         envParams.insert("horizontal_shift", suvg->GetUOffs(time) * 180.0f);
                         envParams.insert("vertical_shift", suvg->GetVOffs(time) * 180.0f);
                     }
@@ -1014,8 +1011,7 @@ namespace
 
             }
 
-            //insert shader
-            //in case of appleseed envmap and bitmap envmap
+            // Insert shader.
             if (rend_params.envMap->IsSubClassOf(AppleseedEnvMap::get_class_id()) || rend_params.envMap->IsSubClassOf(Class_ID(BMTEX_CLASS_ID, 0)))
             {
                 scene.environment_shaders().insert(
@@ -1025,7 +1021,6 @@ namespace
                         .insert("environment_edf", env_edf_name.c_str())
                         .insert("alpha_value", settings.m_background_alpha)));
             }
-            //in case of unknown class
             else
             {
                 scene.environment_shaders().insert(

--- a/src/appleseed-max-impl/plugin.cpp
+++ b/src/appleseed-max-impl/plugin.cpp
@@ -33,6 +33,7 @@
 #include "appleseedobjpropsmod/appleseedobjpropsmod.h"
 #include "appleseedrenderer/appleseedrenderer.h"
 #include "appleseedsssmtl/appleseedsssmtl.h"
+#include "appleseedenvmap/appleseedenvmap.h"
 #include "logtarget.h"
 #include "main.h"
 #include "utilities.h"
@@ -78,7 +79,7 @@ extern "C"
     __declspec(dllexport)
     int LibNumberClasses()
     {
-        return 6;
+        return 7;
     }
 
     __declspec(dllexport)
@@ -92,6 +93,7 @@ extern "C"
           case 3: return &g_appleseed_glassmtl_classdesc;
           case 4: return &g_appleseed_lightmtl_classdesc;
           case 5: return &g_appleseed_objpropsmod_classdesc;
+          case 6: return &g_appleseed_appleseedenvmap_classdesc;
 
           // Make sure to update LibNumberClasses() if you add classes here.
 

--- a/src/appleseed-max-impl/plugin.cpp
+++ b/src/appleseed-max-impl/plugin.cpp
@@ -27,13 +27,13 @@
 //
 
 // appleseed-max headers.
+#include "appleseedenvmap/appleseedenvmap.h"
 #include "appleseeddisneymtl/appleseeddisneymtl.h"
 #include "appleseedglassmtl/appleseedglassmtl.h"
 #include "appleseedlightmtl/appleseedlightmtl.h"
 #include "appleseedobjpropsmod/appleseedobjpropsmod.h"
 #include "appleseedrenderer/appleseedrenderer.h"
 #include "appleseedsssmtl/appleseedsssmtl.h"
-#include "appleseedenvmap/appleseedenvmap.h"
 #include "logtarget.h"
 #include "main.h"
 #include "utilities.h"

--- a/src/appleseed-max/appleseed-max2016.vcxproj
+++ b/src/appleseed-max/appleseed-max2016.vcxproj
@@ -171,9 +171,9 @@ copy /Y "$(TargetPath)" "$(SolutionDir)..\..\appleseed-max2016-plugin-folder\"</
       <GenerateDebugInformation>false</GenerateDebugInformation>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\bin\appleseed-max2015\$(Platform)\$(Configuration)" 2&gt;nul
-copy /Y "$(TargetPath)" "$(SolutionDir)..\bin\appleseed-max2015\$(Platform)\$(Configuration)\"
-copy /Y "$(TargetPath)" "C:\Program Files\Autodesk\3ds Max 2015\plugins\appleseed\"</Command>
+      <Command>mkdir "$(SolutionDir)..\bin\appleseed-max2016\$(Platform)\$(Configuration)" 2&gt;nul
+copy /Y "$(TargetPath)" "$(SolutionDir)..\bin\appleseed-max2016\$(Platform)\$(Configuration)\"
+copy /Y "$(TargetPath)" "$(SolutionDir)..\..\appleseed-max2016-plugin-folder\"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
Hi,

This is an attempt to add environment map to appleseed-max plugin:

- Texture map plugin that holds appleseed sky map parameters. I tried to follow code style of material plugins.
- Turbidity map slot is not translated into appleseed renderer yet.

I've also changed setup_environment function a little:

- it creates Hosek sky edf in case of appleseed environment map
- If environment map is a bitmap it is translated to appleseed as a file texture.
- max's UV offset parameters are translated into LatLongMapEnvironmentEDF's horizontal_shift/vertical_shift parameters

Regards,
Sergo.

Update: Now I realized I only updated projects and solution for 2016 max. Looks like I need to get all three version of sdk-s