### PR TITLE
Glass shader and exposure control

### DIFF
--- a/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.cpp
+++ b/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.cpp
@@ -33,6 +33,7 @@
 #include "appleseedblendmtl/datachunks.h"
 #include "appleseedblendmtl/resource.h"
 #include "appleseeddisneymtl/appleseeddisneymtl.h"
+#include "appleseedglassmtl/appleseedglassmtl.h"
 #include "appleseedrenderer/appleseedrenderer.h"
 #include "bump/bumpparammapdlgproc.h"
 #include "bump/resource.h"
@@ -583,6 +584,7 @@ asf::auto_release_ptr<asr::Material> AppleseedBlendMtl::create_osl_material(
 
     const bool compatible_mtl =
         mat->ClassID() == AppleseedDisneyMtl::get_class_id() ||
+        mat->ClassID() == AppleseedGlassMtl::get_class_id() ||
         mat->ClassID() == AppleseedBlendMtl::get_class_id();
 
     if (!compatible_mtl)

--- a/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.cpp
+++ b/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.cpp
@@ -635,8 +635,8 @@ asf::auto_release_ptr<asr::Material> AppleseedGlassMtl::create_material(
 {
     return
         use_max_procedural_maps
-        ? create_builtin_material(assembly, name)
-        : create_osl_material(assembly, name);
+            ? create_builtin_material(assembly, name)
+            : create_osl_material(assembly, name);
 }
 
 
@@ -698,8 +698,6 @@ asf::auto_release_ptr<asr::Material> AppleseedGlassMtl::create_builtin_material(
 {
     asr::ParamArray material_params;
     std::string instance_name;
-    asr::ParamArray bsdf_params;
-    bsdf_params.insert("mdf", "ggx");
     const bool use_max_procedural_maps = true;
 
     //
@@ -707,6 +705,9 @@ asf::auto_release_ptr<asr::Material> AppleseedGlassMtl::create_builtin_material(
     //
 
     {
+        asr::ParamArray bsdf_params;
+        bsdf_params.insert("mdf", "ggx");
+
         // Surface transmittance.
         instance_name = insert_texture_and_instance(assembly, m_surface_color_texmap, use_max_procedural_maps);
         if (!instance_name.empty())

--- a/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.h
+++ b/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.h
@@ -140,6 +140,7 @@ class AppleseedGlassMtl
     foundation::auto_release_ptr<renderer::Material> create_osl_material(
         renderer::Assembly& assembly,
         const char*         name);
+
   private:
     IParamBlock2*   m_pblock;
     Interval        m_params_validity;

--- a/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.h
+++ b/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.h
@@ -134,7 +134,12 @@ class AppleseedGlassMtl
         renderer::Assembly& assembly,
         const char*         name,
         const bool          use_max_procedural_maps) override;
-
+    foundation::auto_release_ptr<renderer::Material> create_builtin_material(
+        renderer::Assembly& assembly,
+        const char*         name);
+    foundation::auto_release_ptr<renderer::Material> create_osl_material(
+        renderer::Assembly& assembly,
+        const char*         name);
   private:
     IParamBlock2*   m_pblock;
     Interval        m_params_validity;

--- a/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
@@ -1096,6 +1096,16 @@ namespace
             asr::ParamArray env_edf_params;
             env_edf_params.insert("radiance", env_tex_instance_name.c_str());
 
+            if (is_bitmap_texture(rend_params.envMap))
+            {
+                TextureOutput* tex_out = static_cast<BitmapTex*>(rend_params.envMap)->GetTexout();
+                if (tex_out)
+                {
+                    const float output = static_cast<StdTexoutGen*>(tex_out)->GetOutAmt(time);
+                    env_edf_params.insert("exposure", output - 1.0f);
+                }
+            }
+
             UVGen* uvgen = rend_params.envMap->GetTheUVGen();
             if (uvgen && uvgen->IsStdUVGen())
             {


### PR DESCRIPTION
This PR adds glass osl material and makes compatible with blend material. Also makes Output amount control exposure of EnvironmentEDF maps.
For exposure control I just copy (output amount-1) directly into edf's exposure parameter.