### PR TITLE
Sun light node support

### DIFF
--- a/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.cpp
+++ b/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.cpp
@@ -42,11 +42,12 @@ namespace asr = renderer;
 
 namespace
 {
-    const TCHAR* AppleseedEnvMapFriendlyClassName = _T("appleseed Environment Map");
+    const TCHAR* AppleseedEnvMapFriendlyClassName = _T("appleseed Sky");
 }
 
 AppleseedEnvMapClassDesc g_appleseed_envmap_classdesc;
-
+SunNodePBAccessor g_sun_node_accessor;
+SunNodePBValidator g_sun_node_validator;
 
 //
 // AppleseedEnvMap class implementation.
@@ -69,7 +70,10 @@ namespace
         ParamIdLuminGamma           = 7,
         ParamIdSatMultiplier        = 8,
         ParamIdHorizonShift         = 10,
-        ParamIdGroundAlbedo         = 11
+        ParamIdGroundAlbedo         = 11,
+        ParamIdSunNode              = 12,
+        ParamIdSunNodeOn            = 13,
+        ParamIdSunSizeMultiplier    = 14
     };
 
     enum TexmapId
@@ -116,6 +120,25 @@ namespace
             p_default, 0.0f,
             p_range, 0.0f, 360.0f,
             p_ui, TYPE_SPINNER, EDITTYPE_FLOAT, IDC_EDIT_PHI, IDC_SPIN_PHI, 0.01f,
+        p_end,
+
+        ParamIdSunSizeMultiplier, _T("sun_size_multiplier"), TYPE_FLOAT, P_ANIMATABLE, IDS_SIZE_MULTIPLIER,
+            p_default, 1.0f,
+            p_range, 0.0f, 1000.0f,
+            p_ui, TYPE_SPINNER, EDITTYPE_FLOAT, IDC_EDIT_SIZE_MULTIPLIER, IDC_SPIN_SIZE_MULTIPLIER, 0.1f,
+        p_end,
+
+        ParamIdSunNode, _T("sun_node"), TYPE_INODE, 0, IDS_SUN_NODE,
+            p_ui, TYPE_PICKNODEBUTTON, IDC_PICK_SUN_NODE,
+            p_prompt, IDS_PICK_SUN_PROMPT,
+            p_validator, &g_sun_node_validator,
+            p_accessor, &g_sun_node_accessor,
+        p_end,
+
+        ParamIdSunNodeOn, _T("sun_node_on"), TYPE_BOOL, 0, IDS_TURB_MAP_ON,
+        p_default, TRUE,
+        p_ui, TYPE_SINGLECHEKBOX, IDC_SUN_NODE_ON,
+        p_accessor, &g_sun_node_accessor,
         p_end,
 
         ParamIdTurbidity, _T("turbidity"), TYPE_FLOAT, P_ANIMATABLE, IDS_TURBIDITY,
@@ -183,6 +206,8 @@ AppleseedEnvMap::AppleseedEnvMap()
   : m_pblock(nullptr)
   , m_sun_theta(45.0f)
   , m_sun_phi(90.0f)
+  , m_sun_size_multiplier(1.0f)
+  , m_sun_node(nullptr)
   , m_turbidity(1.0f)
   , m_turbidity_map(nullptr)
   , m_turbidity_map_on(true)
@@ -204,7 +229,7 @@ void AppleseedEnvMap::DeleteThis()
 
 void AppleseedEnvMap::GetClassName(TSTR& s)
 {
-    s = _T("appleseedEnvMap");
+    s = _T("appleseedSky");
 }
 
 SClass_ID AppleseedEnvMap::SuperClassID()
@@ -219,7 +244,7 @@ Class_ID AppleseedEnvMap::ClassID()
 
 int AppleseedEnvMap::NumSubs()
 {
-    return 2;   // pblock + subtexture
+    return 1;   // pblock
 }
 
 Animatable* AppleseedEnvMap::SubAnim(int i)
@@ -227,7 +252,6 @@ Animatable* AppleseedEnvMap::SubAnim(int i)
     switch (i)
     {
       case 0: return m_pblock;
-      case 1: return m_turbidity_map;
       default: return nullptr;
     }
 }
@@ -237,7 +261,6 @@ TSTR AppleseedEnvMap::SubAnimName(int i)
     switch (i)
     {
       case 0: return _T("Parameters");
-      case 1: return GetSubTexmapTVName(i - 1);
       default: return nullptr;
     }
 }
@@ -264,7 +287,7 @@ IParamBlock2* AppleseedEnvMap::GetParamBlockByID(BlockID id)
 
 int AppleseedEnvMap::NumRefs()
 {
-    return 2;   // pblock + subtexture
+    return 1;   // pblock
 }
 
 RefTargetHandle AppleseedEnvMap::GetReference(int i)
@@ -272,7 +295,6 @@ RefTargetHandle AppleseedEnvMap::GetReference(int i)
     switch (i)
     {
       case ParamBlockIdEnvMap: return m_pblock;
-      case 1: return m_turbidity_map;
       default: return nullptr;
     }
 }
@@ -282,11 +304,15 @@ void AppleseedEnvMap::SetReference(int i, RefTargetHandle rtarg)
     switch (i)
     {
       case ParamBlockIdEnvMap: m_pblock = (IParamBlock2 *)rtarg; break;
-      case 1: m_turbidity_map = (Texmap *)rtarg; break;
     }
 }
 
-RefResult AppleseedEnvMap::NotifyRefChanged(const Interval& /*changeInt*/, RefTargetHandle hTarget, PartID& /*partID*/, RefMessage message, BOOL /*propagate*/)
+RefResult AppleseedEnvMap::NotifyRefChanged(
+    const Interval& /*changeInt*/,
+    RefTargetHandle hTarget,
+    PartID& partID,
+    RefMessage message,
+    BOOL /*propagate*/)
 {
     switch (message)
     {
@@ -295,21 +321,13 @@ RefResult AppleseedEnvMap::NotifyRefChanged(const Interval& /*changeInt*/, RefTa
         {
             m_pblock = nullptr;
         }
-        else
-        {
-            if (m_turbidity_map == hTarget)
-            {
-                m_turbidity_map = nullptr;
-                break;
-            }
-        }
         break;
-
+      
       case REFMSG_CHANGE:
-        m_params_validity.SetEmpty();
-        m_map_validity.SetEmpty();
         if (hTarget == m_pblock)
+        {
             g_block_desc.InvalidateUI(m_pblock->LastNotifyParamID());
+        }
         break;
     }
 
@@ -320,11 +338,10 @@ RefTargetHandle AppleseedEnvMap::Clone(RemapDir& remap)
 {
     AppleseedEnvMap* mnew = new AppleseedEnvMap();
     *static_cast<MtlBase*>(mnew) = *static_cast<MtlBase*>(this);
+    BaseClone(this, mnew, remap);
 
     mnew->ReplaceReference(0, remap.CloneRef(m_pblock));
-    mnew->ReplaceReference(1, remap.CloneRef(m_turbidity_map));
 
-    BaseClone(this, mnew, remap);
     return (RefTargetHandle)mnew;
 }
 
@@ -335,19 +352,23 @@ int AppleseedEnvMap::NumSubTexmaps()
 
 Texmap* AppleseedEnvMap::GetSubTexmap(int i)
 {
-    return i == 0 ? m_turbidity_map : nullptr;
+    Texmap *sm1 = nullptr;
+    Interval iv;
+    if (i == 0)
+    {
+        m_pblock->GetValue(ParamIdTurbidityMap, 0, sm1, iv);
+    }
+    return sm1;
 }
 
 void AppleseedEnvMap::SetSubTexmap(int i, Texmap* texmap)
 {
     if (i == 0)
     {
-        ReplaceReference(i + 1, texmap);
         const auto texmap_id = static_cast<TexmapId>(i);
         const auto param_id = g_texmap_id_to_param_id[texmap_id];
         m_pblock->SetValue(param_id, 0, texmap);
         g_block_desc.InvalidateUI(param_id);
-        m_map_validity.SetEmpty();
     }
 }
 
@@ -366,42 +387,36 @@ void AppleseedEnvMap::Update(TimeValue t, Interval& valid)
 {
     if (!m_params_validity.InInterval(t))
     {
-        m_params_validity.SetInfinite();
-
-        m_pblock->GetValue(ParamIdSunTheta, t, m_sun_theta, m_params_validity);
-        m_pblock->GetValue(ParamIdSunPhi, t, m_sun_phi, m_params_validity);
-
-        m_pblock->GetValue(ParamIdTurbidity, t, m_turbidity, m_params_validity);
-        m_pblock->GetValue(ParamIdTurbidityMap, t, m_turbidity_map, m_params_validity);
-        m_pblock->GetValue(ParamIdTurbidityMapOn, t, m_turbidity_map_on, m_params_validity);
-
-        m_pblock->GetValue(ParamIdTurbMultiplier, t, m_turb_multiplier, m_params_validity);
-        m_pblock->GetValue(ParamIdLuminMultiplier, t, m_lumin_multiplier, m_params_validity);
-        m_pblock->GetValue(ParamIdLuminGamma, t, m_lumin_gamma, m_params_validity);
-        m_pblock->GetValue(ParamIdSatMultiplier, t, m_sat_multiplier, m_params_validity);
-        m_pblock->GetValue(ParamIdHorizonShift, t, m_horizon_shift, m_params_validity);
-        m_pblock->GetValue(ParamIdGroundAlbedo, t, m_ground_albedo, m_params_validity);
-
         NotifyDependents(FOREVER, PART_ALL, REFMSG_CHANGE);
     }
+    m_params_validity.SetInfinite();
 
-    if (!m_map_validity.InInterval(t))
-    {
-        m_map_validity.SetInfinite();
-        if (m_turbidity_map)
-        {
-            m_turbidity_map->Update(t,m_map_validity);
-        }
-    }
+    m_pblock->GetValue(ParamIdSunTheta, t, m_sun_theta, m_params_validity);
+    m_pblock->GetValue(ParamIdSunPhi, t, m_sun_phi, m_params_validity);
+    m_pblock->GetValue(ParamIdSunSizeMultiplier, t, m_sun_size_multiplier, m_params_validity);
+    m_pblock->GetValue(ParamIdSunNode, t, m_sun_node, m_params_validity);
+    m_pblock->GetValue(ParamIdSunNodeOn, t, m_sun_node_on, m_params_validity);
+    
+    m_pblock->GetValue(ParamIdTurbidity, t, m_turbidity, m_params_validity);
+    m_pblock->GetValue(ParamIdTurbidityMap, t, m_turbidity_map, m_params_validity);
+    m_pblock->GetValue(ParamIdTurbidityMapOn, t, m_turbidity_map_on, m_params_validity);
 
-    valid &= m_map_validity;
-    valid &= m_params_validity;
+    m_pblock->GetValue(ParamIdTurbMultiplier, t, m_turb_multiplier, m_params_validity);
+    m_pblock->GetValue(ParamIdLuminMultiplier, t, m_lumin_multiplier, m_params_validity);
+    m_pblock->GetValue(ParamIdLuminGamma, t, m_lumin_gamma, m_params_validity);
+    m_pblock->GetValue(ParamIdSatMultiplier, t, m_sat_multiplier, m_params_validity);
+    m_pblock->GetValue(ParamIdHorizonShift, t, m_horizon_shift, m_params_validity);
+    m_pblock->GetValue(ParamIdGroundAlbedo, t, m_ground_albedo, m_params_validity);
+
+    if (m_turbidity_map)
+        m_turbidity_map->Update(t, m_params_validity);
+
+    valid = m_params_validity;
 }
 
 void AppleseedEnvMap::Reset()
 {
     m_params_validity.SetEmpty();
-    m_map_validity.SetEmpty();
 }
 
 Interval AppleseedEnvMap::Validity(TimeValue t)
@@ -433,26 +448,8 @@ namespace
             switch (umsg)
             {
               case WM_INITDIALOG:
-                enable_disable_controls(hwnd, map);
+                enable_controls(hwnd, map);
                 return TRUE;
-
-              case WM_COMMAND:
-                switch (LOWORD(wparam))
-                {
-                  case IDC_COMBO_SKY_TYPE:
-                    switch (HIWORD(wparam))
-                    {
-                      case CBN_SELCHANGE:
-                        enable_disable_controls(hwnd, map);
-                        return TRUE;
-
-                      default:
-                        return FALSE;
-                    }
-
-                  default:
-                    return FALSE;
-                }
 
               default:
                 return FALSE;
@@ -460,10 +457,18 @@ namespace
         }
 
       private:
-        void enable_disable_controls(HWND hwnd, IParamMap2* map)
+        void enable_controls(HWND hwnd, IParamMap2* map)
         {
-            const auto selected = SendMessage(GetDlgItem(hwnd, IDC_COMBO_SKY_TYPE), CB_GETCURSEL, 0, 0);
-            map->Enable(ParamIdGroundAlbedo, selected == 0 ? TRUE : FALSE);
+            INode* sun_node;
+            int sun_node_on;
+            IParamBlock2* pblock = map->GetParamBlock();
+            if (pblock)
+            {
+                pblock->GetValue(ParamIdSunNode, 0, sun_node, FOREVER);
+                pblock->GetValue(ParamIdSunNodeOn, 0, sun_node_on, FOREVER);
+            }
+            map->Enable(ParamIdSunTheta, (sun_node_on && sun_node) ? FALSE : TRUE);
+            map->Enable(ParamIdSunPhi, (sun_node_on && sun_node) ? FALSE : TRUE);
         }
     };
 }
@@ -580,6 +585,90 @@ const MCHAR* AppleseedEnvMapBrowserEntryInfo::GetEntryCategory() const
 Bitmap* AppleseedEnvMapBrowserEntryInfo::GetEntryThumbnail() const
 {
     return nullptr;
+}
+
+
+//
+// SunNodePBAccessor class implementation
+//
+void SunNodePBAccessor::TabChanged(
+    tab_changes       changeCode, 
+    Tab<PB2Value>*    tab,
+    ReferenceMaker*   owner, 
+    ParamID           id, 
+    int               tabIndex, 
+    int               count)
+{
+  if (id == ParamIdSunNode)
+  {
+    if (changeCode == tab_ref_deleted)
+    {
+      AppleseedEnvMap* p = (AppleseedEnvMap*)owner;
+      IParamBlock2* pblock = p->GetParamBlock(0);
+      if (pblock)
+      {
+        IParamMap2* map = pblock->GetMap();
+        if (map)
+        {
+          map->Enable(ParamIdSunTheta, TRUE);
+          map->Enable(ParamIdSunPhi, TRUE);
+        }
+      }
+    }
+  }
+}
+
+void SunNodePBAccessor::Set(
+    PB2Value&         v,
+    ReferenceMaker*   owner,
+    ParamID           id,
+    int               tabIndex,
+    TimeValue         t)
+{
+    AppleseedEnvMap* p = (AppleseedEnvMap*)owner;
+    IParamBlock2* pblock = p->GetParamBlock(0);
+    INode* sun_node;
+    if (pblock)
+    {
+        IParamMap2* map = pblock->GetMap();
+        pblock->GetValue(ParamIdSunNode, 0, sun_node, FOREVER);
+        if (map)
+        {
+            switch (id)
+            {
+              case ParamIdSunNodeOn:
+              {
+                  map->Enable(ParamIdSunTheta, (v.i && sun_node) ? FALSE : TRUE);
+                  map->Enable(ParamIdSunPhi, (v.i && sun_node) ? FALSE : TRUE);
+              }
+              break;
+              case ParamIdSunNode:
+              {
+                  if (v.r)
+                  {
+                      pblock->SetValue(ParamIdSunNodeOn, t, TRUE);
+                      map->Enable(ParamIdSunTheta, FALSE);
+                      map->Enable(ParamIdSunPhi, FALSE);
+                  }
+              }
+              break;
+            }
+        }
+    }
+}
+
+
+//
+// SunNodePBValidator class implementation
+//
+
+BOOL SunNodePBValidator::Validate(PB2Value & v)
+{
+  INode *node = (INode*)v.r;
+  Object *obj = node->GetObjectRef();
+
+  return obj->ClassID() == Class_ID(DIR_LIGHT_CLASS_ID, 0) ||
+    obj->ClassID() == Class_ID(TDIR_LIGHT_CLASS_ID, 0) ? true : false;
 }
 
 

--- a/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.cpp
+++ b/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.cpp
@@ -136,9 +136,9 @@ namespace
         p_end,
 
         ParamIdSunNodeOn, _T("sun_node_on"), TYPE_BOOL, 0, IDS_TURB_MAP_ON,
-        p_default, TRUE,
-        p_ui, TYPE_SINGLECHEKBOX, IDC_SUN_NODE_ON,
-        p_accessor, &g_sun_node_accessor,
+            p_default, TRUE,
+            p_ui, TYPE_SINGLECHEKBOX, IDC_SUN_NODE_ON,
+            p_accessor, &g_sun_node_accessor,
         p_end,
 
         ParamIdTurbidity, _T("turbidity"), TYPE_FLOAT, P_ANIMATABLE, IDS_TURBIDITY,
@@ -599,23 +599,23 @@ void SunNodePBAccessor::TabChanged(
     int               tabIndex, 
     int               count)
 {
-  if (id == ParamIdSunNode)
-  {
-    if (changeCode == tab_ref_deleted)
+    if (id == ParamIdSunNode)
     {
-      AppleseedEnvMap* p = (AppleseedEnvMap*)owner;
-      IParamBlock2* pblock = p->GetParamBlock(0);
-      if (pblock)
-      {
-        IParamMap2* map = pblock->GetMap();
-        if (map)
+        if (changeCode == tab_ref_deleted)
         {
-          map->Enable(ParamIdSunTheta, TRUE);
-          map->Enable(ParamIdSunPhi, TRUE);
+            AppleseedEnvMap* p = (AppleseedEnvMap*)owner;
+            IParamBlock2* pblock = p->GetParamBlock(0);
+            if (pblock)
+            {
+                IParamMap2* map = pblock->GetMap();
+                if (map)
+                {
+                    map->Enable(ParamIdSunTheta, TRUE);
+                    map->Enable(ParamIdSunPhi, TRUE);
+                }
+            }
         }
-      }
     }
-  }
 }
 
 void SunNodePBAccessor::Set(
@@ -664,11 +664,11 @@ void SunNodePBAccessor::Set(
 
 BOOL SunNodePBValidator::Validate(PB2Value & v)
 {
-  INode *node = (INode*)v.r;
-  Object *obj = node->GetObjectRef();
+    INode *node = (INode*)v.r;
+    Object *obj = node->GetObjectRef();
 
-  return obj->ClassID() == Class_ID(DIR_LIGHT_CLASS_ID, 0) ||
-    obj->ClassID() == Class_ID(TDIR_LIGHT_CLASS_ID, 0) ? true : false;
+    return obj->ClassID() == Class_ID(DIR_LIGHT_CLASS_ID, 0) ||
+      obj->ClassID() == Class_ID(TDIR_LIGHT_CLASS_ID, 0) ? true : false;
 }
 
 

--- a/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.cpp
+++ b/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.cpp
@@ -135,7 +135,7 @@ namespace
             p_accessor, &g_sun_node_accessor,
         p_end,
 
-        ParamIdSunNodeOn, _T("sun_node_on"), TYPE_BOOL, 0, IDS_TURB_MAP_ON,
+        ParamIdSunNodeOn, _T("sun_node_on"), TYPE_BOOL, 0, IDS_SUN_NODE_ON,
             p_default, TRUE,
             p_ui, TYPE_SINGLECHEKBOX, IDC_SUN_NODE_ON,
             p_accessor, &g_sun_node_accessor,
@@ -308,26 +308,22 @@ void AppleseedEnvMap::SetReference(int i, RefTargetHandle rtarg)
 }
 
 RefResult AppleseedEnvMap::NotifyRefChanged(
-    const Interval& /*changeInt*/,
-    RefTargetHandle hTarget,
-    PartID& partID,
-    RefMessage message,
-    BOOL /*propagate*/)
+    const Interval&   /*changeInt*/,
+    RefTargetHandle   hTarget,
+    PartID&           partID,
+    RefMessage        message,
+    BOOL              /*propagate*/)
 {
     switch (message)
     {
       case REFMSG_TARGET_DELETED:
         if (hTarget == m_pblock)
-        {
             m_pblock = nullptr;
-        }
         break;
-      
+
       case REFMSG_CHANGE:
         if (hTarget == m_pblock)
-        {
             g_block_desc.InvalidateUI(m_pblock->LastNotifyParamID());
-        }
         break;
     }
 
@@ -352,13 +348,13 @@ int AppleseedEnvMap::NumSubTexmaps()
 
 Texmap* AppleseedEnvMap::GetSubTexmap(int i)
 {
-    Texmap *sm1 = nullptr;
+    Texmap* texmap = nullptr;
     Interval iv;
     if (i == 0)
     {
-        m_pblock->GetValue(ParamIdTurbidityMap, 0, sm1, iv);
+        m_pblock->GetValue(ParamIdTurbidityMap, 0, texmap, iv);
     }
-    return sm1;
+    return texmap;
 }
 
 void AppleseedEnvMap::SetSubTexmap(int i, Texmap* texmap)
@@ -448,7 +444,7 @@ namespace
             switch (umsg)
             {
               case WM_INITDIALOG:
-                enable_controls(hwnd, map);
+                enable_disable_controls(hwnd, map);
                 return TRUE;
 
               default:
@@ -457,7 +453,7 @@ namespace
         }
 
       private:
-        void enable_controls(HWND hwnd, IParamMap2* map)
+        void enable_disable_controls(HWND hwnd, IParamMap2* map)
         {
             INode* sun_node;
             int sun_node_on;
@@ -591,6 +587,7 @@ Bitmap* AppleseedEnvMapBrowserEntryInfo::GetEntryThumbnail() const
 //
 // SunNodePBAccessor class implementation
 //
+
 void SunNodePBAccessor::TabChanged(
     tab_changes       changeCode, 
     Tab<PB2Value>*    tab,
@@ -625,8 +622,8 @@ void SunNodePBAccessor::Set(
     int               tabIndex,
     TimeValue         t)
 {
-    AppleseedEnvMap* p = (AppleseedEnvMap*)owner;
-    IParamBlock2* pblock = p->GetParamBlock(0);
+    AppleseedEnvMap* envmap = (AppleseedEnvMap*)owner;
+    IParamBlock2* pblock = envmap->GetParamBlock(0);
     INode* sun_node;
     if (pblock)
     {
@@ -664,11 +661,11 @@ void SunNodePBAccessor::Set(
 
 BOOL SunNodePBValidator::Validate(PB2Value & v)
 {
-    INode *node = (INode*)v.r;
-    Object *obj = node->GetObjectRef();
+    INode* node = (INode*)v.r;
+    Object* obj = node->GetObjectRef();
 
     return obj->ClassID() == Class_ID(DIR_LIGHT_CLASS_ID, 0) ||
-      obj->ClassID() == Class_ID(TDIR_LIGHT_CLASS_ID, 0) ? true : false;
+      obj->ClassID() == Class_ID(TDIR_LIGHT_CLASS_ID, 0) ? TRUE : FALSE;
 }
 
 

--- a/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.h
+++ b/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.h
@@ -144,7 +144,7 @@ class SunNodePBAccessor
 //
 
 class SunNodePBValidator 
-    : public PBValidator 
+  : public PBValidator 
 {
   public:
     virtual BOOL Validate(PB2Value& v);

--- a/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.h
+++ b/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.h
@@ -107,10 +107,12 @@ class AppleseedEnvMap
 
   private:
     IParamBlock2*   m_pblock;          // ref 0
-    Interval        m_params_validity;
-    Interval        m_map_validity;
     float           m_sun_theta;
     float           m_sun_phi;
+    float           m_sun_size_multiplier;
+    INode*          m_sun_node;
+    BOOL            m_sun_node_on;
+    Interval        m_params_validity;
     float           m_turbidity;
     Texmap*         m_turbidity_map;
     BOOL            m_turbidity_map_on;
@@ -120,6 +122,32 @@ class AppleseedEnvMap
     float           m_sat_multiplier;
     float           m_horizon_shift;
     float           m_ground_albedo;
+};
+
+
+//
+// Sun node parameter accessor class declaration
+//
+
+class SunNodePBAccessor
+    : public PBAccessor
+{
+  public:
+    void TabChanged(tab_changes changeCode, Tab<PB2Value>* tab,
+      ReferenceMaker* owner, ParamID id, int tabIndex, int count) override;
+    void Set(PB2Value& v, ReferenceMaker* owner, ParamID id, int tabIndex, TimeValue t) override;
+};
+
+
+//
+// Sun node parameter validator class declaration
+//
+
+class SunNodePBValidator 
+    : public PBValidator 
+{
+  public:
+    virtual BOOL Validate(PB2Value& v);
 };
 
 

--- a/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.rc
+++ b/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.rc
@@ -25,43 +25,47 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 // Dialog
 //
 
-IDD_ENVMAP_PANEL DIALOGEX 0, 0, 217, 166
+IDD_ENVMAP_PANEL DIALOGEX 0, 0, 217, 175
 STYLE DS_SETFONT | WS_CHILD | WS_VISIBLE
 FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
     CONTROL         "",IDC_EDIT_THETA,"CustEdit",WS_TABSTOP,85,12,35,10
     CONTROL         "",IDC_SPIN_THETA,"SpinnerControl",0x0,121,12,7,10
     LTEXT           "Theta Angle:",IDC_STATIC,13,14,41,8
-    GROUPBOX        "Sun",IDC_STATIC,7,3,203,41
+    GROUPBOX        "Sun",IDC_STATIC,7,3,203,49
     CONTROL         "",IDC_EDIT_PHI,"CustEdit",WS_TABSTOP,85,24,35,10
     CONTROL         "",IDC_SPIN_PHI,"SpinnerControl",0x0,121,24,7,10
     LTEXT           "Phi Angle:",IDC_STATIC,13,26,32,8
-    GROUPBOX        "Sky",IDC_STATIC,7,45,203,76
-    CONTROL         "",IDC_EDIT_TURBIDITY,"CustEdit",WS_TABSTOP,85,54,35,10
-    CONTROL         "",IDC_SPIN_TURBIDITY,"SpinnerControl",0x0,121,54,7,10
-    LTEXT           "Turbidity:",IDC_STATIC,13,56,30,8
-    CONTROL         "",IDC_EDIT_TURB_MULTIPLIER,"CustEdit",WS_TABSTOP,85,67,35,10
-    CONTROL         "",IDC_SPIN_TURB_MULTIPLIER,"SpinnerControl",0x0,121,67,7,10
-    LTEXT           "Turbidity Multiplier:",IDC_STATIC,13,68,57,8,SS_CENTERIMAGE
-    CONTROL         "",IDC_EDIT_LUMIN_MULTIPLIER,"CustEdit",WS_TABSTOP,85,80,35,10
-    CONTROL         "",IDC_SPIN_LUMIN_MULTIPLIER,"SpinnerControl",0x0,121,80,7,10
-    LTEXT           "Luminance Multiplier:",IDC_STATIC,13,81,67,8
-    CONTROL         "",IDC_EDIT_LUMIN_GAMMA,"CustEdit",WS_TABSTOP,85,93,35,10
-    CONTROL         "",IDC_SPIN_LUMIN_GAMMA,"SpinnerControl",0x0,121,93,7,10
-    LTEXT           "Luminance Gamma:",IDC_STATIC,13,94,64,8
-    CONTROL         "",IDC_EDIT_SATUR_MULTIPLIER,"CustEdit",WS_TABSTOP,85,106,35,10
-    CONTROL         "",IDC_SPIN_SATUR_MULTIPLIER,"SpinnerControl",0x0,121,106,7,10
-    LTEXT           "Saturation Multiplier:",IDC_STATIC,13,106,64,8
-    CONTROL         "None",IDC_PICK_TURB_TEXTURE,"CustButton",WS_TABSTOP,136,53,56,14
-    GROUPBOX        "Ground",IDC_STATIC,7,122,203,36
-    CONTROL         "",IDC_EDIT_HORIZON_SHIFT,"CustEdit",WS_TABSTOP,85,131,35,10
-    CONTROL         "",IDC_SPIN_HORIZON_SHIFT,"SpinnerControl",0x0,121,131,7,10
-    LTEXT           "Horizon Shift:",IDC_STATIC,13,133,43,8
-    CONTROL         "",IDC_EDIT_GROUND_ALBEDO,"CustEdit",WS_TABSTOP,85,144,35,10
-    CONTROL         "",IDC_SPIN_GROUND_ALBEDO,"SpinnerControl",0x0,121,144,7,10
-    LTEXT           "Ground Albedo:",IDC_STATIC,13,144,50,8
-    CONTROL         "Pick Sun Light",IDC_PICK_SUN,"CustButton",NOT WS_VISIBLE | WS_TABSTOP,136,12,68,14
-    CONTROL         "",IDC_TURB_TEX_ON,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,196,56,8,10
+    GROUPBOX        "Sky",IDC_STATIC,7,55,203,76
+    CONTROL         "",IDC_EDIT_TURBIDITY,"CustEdit",WS_TABSTOP,85,64,35,10
+    CONTROL         "",IDC_SPIN_TURBIDITY,"SpinnerControl",0x0,121,64,7,10
+    LTEXT           "Turbidity:",IDC_STATIC,13,66,30,8
+    CONTROL         "",IDC_EDIT_TURB_MULTIPLIER,"CustEdit",WS_TABSTOP,85,77,35,10
+    CONTROL         "",IDC_SPIN_TURB_MULTIPLIER,"SpinnerControl",0x0,121,77,7,10
+    LTEXT           "Turbidity Multiplier:",IDC_STATIC,13,78,57,8,SS_CENTERIMAGE
+    CONTROL         "",IDC_EDIT_LUMIN_MULTIPLIER,"CustEdit",WS_TABSTOP,85,90,35,10
+    CONTROL         "",IDC_SPIN_LUMIN_MULTIPLIER,"SpinnerControl",0x0,121,90,7,10
+    LTEXT           "Luminance Multiplier:",IDC_STATIC,13,91,67,8
+    CONTROL         "",IDC_EDIT_LUMIN_GAMMA,"CustEdit",WS_TABSTOP,85,103,35,10
+    CONTROL         "",IDC_SPIN_LUMIN_GAMMA,"SpinnerControl",0x0,121,103,7,10
+    LTEXT           "Luminance Gamma:",IDC_STATIC,13,104,64,8
+    CONTROL         "",IDC_EDIT_SATUR_MULTIPLIER,"CustEdit",WS_TABSTOP,85,116,35,10
+    CONTROL         "",IDC_SPIN_SATUR_MULTIPLIER,"SpinnerControl",0x0,121,116,7,10
+    LTEXT           "Saturation Multiplier:",IDC_STATIC,13,116,64,8
+    CONTROL         "None",IDC_PICK_TURB_TEXTURE,"CustButton",WS_TABSTOP,136,63,56,14
+    GROUPBOX        "Ground",IDC_STATIC,7,132,203,36
+    CONTROL         "",IDC_EDIT_HORIZON_SHIFT,"CustEdit",WS_TABSTOP,85,142,35,10
+    CONTROL         "",IDC_SPIN_HORIZON_SHIFT,"SpinnerControl",0x0,121,142,7,10
+    LTEXT           "Horizon Shift:",IDC_STATIC,13,143,43,8
+    CONTROL         "",IDC_EDIT_GROUND_ALBEDO,"CustEdit",WS_TABSTOP,85,154,35,10
+    CONTROL         "",IDC_SPIN_GROUND_ALBEDO,"SpinnerControl",0x0,121,154,7,10
+    LTEXT           "Ground Albedo:",IDC_STATIC,13,154,50,8
+    CONTROL         "Pick Sun Light",IDC_PICK_SUN_NODE,"CustButton",WS_TABSTOP,136,12,56,14
+    CONTROL         "",IDC_TURB_TEX_ON,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,196,66,8,10
+    CONTROL         "",IDC_SUN_NODE_ON,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,196,15,8,10
+    CONTROL         "",IDC_EDIT_SIZE_MULTIPLIER,"CustEdit",WS_TABSTOP,85,36,35,10
+    CONTROL         "",IDC_SPIN_SIZE_MULTIPLIER,"SpinnerControl",0x0,121,36,7,10
+    LTEXT           "Size Multiplier:",IDC_STATIC,13,38,58,8
 END
 
 
@@ -80,8 +84,10 @@ BEGIN
         VERTGUIDE, 13
         VERTGUIDE, 85
         VERTGUIDE, 128
+        VERTGUIDE, 136
+        VERTGUIDE, 192
         TOPMARGIN, 7
-        BOTTOMMARGIN, 159
+        BOTTOMMARGIN, 168
         HORZGUIDE, 12
     END
 END
@@ -117,16 +123,29 @@ END
 
 /////////////////////////////////////////////////////////////////////////////
 //
+// AFX_DIALOG_LAYOUT
+//
+
+IDD_ENVMAP_PANEL AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
 // String Table
 //
 
 STRINGTABLE
 BEGIN
-    IDS_LIBDESCRIPTION      "appleseed Environment Map"
-    IDS_CLASS_NAME          "appleseed Env Map"
-    IDS_ENVMAP_PARAMS       "appleseed Environment Map Parameters"
-    IDS_CLASS_NAME_CDESC    "appleseed Environment Map"
+    IDS_LIBDESCRIPTION      "appleseed Sky"
+    IDS_SUN_NODE            "Sun Node"
+    IDS_CLASS_NAME          "appleseed Sky"
+    IDS_ENVMAP_PARAMS       "appleseed Sky Parameters"
+    IDS_CLASS_NAME_CDESC    "appleseed Sky"
     IDS_THETA               "Sun Theta Angle"
+    IDS_PICK_SUN_PROMPT     "Pick Directional Light"
     IDS_PHI                 "Sun Phi Angle"
     IDS_TURBIDITY           "Turbidity"
     IDS_TURB_MULTIPLIER     "Turbidity Multiplier"
@@ -142,6 +161,8 @@ BEGIN
     IDS_SAT_MULITPLIER      "Saturation Multiplier"
     IDS_HORIZON_SHIFT       "Horizon Shift"
     IDS_GROUND_ALBEDO       "Ground Albedo"
+    IDS_SUN_NODE_ON         "Sun Node On"
+    IDS_SIZE_MULTIPLIER     "Sun Size Multiplier"
 END
 
 #endif    // English (United States) resources

--- a/src/appleseed-max-impl/appleseedenvmap/resource.h
+++ b/src/appleseed-max-impl/appleseedenvmap/resource.h
@@ -22,12 +22,9 @@
 #define IDS_HORIZON_SHIFT               8017
 #define IDS_GROUND_ALBEDO               8018
 #define IDS_SUN_NODE_ON                 8019
-#define IDC_CLOSEBUTTON                 8020
-#define IDC_DOSTUFF                     8020
 #define IDS_SIZE_MULTIPLIER             8020
 #define IDC_PICK_SUN                    8022
 #define IDC_PICK_SUN_NODE               8022
-#define IDC_BUTTON3                     8023
 #define IDC_PICK_TURB_TEXTURE           8024
 #define IDC_COMBO_SKY_TYPE              8025
 #define IDC_TURB_TEX_ON                 8026

--- a/src/appleseed-max-impl/appleseedenvmap/resource.h
+++ b/src/appleseed-max-impl/appleseedenvmap/resource.h
@@ -2,15 +2,37 @@
 // Microsoft Visual C++ generated include file.
 // Used by appleseedenvmap.rc
 //
+#define IDS_LIBDESCRIPTION              8001
+#define IDS_SUN_NODE                    8002
+#define IDS_CLASS_NAME                  8003
+#define IDS_ENVMAP_PARAMS               8004
+#define IDS_CLASS_NAME_CDESC            8005
+#define IDS_THETA                       8006
 #define IDS_COORDS                      8007
-#define IDD_ENVMAP_PANEL                8101
+#define IDS_PICK_SUN_PROMPT             8007
+#define IDS_PHI                         8008
+#define IDS_TURBIDITY                   8009
+#define IDS_TURB_MULTIPLIER             8010
+#define IDS_TURB_MAP                    8011
+#define IDS_CATEGORY                    8012
+#define IDS_TURB_MAP_ON                 8013
+#define IDS_LUMINANCE_MULTIPLIER        8014
+#define IDS_LUMINANCE_GAMMA             8015
+#define IDS_SAT_MULITPLIER              8016
+#define IDS_HORIZON_SHIFT               8017
+#define IDS_GROUND_ALBEDO               8018
+#define IDS_SUN_NODE_ON                 8019
 #define IDC_CLOSEBUTTON                 8020
 #define IDC_DOSTUFF                     8020
+#define IDS_SIZE_MULTIPLIER             8020
 #define IDC_PICK_SUN                    8022
+#define IDC_PICK_SUN_NODE               8022
 #define IDC_BUTTON3                     8023
 #define IDC_PICK_TURB_TEXTURE           8024
 #define IDC_COMBO_SKY_TYPE              8025
 #define IDC_TURB_TEX_ON                 8026
+#define IDC_SUN_NODE_ON                 8027
+#define IDD_ENVMAP_PANEL                8101
 #define IDC_COLOR                       8456
 #define IDC_EDIT_THETA                  8490
 #define IDC_EDIT_PHI                    8491
@@ -30,28 +52,14 @@
 #define IDC_SPIN_HORIZON_SHIFT          8505
 #define IDC_EDIT_GROUND_ALBEDO          8506
 #define IDC_SPIN_GROUND_ALBEDO          8507
-#define IDS_LIBDESCRIPTION              8001
-#define IDS_CLASS_NAME                  8003
-#define IDS_ENVMAP_PARAMS               8004
-#define IDS_CLASS_NAME_CDESC            8005
-#define IDS_THETA                       8006
-#define IDS_PHI                         8008
-#define IDS_TURBIDITY                   8009
-#define IDS_TURB_MULTIPLIER             8010
-#define IDS_TURB_MAP                    8011
-#define IDS_CATEGORY                    8012
-#define IDS_TURB_MAP_ON                 8013
-#define IDS_LUMINANCE_MULTIPLIER        8014
-#define IDS_LUMINANCE_GAMMA             8015
-#define IDS_SAT_MULITPLIER              8016
-#define IDS_HORIZON_SHIFT               8017
-#define IDS_GROUND_ALBEDO               8018
+#define IDC_EDIT_SIZE_MULTIPLIER        8508
+#define IDC_SPIN_SIZE_MULTIPLIER        8509
 
 // Next default values for new objects
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        102
+#define _APS_NEXT_RESOURCE_VALUE        103
 #define _APS_NEXT_COMMAND_VALUE         40001
 #define _APS_NEXT_CONTROL_VALUE         1006
 #define _APS_NEXT_SYMED_VALUE           101

--- a/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
@@ -1054,14 +1054,15 @@ namespace
                         sun_theta = std::acosf(sun_dir.z);
 
                         float cos_phi = sun_dir.x / sqrtf(1.0f - std::powf(sun_dir.z, 2));
+                        
                         if (cos_phi > 1.0f)
-                          cos_phi = 1.0f;
+                            cos_phi = 1.0f;
+
                         sun_phi = std::acosf(cos_phi);
 
                         if (sun_dir.y > 0)
-                        {
                             sun_phi = asf::TwoPi<float>() - sun_phi;
-                        }
+                        
                         sun_theta = asf::rad_to_deg(sun_theta);
                         sun_phi = asf::rad_to_deg(sun_phi);
                     }


### PR DESCRIPTION
Hi,
This PR adds support of picking directional light as a sun light for the appleseed sky map.

Changes are:
 * Pick button and on/off checkbox added to sky map
 * Size multiplier spinner added
 * directional light's transforms are converted to appleseed's theta/phi angles
 * Default lights are not added when sky map is present

Minor changes:
 * Environment map is renamed to appleseed sky
 * map plugin simplified by removing redundant references

Regards,
Sergo.