### PR TITLE
Physical camera and IMtlRender_Compatibility support

### DIFF
--- a/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
+++ b/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
@@ -30,10 +30,11 @@
 #include "appleseeddisneymtl.h"
 
 // appleseed-max headers.
-#include "bump/bumpparammapdlgproc.h"
-#include "bump/resource.h"
 #include "appleseeddisneymtl/datachunks.h"
 #include "appleseeddisneymtl/resource.h"
+#include "appleseedrenderer/appleseedrenderer.h"
+#include "bump/bumpparammapdlgproc.h"
+#include "bump/resource.h"
 #include "main.h"
 #include "utilities.h"
 #include "version.h"
@@ -807,6 +808,11 @@ Bitmap* AppleseedDisneyMtlBrowserEntryInfo::GetEntryThumbnail() const
 // AppleseedDisneyMtlClassDesc class implementation.
 //
 
+AppleseedDisneyMtlClassDesc::AppleseedDisneyMtlClassDesc()
+{
+    IMtlRender_Compatibility_MtlBase::Init(*this);
+}
+
 int AppleseedDisneyMtlClassDesc::IsPublic()
 {
     return TRUE;
@@ -854,4 +860,9 @@ FPInterface* AppleseedDisneyMtlClassDesc::GetInterface(Interface_ID id)
 HINSTANCE AppleseedDisneyMtlClassDesc::HInstance()
 {
     return g_module;
+}
+
+bool AppleseedDisneyMtlClassDesc::IsCompatibleWithRenderer(ClassDesc& renderer_class_desc)
+{
+    return (renderer_class_desc.ClassID() == AppleseedRenderer::get_class_id()) ? true : false;
 }

--- a/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.h
+++ b/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.h
@@ -38,6 +38,7 @@
 // 3ds Max headers.
 #include <color.h>
 #include <IMaterialBrowserEntryInfo.h>
+#include <IMtlRender_Compatibility.h>
 #include <imtl.h>
 #include <interval.h>
 #include <iparamb2.h>
@@ -185,8 +186,10 @@ class AppleseedDisneyMtlBrowserEntryInfo
 
 class AppleseedDisneyMtlClassDesc
   : public ClassDesc2
+  , public IMtlRender_Compatibility_MtlBase
 {
   public:
+    AppleseedDisneyMtlClassDesc();
     virtual int IsPublic() override;
     virtual void* Create(BOOL loading) override;
     virtual const MCHAR* ClassName() override;
@@ -196,6 +199,9 @@ class AppleseedDisneyMtlClassDesc
     virtual const MCHAR* InternalName() override;
     virtual FPInterface* GetInterface(Interface_ID id) override;
     virtual HINSTANCE HInstance() override;
+
+    // From IMtlRender_Compatibility_MtlBase.
+    virtual bool IsCompatibleWithRenderer(ClassDesc& renderer_class_desc) override;
 
   private:
     AppleseedDisneyMtlBrowserEntryInfo m_browser_entry_info;

--- a/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.cpp
+++ b/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.cpp
@@ -32,6 +32,7 @@
 // appleseed-max headers.
 #include "appleseedenvmap/datachunks.h"
 #include "appleseedenvmap/resource.h"
+#include "appleseedrenderer/appleseedrenderer.h"
 #include "main.h"
 #include "utilities.h"
 #include "version.h"
@@ -586,6 +587,11 @@ Bitmap* AppleseedEnvMapBrowserEntryInfo::GetEntryThumbnail() const
 // AppleseedEnvMapClassDesc class implementation.
 //
 
+AppleseedEnvMapClassDesc::AppleseedEnvMapClassDesc()
+{
+    IMtlRender_Compatibility_MtlBase::Init(*this);
+}
+
 int AppleseedEnvMapClassDesc::IsPublic()
 {
     return TRUE;
@@ -633,4 +639,9 @@ FPInterface* AppleseedEnvMapClassDesc::GetInterface(Interface_ID id)
 HINSTANCE AppleseedEnvMapClassDesc::HInstance()
 {
     return g_module;
+}
+
+bool AppleseedEnvMapClassDesc::IsCompatibleWithRenderer(ClassDesc& renderer_class_desc)
+{
+    return (renderer_class_desc.ClassID() == AppleseedRenderer::get_class_id()) ? true : false;
 }

--- a/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.h
+++ b/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.h
@@ -37,6 +37,7 @@
 
 // 3ds Max headers.
 #include <IMaterialBrowserEntryInfo.h>
+#include <IMtlRender_Compatibility.h>
 #include <imtl.h>
 #include <iparamb2.h>
 #include <iparamm2.h>
@@ -142,8 +143,10 @@ class AppleseedEnvMapBrowserEntryInfo
 
 class AppleseedEnvMapClassDesc
   : public ClassDesc2
+  , public IMtlRender_Compatibility_MtlBase
 {
   public:
+    AppleseedEnvMapClassDesc();
     virtual int IsPublic() override;
     virtual void* Create(BOOL /*loading = FALSE*/) override;
     virtual const TCHAR* ClassName() override;
@@ -153,6 +156,9 @@ class AppleseedEnvMapClassDesc
     virtual const TCHAR* InternalName() override;
     virtual FPInterface* GetInterface(Interface_ID id) override;
     virtual HINSTANCE HInstance() override;
+
+    // From IMtlRender_Compatibility_MtlBase.
+    virtual bool IsCompatibleWithRenderer(ClassDesc& renderer_class_desc) override;
 
   private:
     AppleseedEnvMapBrowserEntryInfo m_browser_entry_info;

--- a/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.cpp
+++ b/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.cpp
@@ -32,6 +32,7 @@
 // appleseed-max headers.
 #include "appleseedglassmtl/datachunks.h"
 #include "appleseedglassmtl/resource.h"
+#include "appleseedrenderer/appleseedrenderer.h"
 #include "bump/bumpparammapdlgproc.h"
 #include "bump/resource.h"
 #include "main.h"
@@ -755,6 +756,11 @@ Bitmap* AppleseedGlassMtlBrowserEntryInfo::GetEntryThumbnail() const
 // AppleseedGlassMtlClassDesc class implementation.
 //
 
+AppleseedGlassMtlClassDesc::AppleseedGlassMtlClassDesc()
+{
+    IMtlRender_Compatibility_MtlBase::Init(*this);
+}
+
 int AppleseedGlassMtlClassDesc::IsPublic()
 {
     return TRUE;
@@ -802,4 +808,9 @@ FPInterface* AppleseedGlassMtlClassDesc::GetInterface(Interface_ID id)
 HINSTANCE AppleseedGlassMtlClassDesc::HInstance()
 {
     return g_module;
+}
+
+bool AppleseedGlassMtlClassDesc::IsCompatibleWithRenderer(ClassDesc& renderer_class_desc)
+{
+    return (renderer_class_desc.ClassID() == AppleseedRenderer::get_class_id()) ? true : false;
 }

--- a/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.h
+++ b/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.h
@@ -38,6 +38,7 @@
 // 3ds Max headers.
 #include <color.h>
 #include <IMaterialBrowserEntryInfo.h>
+#include <IMtlRender_Compatibility.h>
 #include <imtl.h>
 #include <interval.h>
 #include <iparamb2.h>
@@ -177,8 +178,10 @@ class AppleseedGlassMtlBrowserEntryInfo
 
 class AppleseedGlassMtlClassDesc
   : public ClassDesc2
+  , public IMtlRender_Compatibility_MtlBase
 {
   public:
+    AppleseedGlassMtlClassDesc();
     virtual int IsPublic() override;
     virtual void* Create(BOOL loading) override;
     virtual const MCHAR* ClassName() override;
@@ -188,6 +191,9 @@ class AppleseedGlassMtlClassDesc
     virtual const MCHAR* InternalName() override;
     virtual FPInterface* GetInterface(Interface_ID id) override;
     virtual HINSTANCE HInstance() override;
+
+    // From IMtlRender_Compatibility_MtlBase.
+    virtual bool IsCompatibleWithRenderer(ClassDesc& renderer_class_desc) override;
 
   private:
     AppleseedGlassMtlBrowserEntryInfo m_browser_entry_info;

--- a/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.cpp
+++ b/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.cpp
@@ -32,6 +32,7 @@
 // appleseed-max headers.
 #include "appleseedlightmtl/datachunks.h"
 #include "appleseedlightmtl/resource.h"
+#include "appleseedrenderer/appleseedrenderer.h"
 #include "main.h"
 #include "utilities.h"
 #include "version.h"
@@ -544,6 +545,11 @@ Bitmap* AppleseedLightMtlBrowserEntryInfo::GetEntryThumbnail() const
 // AppleseedLightMtlClassDesc class implementation.
 //
 
+AppleseedLightMtlClassDesc::AppleseedLightMtlClassDesc()
+{
+    IMtlRender_Compatibility_MtlBase::Init(*this);
+}
+
 int AppleseedLightMtlClassDesc::IsPublic()
 {
     return TRUE;
@@ -591,4 +597,9 @@ FPInterface* AppleseedLightMtlClassDesc::GetInterface(Interface_ID id)
 HINSTANCE AppleseedLightMtlClassDesc::HInstance()
 {
     return g_module;
+}
+
+bool AppleseedLightMtlClassDesc::IsCompatibleWithRenderer(ClassDesc& renderer_class_desc)
+{
+    return (renderer_class_desc.ClassID() == AppleseedRenderer::get_class_id()) ? true : false;
 }

--- a/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.h
+++ b/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.h
@@ -38,6 +38,7 @@
 // 3ds Max headers.
 #include <color.h>
 #include <IMaterialBrowserEntryInfo.h>
+#include <IMtlRender_Compatibility.h>
 #include <imtl.h>
 #include <interval.h>
 #include <iparamb2.h>
@@ -164,8 +165,10 @@ class AppleseedLightMtlBrowserEntryInfo
 
 class AppleseedLightMtlClassDesc
   : public ClassDesc2
+  , public IMtlRender_Compatibility_MtlBase
 {
   public:
+    AppleseedLightMtlClassDesc();
     virtual int IsPublic() override;
     virtual void* Create(BOOL loading) override;
     virtual const MCHAR* ClassName() override;
@@ -175,6 +178,9 @@ class AppleseedLightMtlClassDesc
     virtual const MCHAR* InternalName() override;
     virtual FPInterface* GetInterface(Interface_ID id) override;
     virtual HINSTANCE HInstance() override;
+
+    // From IMtlRender_Compatibility_MtlBase.
+    virtual bool IsCompatibleWithRenderer(ClassDesc& renderer_class_desc) override;
 
   private:
     AppleseedLightMtlBrowserEntryInfo m_browser_entry_info;

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
@@ -75,6 +75,11 @@ AppleseedRendererClassDesc g_appleseed_renderer_classdesc;
 // AppleseedRenderer class implementation.
 //
 
+Class_ID AppleseedRenderer::get_class_id()
+{
+    return AppleseedRendererClassId;
+}
+
 AppleseedRenderer::AppleseedRenderer()
   : m_settings(RendererSettings::defaults())
 {

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
@@ -401,6 +401,7 @@ int AppleseedRenderer::Render(
         build_project(
             m_entities,
             m_default_lights,
+            m_view_node,
             m_view_params,
             m_rend_params,
             frame_rend_params,

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.h
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.h
@@ -51,6 +51,8 @@ class AppleseedRenderer
   : public Renderer
 {
   public:
+    static Class_ID get_class_id();
+
     AppleseedRenderer();
 
     virtual Class_ID ClassID() override;

--- a/src/appleseed-max-impl/appleseedrenderer/projectbuilder.h
+++ b/src/appleseed-max-impl/appleseedrenderer/projectbuilder.h
@@ -35,6 +35,9 @@
 // 3ds Max headers.
 #include <maxtypes.h>
 #include <render.h>
+#if MAX_RELEASE != MAX_RELEASE_R16
+    #include <Scene/IPhysicalCamera.h>
+#endif
 
 // Standard headers.
 #include <vector>
@@ -52,6 +55,7 @@ class ViewParams;
 foundation::auto_release_ptr<renderer::Project> build_project(
     const MaxSceneEntities&             entities,
     const std::vector<DefaultLight>&    default_lights,
+    INode*                              view_node,
     const ViewParams&                   view_params,
     const RendParams&                   rend_params,
     const FrameRendParams&              frame_rend_params,

--- a/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
+++ b/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
@@ -30,6 +30,7 @@
 #include "appleseedsssmtl.h"
 
 // appleseed-max headers.
+#include "appleseedrenderer/appleseedrenderer.h"
 #include "appleseedsssmtl/datachunks.h"
 #include "appleseedsssmtl/resource.h"
 #include "bump/bumpparammapdlgproc.h"
@@ -780,6 +781,11 @@ Bitmap* AppleseedSSSMtlBrowserEntryInfo::GetEntryThumbnail() const
 // AppleseedSSSMtlClassDesc class implementation.
 //
 
+AppleseedSSSMtlClassDesc::AppleseedSSSMtlClassDesc()
+{
+    IMtlRender_Compatibility_MtlBase::Init(*this);
+}
+
 int AppleseedSSSMtlClassDesc::IsPublic()
 {
     return TRUE;
@@ -827,4 +833,9 @@ FPInterface* AppleseedSSSMtlClassDesc::GetInterface(Interface_ID id)
 HINSTANCE AppleseedSSSMtlClassDesc::HInstance()
 {
     return g_module;
+}
+
+bool AppleseedSSSMtlClassDesc::IsCompatibleWithRenderer(ClassDesc& renderer_class_desc)
+{
+    return (renderer_class_desc.ClassID() == AppleseedRenderer::get_class_id()) ? true : false;
 }

--- a/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.h
+++ b/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.h
@@ -38,6 +38,7 @@
 // 3ds Max headers.
 #include <color.h>
 #include <IMaterialBrowserEntryInfo.h>
+#include <IMtlRender_Compatibility.h>
 #include <imtl.h>
 #include <interval.h>
 #include <iparamb2.h>
@@ -178,8 +179,10 @@ class AppleseedSSSMtlBrowserEntryInfo
 
 class AppleseedSSSMtlClassDesc
   : public ClassDesc2
+  , public IMtlRender_Compatibility_MtlBase
 {
   public:
+    AppleseedSSSMtlClassDesc();
     virtual int IsPublic() override;
     virtual void* Create(BOOL loading) override;
     virtual const MCHAR* ClassName() override;
@@ -189,6 +192,9 @@ class AppleseedSSSMtlClassDesc
     virtual const MCHAR* InternalName() override;
     virtual FPInterface* GetInterface(Interface_ID id) override;
     virtual HINSTANCE HInstance() override;
+
+    // From IMtlRender_Compatibility_MtlBase.
+    virtual bool IsCompatibleWithRenderer(ClassDesc& renderer_class_desc) override;
 
   private:
     AppleseedSSSMtlBrowserEntryInfo m_browser_entry_info;


### PR DESCRIPTION
Hi,

I'm trying add Depth of Field and Bokeh support by converting Physical camera's properties. Works only with 3ds max version 2016 and higher. Depth of field and Bokeh is turning on when Enable Depth of Field checkbox is on in Physical Camera properties.
Properties being transferred to appleseed are:
- Aperture
- Target Distance (distance to target or custom distance)
- Circular and Bladed Bokeh
- Blade number and Rotation

Also I've added IMtlRender_Compatibility_MtlBase implementation to each material to hide them from material list when any renderer other than appleseed is chosen in 3ds max.

Thanks for reviewing,
Sergo.