### PR TITLE
Support vraycolor and vrayhdri, linear_rgb for hdr-s, some support of procedural environment maps

### DIFF
--- a/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
@@ -1071,7 +1071,9 @@ namespace
         else
         {
             std::string env_tex_instance_name;
-            if (is_bitmap_texture(rend_params.envMap))
+            if (settings.m_use_max_procedural_maps)
+                env_tex_instance_name = insert_procedural_texture_and_instance(scene, rend_params.envMap);
+            else if (is_bitmap_texture(rend_params.envMap))
                 env_tex_instance_name = insert_bitmap_texture_and_instance(scene, rend_params.envMap);
             else
             {

--- a/src/appleseed-max-impl/utilities.cpp
+++ b/src/appleseed-max-impl/utilities.cpp
@@ -152,6 +152,10 @@ bool is_supported_procedural_texture(Texmap* map)
 
     switch (part_a)
     {
+      case 0x6769144B:                  // VrayHDRI
+        return part_b == 0x2C1017D;
+      case 0x58F82B74:                  // VrayColor
+        return part_b == 0x73B75D7F;
       case 0x64035FB9:                  // tiles
         return part_b == 0x69664CDC;
       case 0x1DEC5B86:                  // gradient ramp
@@ -242,7 +246,8 @@ std::string insert_bitmap_texture_and_instance(
 
     if (!texture_params.strings().exist("color_space"))
     {
-        if (asf::ends_with(filepath, ".exr"))
+        if (asf::ends_with(filepath, ".exr") ||
+            asf::ends_with(filepath, ".hdr"))
             texture_params.insert("color_space", "linear_rgb");
         else texture_params.insert("color_space", "srgb");
     }


### PR DESCRIPTION
Hi,
This pr adds support of procedural maps in environment maps. Logic is following - if procedural maps flag is on then everything including bitmaps gets handled by 3ds max shade context. If flag is off then in case of bitmap it's just used as is and if not bitmap then it's re-rendered as before.

Other changes are straightforward.