### PR TITLE
Light and sss osl shaders

### DIFF
--- a/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.cpp
+++ b/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.cpp
@@ -479,6 +479,10 @@ Color AppleseedBlendMtl::GetAmbient(int mtlNum, BOOL backFace)
 
 Color AppleseedBlendMtl::GetDiffuse(int mtlNum, BOOL backFace)
 {
+    Mtl* mat = nullptr;
+    m_pblock->GetValue(ParamIdBaseMtl, 0, mat, FOREVER);
+    if (mat != nullptr)
+        return mat->GetDiffuse(mtlNum, backFace);
     return Color(0.0f, 0.0f, 0.0f);
 }
 
@@ -499,6 +503,10 @@ float AppleseedBlendMtl::GetShinStr(int mtlNum, BOOL backFace)
 
 float AppleseedBlendMtl::GetXParency(int mtlNum, BOOL backFace)
 {
+    Mtl* mat = nullptr;
+    m_pblock->GetValue(ParamIdBaseMtl, 0, mat, FOREVER);
+    if (mat != nullptr)
+        return mat->GetXParency(mtlNum, backFace);
     return 0.0f;
 }
 
@@ -584,16 +592,6 @@ asf::auto_release_ptr<asr::Material> AppleseedBlendMtl::create_osl_material(
     if (!mat)
         return blend_material;
 
-    const bool compatible_mtl =
-        mat->ClassID() == AppleseedDisneyMtl::get_class_id() ||
-        mat->ClassID() == AppleseedGlassMtl::get_class_id() ||
-        mat->ClassID() == AppleseedLightMtl::get_class_id() ||
-        mat->ClassID() == AppleseedSSSMtl::get_class_id() ||
-        mat->ClassID() == AppleseedBlendMtl::get_class_id();
-    
-    if (!compatible_mtl)
-        return blend_material;
-
     auto shader_group_name = make_unique_name(assembly.shader_groups(), std::string(name) + "_shader_group");
     auto shader_group = asr::ShaderGroupFactory::create(shader_group_name.c_str());
 
@@ -609,15 +607,6 @@ asf::auto_release_ptr<asr::Material> AppleseedBlendMtl::create_osl_material(
         Mtl* mat = nullptr;
         m_pblock->GetValue(ParamIdLayerMtl, time, mat, FOREVER, i);
         if (mat == nullptr)
-            continue;
-
-        const bool compatible_mtl =
-            mat->ClassID() == AppleseedDisneyMtl::get_class_id() ||
-            mat->ClassID() == AppleseedGlassMtl::get_class_id() ||
-            mat->ClassID() == AppleseedLightMtl::get_class_id() ||
-            mat->ClassID() == AppleseedSSSMtl::get_class_id() ||
-            mat->ClassID() == AppleseedBlendMtl::get_class_id();
-        if (!compatible_mtl)
             continue;
 
         connect_sub_mtl(assembly, shader_group.ref(), name, asf::format("LayerMtl_{0}", layer_index).c_str(), mat);

--- a/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.cpp
+++ b/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.cpp
@@ -34,6 +34,8 @@
 #include "appleseedblendmtl/resource.h"
 #include "appleseeddisneymtl/appleseeddisneymtl.h"
 #include "appleseedglassmtl/appleseedglassmtl.h"
+#include "appleseedlightmtl/appleseedlightmtl.h"
+#include "appleseedsssmtl/appleseedsssmtl.h"
 #include "appleseedrenderer/appleseedrenderer.h"
 #include "bump/bumpparammapdlgproc.h"
 #include "bump/resource.h"
@@ -585,8 +587,10 @@ asf::auto_release_ptr<asr::Material> AppleseedBlendMtl::create_osl_material(
     const bool compatible_mtl =
         mat->ClassID() == AppleseedDisneyMtl::get_class_id() ||
         mat->ClassID() == AppleseedGlassMtl::get_class_id() ||
+        mat->ClassID() == AppleseedLightMtl::get_class_id() ||
+        mat->ClassID() == AppleseedSSSMtl::get_class_id() ||
         mat->ClassID() == AppleseedBlendMtl::get_class_id();
-
+    
     if (!compatible_mtl)
         return blend_material;
 
@@ -609,6 +613,9 @@ asf::auto_release_ptr<asr::Material> AppleseedBlendMtl::create_osl_material(
 
         const bool compatible_mtl =
             mat->ClassID() == AppleseedDisneyMtl::get_class_id() ||
+            mat->ClassID() == AppleseedGlassMtl::get_class_id() ||
+            mat->ClassID() == AppleseedLightMtl::get_class_id() ||
+            mat->ClassID() == AppleseedSSSMtl::get_class_id() ||
             mat->ClassID() == AppleseedBlendMtl::get_class_id();
         if (!compatible_mtl)
             continue;

--- a/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.cpp
+++ b/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.cpp
@@ -491,8 +491,8 @@ asf::auto_release_ptr<asr::Material> AppleseedLightMtl::create_material(
 {
     return
         use_max_procedural_maps
-        ? create_builtin_material(assembly, name)
-        : create_osl_material(assembly, name);
+            ? create_builtin_material(assembly, name)
+            : create_osl_material(assembly, name);
 }
 
 asf::auto_release_ptr<asr::Material> AppleseedLightMtl::create_osl_material(

--- a/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.h
+++ b/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.h
@@ -134,7 +134,12 @@ class AppleseedLightMtl
         renderer::Assembly& assembly,
         const char*         name,
         const bool          use_max_procedural_maps) override;
-
+    foundation::auto_release_ptr<renderer::Material> create_builtin_material(
+        renderer::Assembly& assembly,
+        const char*         name);
+    foundation::auto_release_ptr<renderer::Material> create_osl_material(
+        renderer::Assembly& assembly,
+        const char*         name);
 
   private:
     IParamBlock2*   m_pblock;

--- a/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
@@ -924,33 +924,35 @@ namespace
         }
     }
 
+    bool is_light_emitting_material(Mtl* mtl)
+    {
+        IAppleseedMtl* appleseed_mtl =
+            static_cast<IAppleseedMtl*>(mtl->GetInterface(IAppleseedMtl::interface_id()));
+        if (appleseed_mtl != nullptr && appleseed_mtl->can_emit_light())
+            return true;
+        else
+        {
+            const int submtl_count = mtl->NumSubMtls();
+            for (int i = 0; i < submtl_count; ++i)
+            {
+                Mtl* sub_mtl = mtl->GetSubMtl(i);
+                if (sub_mtl != nullptr)
+                {
+                    if (is_light_emitting_material(sub_mtl))
+                        return true;
+                }
+            }
+        }
+        return false;
+    }
+
     bool has_light_emitting_materials(const MaterialMap& material_map)
     {
         for (const auto& entry : material_map)
         {
             Mtl* mtl = entry.first;
-            IAppleseedMtl* appleseed_mtl =
-                static_cast<IAppleseedMtl*>(mtl->GetInterface(IAppleseedMtl::interface_id()));
-            if (appleseed_mtl->can_emit_light())
+            if (is_light_emitting_material(mtl))
                 return true;
-            else
-            {
-                const int submtlcount = mtl->NumSubMtls();
-                if (!mtl->IsMultiMtl() && submtlcount > 0)
-                {
-                    for (int i = 0; i < submtlcount; ++i)
-                    {
-                        Mtl* sub_mtl = mtl->GetSubMtl(i);
-                        if (sub_mtl != nullptr)
-                        {
-                            IAppleseedMtl* appleseed_sub_mtl =
-                                static_cast<IAppleseedMtl*>(sub_mtl->GetInterface(IAppleseedMtl::interface_id()));
-                            if (appleseed_sub_mtl->can_emit_light())
-                                return true;
-                        }
-                    }
-                }
-            }
         }
 
         return false;

--- a/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
@@ -933,6 +933,24 @@ namespace
                 static_cast<IAppleseedMtl*>(mtl->GetInterface(IAppleseedMtl::interface_id()));
             if (appleseed_mtl->can_emit_light())
                 return true;
+            else
+            {
+                const int submtlcount = mtl->NumSubMtls();
+                if (!mtl->IsMultiMtl() && submtlcount > 0)
+                {
+                    for (int i = 0; i < submtlcount; ++i)
+                    {
+                        Mtl* sub_mtl = mtl->GetSubMtl(i);
+                        if (sub_mtl != nullptr)
+                        {
+                            IAppleseedMtl* appleseed_sub_mtl =
+                                static_cast<IAppleseedMtl*>(sub_mtl->GetInterface(IAppleseedMtl::interface_id()));
+                            if (appleseed_sub_mtl->can_emit_light())
+                                return true;
+                        }
+                    }
+                }
+            }
         }
 
         return false;

--- a/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
+++ b/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
@@ -652,8 +652,8 @@ asf::auto_release_ptr<asr::Material> AppleseedSSSMtl::create_material(
 {
     return
         use_max_procedural_maps
-        ? create_builtin_material(assembly, name)
-        : create_osl_material(assembly, name);
+            ? create_builtin_material(assembly, name)
+            : create_osl_material(assembly, name);
 }
 
 asf::auto_release_ptr<asr::Material> AppleseedSSSMtl::create_osl_material(

--- a/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
+++ b/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
@@ -36,6 +36,7 @@
 #include "bump/bumpparammapdlgproc.h"
 #include "bump/resource.h"
 #include "main.h"
+#include "oslutils.h"
 #include "utilities.h"
 #include "version.h"
 
@@ -44,6 +45,7 @@
 #include "renderer/api/bssrdf.h"
 #include "renderer/api/material.h"
 #include "renderer/api/scene.h"
+#include "renderer/api/shadergroup.h"
 #include "renderer/api/utility.h"
 
 // appleseed.foundation headers.
@@ -648,8 +650,77 @@ asf::auto_release_ptr<asr::Material> AppleseedSSSMtl::create_material(
     const char*     name,
     const bool      use_max_procedural_maps)
 {
+    return
+        use_max_procedural_maps
+        ? create_builtin_material(assembly, name)
+        : create_osl_material(assembly, name);
+}
+
+asf::auto_release_ptr<asr::Material> AppleseedSSSMtl::create_osl_material(
+    asr::Assembly&  assembly,
+    const char*     name)
+{
+    //
+    // Shader group.
+    //
+    asr::ParamArray shader_params;
+
+    auto shader_group_name = make_unique_name(assembly.shader_groups(), std::string(name) + "_shader_group");
+    auto shader_group = asr::ShaderGroupFactory::create(shader_group_name.c_str());
+
+    // BSSRDF.
+    connect_color_texture(shader_group.ref(), name, "Radius", m_sss_scattering_color_texmap, m_sss_scattering_color);
+    connect_color_texture(shader_group.ref(), name, "SSSColor", m_sss_color_texmap, m_sss_color);
+    shader_params.insert("RadiusScale", fmt_osl_expr(m_sss_scale));
+    shader_params.insert("Profile", fmt_osl_expr("normalized_diffusion"));
+    shader_params.insert("SSSReflectance", fmt_osl_expr(m_sss_amount / 100.0f));
+    
+    // BRDF.
+    connect_color_texture(shader_group.ref(), name, "SpecularColor", m_specular_color_texmap, m_specular_color);
+    connect_float_texture(shader_group.ref(), name, "SpecularReflectance", m_specular_amount_texmap, m_specular_amount / 100.0f);
+    connect_float_texture(shader_group.ref(), name, "Roughness", m_specular_roughness_texmap, m_specular_roughness / 100.0f);
+    connect_float_texture(shader_group.ref(), name, "Anisotropic", m_specular_anisotropy_texmap, m_specular_anisotropy / 100.0f);
+    shader_params.insert("Distribution", fmt_osl_expr("ggx"));
+
+    shader_params.insert("Ior", fmt_osl_expr(m_sss_ior));
+
+    if (is_bitmap_texture(m_bump_texmap))
+    {
+        if (m_bump_method == 0)
+        {
+            // Bump mapping.
+            connect_bump_map(shader_group.ref(), name, "Normal", "Tn", m_bump_texmap, m_bump_amount);
+        }
+        else
+        {
+            // Normal mapping.
+            connect_normal_map(shader_group.ref(), name, "Normal", "Tn", m_bump_texmap, m_bump_up_vector);
+        }
+    }
+
+    // Must come last.
+    shader_group->add_shader("surface", "as_max_sss_material", name, shader_params);
+
+    assembly.shader_groups().insert(shader_group);
+
+    //
+    // Material.
+    //
+
+    asr::ParamArray material_params;
+    material_params.insert("osl_surface", shader_group_name);
+
+    return asr::OSLMaterialFactory().create(name, material_params);
+}
+
+asf::auto_release_ptr<asr::Material> AppleseedSSSMtl::create_builtin_material(
+    asr::Assembly&  assembly,
+    const char*     name)
+{
+
     asr::ParamArray material_params;
     std::string instance_name;
+    const bool use_max_procedural_maps = true;
 
     //
     // BSSRDF.

--- a/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.h
+++ b/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.h
@@ -134,6 +134,12 @@ class AppleseedSSSMtl
         renderer::Assembly& assembly,
         const char*         name,
         const bool          use_max_procedural_maps) override;
+    foundation::auto_release_ptr<renderer::Material> create_builtin_material(
+        renderer::Assembly& assembly,
+        const char*         name);
+    foundation::auto_release_ptr<renderer::Material> create_osl_material(
+        renderer::Assembly& assembly,
+        const char*         name);
 
 private:
     IParamBlock2*   m_pblock;


### PR DESCRIPTION
Also simplifies blend material compatibility check - blend material discards any material without osl_surface, so checking the type is redundant, I think.
Improves lighting materials check in the scene by checking blend's submaterials.
Makes blend material look in viewport similar to it's base material.