### PR TITLE
maxsource, sourceentity collection support, different texture support

### DIFF
--- a/src/appleseed-max-impl/appleseed-max2016-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2016-impl.vcxproj
@@ -239,6 +239,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir
     <ClCompile Include="appleseedlightmtl\appleseedlightmtl.cpp" />
     <ClCompile Include="logtarget.cpp" />
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="maxtextures\maxproctexturesource.cpp" />
     <ClCompile Include="oslutils.cpp" />
     <ClCompile Include="plugin.cpp" />
     <ClCompile Include="appleseedrenderer\appleseedrenderer.cpp" />
@@ -291,6 +292,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir
     <ClInclude Include="appleseedsssmtl\appleseedsssmtl.h" />
     <ClInclude Include="appleseedsssmtl\datachunks.h" />
     <ClInclude Include="appleseedsssmtl\resource.h" />
+    <ClInclude Include="maxtextures\maxproctexturesource.h" />
     <ClInclude Include="oslutils.h" />
     <ClInclude Include="seexprutils.h" />
     <ClInclude Include="utilities.h" />

--- a/src/appleseed-max-impl/appleseed-max2016-impl.vcxproj.filters
+++ b/src/appleseed-max-impl/appleseed-max2016-impl.vcxproj.filters
@@ -63,6 +63,9 @@
     <ClCompile Include="appleseedinteractive\interactiverenderercontroller.cpp">
       <Filter>appleseedinteractive</Filter>
     </ClCompile>
+    <ClCompile Include="maxtextures\maxproctexturesource.cpp">
+      <Filter>maxtextures</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="appleseedrenderer\appleseedrenderer.h">
@@ -171,6 +174,9 @@
     <ClInclude Include="appleseedinteractive\interactivesession.h">
       <Filter>appleseedinteractive</Filter>
     </ClInclude>
+    <ClInclude Include="maxtextures\maxproctexturesource.h">
+      <Filter>maxtextures</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="appleseedrenderer\appleseedrenderer.rc">
@@ -225,6 +231,9 @@
     </Filter>
     <Filter Include="appleseedinteractive">
       <UniqueIdentifier>{ee864abd-823b-4815-bd20-52108be5b332}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="maxtextures">
+      <UniqueIdentifier>{f2aec660-74d1-4dca-9124-cba507457446}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.cpp
+++ b/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.cpp
@@ -513,6 +513,7 @@ asf::auto_release_ptr<asr::Material> AppleseedLightMtl::create_material(
             const std::string texture_name = wide_to_utf8(m_light_color_texmap->GetName());
             if (assembly.source_entities().get_by_name(texture_name.c_str()) == nullptr)
             {
+                m_light_color_texmap->Update(GetCOREInterface()->GetTime(), FOREVER); //this should be called once per frame per map
                 assembly.source_entities().insert(
                     asf::auto_release_ptr<asr::SourceEntity>(
                         new asr::SourceEntity(

--- a/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.cpp
+++ b/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.cpp
@@ -43,7 +43,7 @@
 #include "renderer/api/material.h"
 #include "renderer/api/scene.h"
 #include "renderer/api/utility.h"
-#include "renderer/modeling/texture/sourceentity.h"
+#include "renderer/modeling/input/sourceentity.h"
 
 // appleseed.foundation headers.
 #include "foundation/image/colorspace.h"

--- a/src/appleseed-max-impl/maxtextures/maxproctexturesource.cpp
+++ b/src/appleseed-max-impl/maxtextures/maxproctexturesource.cpp
@@ -1,0 +1,100 @@
+
+// Interface
+#include "maxproctexturesource.h"
+
+// appleseed.foundation headers.
+#include "foundation/utility/siphash.h"
+
+// 3ds max include
+#include "imtl.h"
+#include "maxapi.h"
+
+MaxProceduralSource::MaxProceduralSource(
+    Texmap* max_texmap)
+    : m_texmap(max_texmap)
+{
+}
+
+MaxProceduralSource::~MaxProceduralSource()
+{
+}
+
+foundation::uint64 MaxProceduralSource::compute_signature() const
+{
+    return foundation::siphash24(m_texmap, sizeof(*m_texmap));
+}
+
+//--- Shade Context
+class MaxProceduralSource::MaxSC
+  :public ShadeContext 
+{
+  public:
+    TimeValue curtime;
+    Point3 ltPos; // position of point in light space
+    Point3 view;  // unit vector from light to point, in light space
+    Point3 dp;
+    Point2 uv, duv;
+    IPoint2 scrpos;
+    float curve;
+    int projType;
+
+    BOOL InMtlEditor() { return false; }
+    LightDesc* Light(int n) { return NULL; }
+    TimeValue CurTime() { return GetCOREInterface()->GetTime(); }
+    int NodeID() { return -1; }
+    int FaceNumber() { return 0; }
+    int ProjType() { return projType; }
+    Point3 Normal() { return Point3(0, 0, 0); }
+    Point3 GNormal() { return Point3(0, 0, 0); }
+    Point3 ReflectVector() { return Point3(0, 0, 0); }
+    Point3 RefractVector(float ior) { return Point3(0, 0, 0); }
+    Point3 CamPos() { return Point3(0, 0, 0); }
+    Point3 V() { return view; }
+    void SetView(Point3 v) { view = v; }
+    Point3 P() { return ltPos; }
+    Point3 DP() { return dp; }
+    Point3 PObj() { return ltPos; }
+    Point3 DPObj() { return Point3(0, 0, 0); }
+    Box3 ObjectBox() { return Box3(Point3(-1, -1, -1), Point3(1, 1, 1)); }
+    Point3 PObjRelBox() { return view; }
+    Point3 DPObjRelBox() { return Point3(0, 0, 0); }
+    void ScreenUV(Point2& UV, Point2 &Duv) { UV = uv; Duv = duv; }
+    IPoint2 ScreenCoord() { return scrpos; }
+    Point3 UVW(int chan) { return Point3(uv.x, uv.y, 0.0f); }
+    Point3 DUVW(int chan) { return Point3(duv.x, duv.y, 0.0f); }
+    void DPdUVW(Point3 dP[3], int chan) {}  // dont need bump vectors
+    void GetBGColor(Color &bgcol, Color& transp, BOOL fogBG = TRUE) {}   // returns Background color, bg transparency
+    float Curve() { return curve; }
+
+    // Transform to and from internal space
+    Point3 PointTo(const Point3& p, RefFrame ito) { return p; }
+    Point3 PointFrom(const Point3& p, RefFrame ifrom) { return p; }
+    Point3 VectorTo(const Point3& p, RefFrame ito) { return p; }
+    Point3 VectorFrom(const Point3& p, RefFrame ifrom) { return p; }
+    MaxSC() { doMaps = TRUE; curve = 0.0f; dp = Point3(0.0f, 0.0f, 0.0f); }
+};
+
+foundation::Color4f MaxProceduralSource::sample_max_texture(
+    const foundation::Vector2f& uv) const
+{
+    MaxProceduralSource::MaxSC maxsc;
+
+    maxsc.mode = SCMODE_NORMAL;
+    maxsc.projType = 0; // 0: perspective, 1: parallel
+    maxsc.curtime = GetCOREInterface()->GetTime();
+    //maxsc.curve = curve;
+    //maxsc.ltPos = plt;
+    //maxsc.view = FNormalize(Point3(plt.x, plt.y, 0.0f));
+    maxsc.uv.x = uv.x;
+    maxsc.uv.y = uv.y;
+    //maxsc.scrpos.x = (int)(x + 0.5);
+    //maxsc.scrpos.y = (int)(y + 0.5);
+    maxsc.filterMaps = false;
+    maxsc.mtlNum = 1;
+    //maxsc.globContext = sc.globContext;
+
+    m_texmap->Update(GetCOREInterface()->GetTime(), FOREVER); //this should be called once per frame per map
+    AColor color = m_texmap->EvalColor(maxsc);
+
+    return foundation::Color4f(color.r, color.g, color.b, color.a);
+}

--- a/src/appleseed-max-impl/maxtextures/maxproctexturesource.h
+++ b/src/appleseed-max-impl/maxtextures/maxproctexturesource.h
@@ -1,0 +1,30 @@
+
+// appleseed.renderer headers.
+#include "renderer/modeling/input/maxsource.h"
+
+// Forward declarations.
+class Texmap;
+
+class MaxProceduralSource
+    : public renderer::MaxSource
+{
+public:
+    // Constructor.
+    MaxProceduralSource(
+        Texmap* max_texmap);
+
+    // Destructor.
+    virtual ~MaxProceduralSource();
+
+    virtual foundation::uint64 compute_signature() const;
+
+    virtual foundation::Color4f sample_max_texture(
+        const foundation::Vector2f& uv) const override;
+
+private:
+    // Max texture
+    Texmap* m_texmap;
+
+    // ShaderContext
+    class MaxSC;
+};

--- a/src/appleseed-max-impl/maxtextures/maxproctexturesource.h
+++ b/src/appleseed-max-impl/maxtextures/maxproctexturesource.h
@@ -1,12 +1,13 @@
 
 // appleseed.renderer headers.
-#include "renderer/modeling/input/maxsource.h"
+#include "renderer/global/globaltypes.h"
+#include "renderer/modeling/input/source.h"
 
 // Forward declarations.
 class Texmap;
 
 class MaxProceduralSource
-    : public renderer::MaxSource
+    : public renderer::Source
 {
 public:
     // Constructor.
@@ -18,10 +19,43 @@ public:
 
     virtual foundation::uint64 compute_signature() const;
 
+    // Evaluate the source at a given shading point.
+    virtual void evaluate(
+        renderer::TextureCache&             texture_cache,
+        const foundation::Vector2f&         uv,
+        float&                              scalar) const override;
+    virtual void evaluate(
+        renderer::TextureCache&             texture_cache,
+        const foundation::Vector2f&         uv,
+        foundation::Color3f&                linear_rgb) const override;
+    virtual void evaluate(
+        renderer::TextureCache&             texture_cache,
+        const foundation::Vector2f&         uv,
+        renderer::Spectrum&                 spectrum) const override;
+    virtual void evaluate(
+        renderer::TextureCache&             texture_cache,
+        const foundation::Vector2f&         uv,
+        renderer::Alpha&                    alpha) const override;
+    virtual void evaluate(
+        renderer::TextureCache&             texture_cache,
+        const foundation::Vector2f&         uv,
+        foundation::Color3f&                linear_rgb,
+        renderer::Alpha&                    alpha) const override;
+    virtual void evaluate(
+        renderer::TextureCache&             texture_cache,
+        const foundation::Vector2f&         uv,
+        renderer::Spectrum&                 spectrum,
+        renderer::Alpha&                    alpha) const override;
+
     virtual foundation::Color4f sample_max_texture(
-        const foundation::Vector2f& uv) const override;
+        const foundation::Vector2f& uv) const;
 
 private:
+    // Compute an alpha value given a linear RGBA color and the alpha mode of the texture instance.
+    void evaluate_alpha(
+        const foundation::Color4f&          color,
+        renderer::Alpha&                              alpha) const;
+
     // Max texture
     Texmap* m_texmap;
 

--- a/src/appleseed-max-impl/utilities.cpp
+++ b/src/appleseed-max-impl/utilities.cpp
@@ -125,6 +125,9 @@ bool is_supported_texture(Texmap* map)
 
     switch (map->ClassID().PartA())
     {
+      case 0x64035FB9:              // Tiles
+        if (map->ClassID().PartB() != 0x69664CDC)
+            return false;
       case CHECKER_CLASS_ID:
       case MARBLE_CLASS_ID:
       case MASK_CLASS_ID:

--- a/src/appleseed-max-impl/utilities.cpp
+++ b/src/appleseed-max-impl/utilities.cpp
@@ -118,6 +118,47 @@ bool is_bitmap_texture(Texmap* map)
     return true;
 }
 
+bool is_supported_texture(Texmap* map)
+{
+    if (map == nullptr)
+        return false;
+
+    switch (map->ClassID().PartA())
+    {
+      case CHECKER_CLASS_ID:
+      case MARBLE_CLASS_ID:
+      case MASK_CLASS_ID:
+      case MIX_CLASS_ID:
+      case NOISE_CLASS_ID:
+      case GRADIENT_CLASS_ID:
+      case TINT_CLASS_ID:
+      case BMTEX_CLASS_ID:
+      //case ACUBIC_CLASS_ID:       // Reflect/refract.
+      //case MIRROR_CLASS_ID:       // Flat mirror.
+      case COMPOSITE_CLASS_ID:
+      case RGBMULT_CLASS_ID:
+      //case FALLOFF_CLASS_ID:      // Falloff texture.
+      case OUTPUT_CLASS_ID:
+      //case PLATET_CLASS_ID:       // Plate glass texture
+      case COLORCORRECTION_CLASS_ID:
+      case 0x0000214:               // WOOD_CLASS_ID
+      case 0x0000218:               // DENT_CLASS_ID
+      case 0x46396cf1:              // PLANET_CLASS_ID
+      case 0x7712634e:              // WATER_CLASS_ID
+      case 0xa845e7c:               // SMOKE_CLASS_ID
+      case 0x62c32b8a:              // SPECKLE_CLASS_ID
+      case 0x90b04f9:               // SPLAT_CLASS_ID
+      case 0x9312fbe:               // STUCCO_CLASS_ID
+          return true;
+          break;
+      default:
+          return false;
+          break;
+    }
+    
+    return true;
+}
+
 std::string get_root_path()
 {
     wchar_t path[MAX_PATH];

--- a/src/appleseed-max-impl/utilities.h
+++ b/src/appleseed-max-impl/utilities.h
@@ -51,12 +51,12 @@
 // Standard headers.
 #include <cstddef>
 #include <string>
+#include <vector>
 
 // Forward declarations.
 namespace renderer  { class BaseGroup; }
 class Interval;
 class Texmap;
-
 
 //
 // Math functions.
@@ -100,7 +100,7 @@ std::wstring utf8_to_wide(const char* str);
 
 // Return true if a given map is a valid bitmap texture.
 bool is_bitmap_texture(Texmap* map);
-
+bool is_supported_texture(Texmap* map);
 
 //
 // I/O and paths functions.
@@ -158,7 +158,6 @@ std::string insert_texture_and_instance(
     Texmap*                 texmap,
     renderer::ParamArray    texture_params = renderer::ParamArray(),
     renderer::ParamArray    texture_instance_params = renderer::ParamArray());
-
 
 //
 // Implementation.


### PR DESCRIPTION
This PR accompanies appleseed PR #1621.

Code is not intended for merge, just review of crude concept. Right now only appleseed lightmaterial supported and following textures render properly: Checker, Dent, Gradient, Marble, Noise, Wood, Splat, Speckle, Smoke. Some texture only work if they are placed as sub-texture into working texture - Tile texture for example works if placed into Checker's color. Unfortunately color adjusting/mixing/masking textures don't work right now.

Screenshot:
![image](https://user-images.githubusercontent.com/1850877/30257746-37c4d8ce-9682-11e7-83e9-474d02f7df60.png)
