### PR TITLE
Fix titles on small texture buttons

### DIFF
--- a/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
+++ b/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
@@ -70,6 +70,7 @@ namespace
 }
 
 AppleseedDisneyMtlClassDesc g_appleseed_disneymtl_classdesc;
+TexturePBAccessor g_texture_accessor;
 
 
 //
@@ -168,6 +169,33 @@ namespace
         ParamIdBumpTexmap
     };
 
+    void update_map_buttons(IParamBlock2* pblock)
+    {
+        if (pblock == nullptr)
+            return;
+
+        IParamMap2* map = pblock->GetMap(ParamMapIdDisney);
+        if (map == nullptr)
+            return;
+
+        const int count = pblock->NumParams();
+        for (int i=0; i < count; ++i)
+        {
+            const int param_id = pblock->IndextoID(i);
+            if (param_id == ParamIdBaseColorTexmap)
+                continue;
+
+            if (pblock->GetParameterType(param_id) == TYPE_TEXMAP)
+            {
+                const auto texmap = pblock->GetTexmap(param_id, GetCOREInterface()->GetTime(), FOREVER);
+                if (texmap == nullptr)
+                    map->SetText(param_id, L"");
+                else
+                    map->SetText(param_id, L"M");
+            }
+        }
+    }
+
     ParamBlockDesc2 g_block_desc(
         // --- Required arguments ---
         ParamBlockIdDisneyMtl,                      // parameter block's ID
@@ -214,8 +242,9 @@ namespace
             p_range, 0.0f, 100.0f,
             p_ui, ParamMapIdDisney, TYPE_SLIDER, EDITTYPE_FLOAT, IDC_EDIT_METALLIC, IDC_SLIDER_METALLIC, 10.0f,
         p_end,
-        ParamIdMetallicTexmap, L"metallic_texmap", TYPE_TEXMAP, 0, IDS_TEXMAP_METALLIC,
+        ParamIdMetallicTexmap, L"metallic_texmap", TYPE_TEXMAP, P_NO_AUTO_LABELS, IDS_TEXMAP_METALLIC,
             p_subtexno, TexmapIdMetallic,
+            p_accessor, &g_texture_accessor,
             p_ui, ParamMapIdDisney, TYPE_TEXMAPBUTTON, IDC_TEXMAP_METALLIC,
         p_end,
 
@@ -224,8 +253,9 @@ namespace
             p_range, 0.0f, 100.0f,
             p_ui, ParamMapIdDisney, TYPE_SLIDER, EDITTYPE_FLOAT, IDC_EDIT_SPECULAR, IDC_SLIDER_SPECULAR, 10.0f,
         p_end,
-        ParamIdSpecularTexmap, L"specular_texmap", TYPE_TEXMAP, 0, IDS_TEXMAP_SPECULAR,
+        ParamIdSpecularTexmap, L"specular_texmap", TYPE_TEXMAP, P_NO_AUTO_LABELS, IDS_TEXMAP_SPECULAR,
             p_subtexno, TexmapIdSpecular,
+            p_accessor, &g_texture_accessor,
             p_ui, ParamMapIdDisney, TYPE_TEXMAPBUTTON, IDC_TEXMAP_SPECULAR,
         p_end,
 
@@ -234,8 +264,9 @@ namespace
             p_range, 0.0f, 100.0f,
             p_ui, ParamMapIdDisney, TYPE_SLIDER, EDITTYPE_FLOAT, IDC_EDIT_SPECULAR_TINT, IDC_SLIDER_SPECULAR_TINT, 10.0f,
         p_end,
-        ParamIdSpecularTintTexmap, L"specular_tint_texmap", TYPE_TEXMAP, 0, IDS_TEXMAP_SPECULAR_TINT,
+        ParamIdSpecularTintTexmap, L"specular_tint_texmap", TYPE_TEXMAP, P_NO_AUTO_LABELS, IDS_TEXMAP_SPECULAR_TINT,
             p_subtexno, TexmapIdSpecularTint,
+            p_accessor, &g_texture_accessor,
             p_ui, ParamMapIdDisney, TYPE_TEXMAPBUTTON, IDC_TEXMAP_SPECULAR_TINT,
         p_end,
 
@@ -244,8 +275,9 @@ namespace
             p_range, 0.0f, 100.0f,
             p_ui, ParamMapIdDisney, TYPE_SLIDER, EDITTYPE_FLOAT, IDC_EDIT_ROUGHNESS, IDC_SLIDER_ROUGHNESS, 10.0f,
         p_end,
-        ParamIdRoughnessTexmap, L"roughness_texmap", TYPE_TEXMAP, 0, IDS_TEXMAP_ROUGHNESS,
+        ParamIdRoughnessTexmap, L"roughness_texmap", TYPE_TEXMAP, P_NO_AUTO_LABELS, IDS_TEXMAP_ROUGHNESS,
             p_subtexno, TexmapIdRoughness,
+            p_accessor, &g_texture_accessor,
             p_ui, ParamMapIdDisney, TYPE_TEXMAPBUTTON, IDC_TEXMAP_ROUGHNESS,
         p_end,
 
@@ -254,8 +286,9 @@ namespace
             p_range, 0.0f, 1000.0f,
             p_ui, ParamMapIdDisney, TYPE_SLIDER, EDITTYPE_FLOAT, IDC_EDIT_SHEEN, IDC_SLIDER_SHEEN, 10.0f,
         p_end,
-        ParamIdSheenTexmap, L"sheen_texmap", TYPE_TEXMAP, 0, IDS_TEXMAP_SHEEN,
+        ParamIdSheenTexmap, L"sheen_texmap", TYPE_TEXMAP, P_NO_AUTO_LABELS, IDS_TEXMAP_SHEEN,
             p_subtexno, TexmapIdSheen,
+            p_accessor, &g_texture_accessor,
             p_ui, ParamMapIdDisney, TYPE_TEXMAPBUTTON, IDC_TEXMAP_SHEEN,
         p_end,
 
@@ -264,8 +297,9 @@ namespace
             p_range, 0.0f, 100.0f,
             p_ui, ParamMapIdDisney, TYPE_SLIDER, EDITTYPE_FLOAT, IDC_EDIT_SHEEN_TINT, IDC_SLIDER_SHEEN_TINT, 10.0f,
         p_end,
-        ParamIdSheenTintTexmap, L"sheen_tint_texmap", TYPE_TEXMAP, 0, IDS_TEXMAP_SHEEN_TINT,
+        ParamIdSheenTintTexmap, L"sheen_tint_texmap", TYPE_TEXMAP, P_NO_AUTO_LABELS, IDS_TEXMAP_SHEEN_TINT,
             p_subtexno, TexmapIdSheenTint,
+            p_accessor, &g_texture_accessor,
             p_ui, ParamMapIdDisney, TYPE_TEXMAPBUTTON, IDC_TEXMAP_SHEEN_TINT,
         p_end,
 
@@ -274,8 +308,9 @@ namespace
             p_range, -1.0f, 1.0f,
             p_ui, ParamMapIdDisney, TYPE_SLIDER, EDITTYPE_FLOAT, IDC_EDIT_ANISOTROPY, IDC_SLIDER_ANISOTROPY, 0.1f,
         p_end,
-        ParamIdAnisotropyTexmap, L"anisotropy_texmap", TYPE_TEXMAP, 0, IDS_TEXMAP_ANISOTROPY,
+        ParamIdAnisotropyTexmap, L"anisotropy_texmap", TYPE_TEXMAP, P_NO_AUTO_LABELS, IDS_TEXMAP_ANISOTROPY,
             p_subtexno, TexmapIdAnisotropy,
+            p_accessor, &g_texture_accessor,
             p_ui, ParamMapIdDisney, TYPE_TEXMAPBUTTON, IDC_TEXMAP_ANISOTROPY,
         p_end,
 
@@ -284,8 +319,9 @@ namespace
             p_range, 0.0f, 1000.0f,
             p_ui, ParamMapIdDisney, TYPE_SLIDER, EDITTYPE_FLOAT, IDC_EDIT_CLEARCOAT, IDC_SLIDER_CLEARCOAT, 10.0f,
         p_end,
-        ParamIdClearcoatTexmap, L"clearcoat_texmap", TYPE_TEXMAP, 0, IDS_TEXMAP_CLEARCOAT,
+        ParamIdClearcoatTexmap, L"clearcoat_texmap", TYPE_TEXMAP, P_NO_AUTO_LABELS, IDS_TEXMAP_CLEARCOAT,
             p_subtexno, TexmapIdClearcoat,
+            p_accessor, &g_texture_accessor,
             p_ui, ParamMapIdDisney, TYPE_TEXMAPBUTTON, IDC_TEXMAP_CLEARCOAT,
         p_end,
 
@@ -294,8 +330,9 @@ namespace
             p_range, 0.0f, 100.0f,
             p_ui, ParamMapIdDisney, TYPE_SLIDER, EDITTYPE_FLOAT, IDC_EDIT_CLEARCOAT_GLOSS, IDC_SLIDER_CLEARCOAT_GLOSS, 10.0f,
         p_end,
-        ParamIdClearcoatGlossTexmap, L"clearcoat_gloss_texmap", TYPE_TEXMAP, 0, IDS_TEXMAP_CLEARCOAT_GLOSS,
+        ParamIdClearcoatGlossTexmap, L"clearcoat_gloss_texmap", TYPE_TEXMAP, P_NO_AUTO_LABELS, IDS_TEXMAP_CLEARCOAT_GLOSS,
             p_subtexno, TexmapIdClearcoatGloss,
+            p_accessor, &g_texture_accessor,
             p_ui, ParamMapIdDisney, TYPE_TEXMAPBUTTON, IDC_TEXMAP_CLEARCOAT_GLOSS,
         p_end,
 
@@ -304,8 +341,9 @@ namespace
             p_range, 0.0f, 100.0f,
             p_ui, ParamMapIdDisney, TYPE_SLIDER, EDITTYPE_FLOAT, IDC_EDIT_ALPHA, IDC_SLIDER_ALPHA, 10.0f,
         p_end,
-        ParamIdAlphaTexmap, L"alpha_texmap", TYPE_TEXMAP, 0, IDS_TEXMAP_ALPHA,
+        ParamIdAlphaTexmap, L"alpha_texmap", TYPE_TEXMAP, P_NO_AUTO_LABELS, IDS_TEXMAP_ALPHA,
             p_subtexno, TexmapIdAlpha,
+            p_accessor, &g_texture_accessor,
             p_ui, ParamMapIdDisney, TYPE_TEXMAPBUTTON, IDC_TEXMAP_ALPHA,
         p_end,
 
@@ -591,6 +629,7 @@ Interval AppleseedDisneyMtl::Validity(TimeValue t)
 ParamDlg* AppleseedDisneyMtl::CreateParamDlg(HWND hwMtlEdit, IMtlParams* imp)
 {
     ParamDlg* param_dialog = g_appleseed_disneymtl_classdesc.CreateParamDlgs(hwMtlEdit, imp, this);
+    update_map_buttons(m_pblock);
     g_block_desc.SetUserDlgProc(ParamMapIdBump, new BumpParamMapDlgProc());
     return param_dialog;
 }
@@ -916,6 +955,35 @@ asf::auto_release_ptr<asr::Material> AppleseedDisneyMtl::create_builtin_material
     }
 
     return asr::GenericMaterialFactory().create(name, material_params);
+}
+
+
+//
+// TexturePBAccessor class implementation
+//
+
+void TexturePBAccessor::Set(
+    PB2Value&         v,
+    ReferenceMaker*   owner,
+    ParamID           id,
+    int               tabIndex,
+    TimeValue         t)
+{
+    if (id == ParamIdBaseColorTexmap)
+        return;
+
+    IParamBlock2* pblock = static_cast<AppleseedDisneyMtl*>(owner)->GetParamBlock(0);
+    if (pblock == nullptr)
+        return;
+
+    IParamMap2* map = pblock->GetMap(ParamMapIdDisney);
+    if (map == nullptr)
+        return;
+
+    if (v.r == nullptr)
+        map->SetText(id, L"", 0);
+    else
+        map->SetText(id, L"M", 0);
 }
 
 

--- a/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
+++ b/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
@@ -70,7 +70,6 @@ namespace
 }
 
 AppleseedDisneyMtlClassDesc g_appleseed_disneymtl_classdesc;
-TexturePBAccessor g_texture_accessor;
 
 
 //
@@ -169,33 +168,6 @@ namespace
         ParamIdBumpTexmap
     };
 
-    void update_map_buttons(IParamBlock2* pblock)
-    {
-        if (pblock == nullptr)
-            return;
-
-        IParamMap2* map = pblock->GetMap(ParamMapIdDisney);
-        if (map == nullptr)
-            return;
-
-        const int count = pblock->NumParams();
-        for (int i=0; i < count; ++i)
-        {
-            const int param_id = pblock->IndextoID(i);
-            if (param_id == ParamIdBaseColorTexmap)
-                continue;
-
-            if (pblock->GetParameterType(param_id) == TYPE_TEXMAP)
-            {
-                const auto texmap = pblock->GetTexmap(param_id, GetCOREInterface()->GetTime(), FOREVER);
-                if (texmap == nullptr)
-                    map->SetText(param_id, L"");
-                else
-                    map->SetText(param_id, L"M");
-            }
-        }
-    }
-
     ParamBlockDesc2 g_block_desc(
         // --- Required arguments ---
         ParamBlockIdDisneyMtl,                      // parameter block's ID
@@ -244,7 +216,6 @@ namespace
         p_end,
         ParamIdMetallicTexmap, L"metallic_texmap", TYPE_TEXMAP, P_NO_AUTO_LABELS, IDS_TEXMAP_METALLIC,
             p_subtexno, TexmapIdMetallic,
-            p_accessor, &g_texture_accessor,
             p_ui, ParamMapIdDisney, TYPE_TEXMAPBUTTON, IDC_TEXMAP_METALLIC,
         p_end,
 
@@ -255,7 +226,6 @@ namespace
         p_end,
         ParamIdSpecularTexmap, L"specular_texmap", TYPE_TEXMAP, P_NO_AUTO_LABELS, IDS_TEXMAP_SPECULAR,
             p_subtexno, TexmapIdSpecular,
-            p_accessor, &g_texture_accessor,
             p_ui, ParamMapIdDisney, TYPE_TEXMAPBUTTON, IDC_TEXMAP_SPECULAR,
         p_end,
 
@@ -266,7 +236,6 @@ namespace
         p_end,
         ParamIdSpecularTintTexmap, L"specular_tint_texmap", TYPE_TEXMAP, P_NO_AUTO_LABELS, IDS_TEXMAP_SPECULAR_TINT,
             p_subtexno, TexmapIdSpecularTint,
-            p_accessor, &g_texture_accessor,
             p_ui, ParamMapIdDisney, TYPE_TEXMAPBUTTON, IDC_TEXMAP_SPECULAR_TINT,
         p_end,
 
@@ -277,7 +246,6 @@ namespace
         p_end,
         ParamIdRoughnessTexmap, L"roughness_texmap", TYPE_TEXMAP, P_NO_AUTO_LABELS, IDS_TEXMAP_ROUGHNESS,
             p_subtexno, TexmapIdRoughness,
-            p_accessor, &g_texture_accessor,
             p_ui, ParamMapIdDisney, TYPE_TEXMAPBUTTON, IDC_TEXMAP_ROUGHNESS,
         p_end,
 
@@ -288,7 +256,6 @@ namespace
         p_end,
         ParamIdSheenTexmap, L"sheen_texmap", TYPE_TEXMAP, P_NO_AUTO_LABELS, IDS_TEXMAP_SHEEN,
             p_subtexno, TexmapIdSheen,
-            p_accessor, &g_texture_accessor,
             p_ui, ParamMapIdDisney, TYPE_TEXMAPBUTTON, IDC_TEXMAP_SHEEN,
         p_end,
 
@@ -299,7 +266,6 @@ namespace
         p_end,
         ParamIdSheenTintTexmap, L"sheen_tint_texmap", TYPE_TEXMAP, P_NO_AUTO_LABELS, IDS_TEXMAP_SHEEN_TINT,
             p_subtexno, TexmapIdSheenTint,
-            p_accessor, &g_texture_accessor,
             p_ui, ParamMapIdDisney, TYPE_TEXMAPBUTTON, IDC_TEXMAP_SHEEN_TINT,
         p_end,
 
@@ -310,7 +276,6 @@ namespace
         p_end,
         ParamIdAnisotropyTexmap, L"anisotropy_texmap", TYPE_TEXMAP, P_NO_AUTO_LABELS, IDS_TEXMAP_ANISOTROPY,
             p_subtexno, TexmapIdAnisotropy,
-            p_accessor, &g_texture_accessor,
             p_ui, ParamMapIdDisney, TYPE_TEXMAPBUTTON, IDC_TEXMAP_ANISOTROPY,
         p_end,
 
@@ -321,7 +286,6 @@ namespace
         p_end,
         ParamIdClearcoatTexmap, L"clearcoat_texmap", TYPE_TEXMAP, P_NO_AUTO_LABELS, IDS_TEXMAP_CLEARCOAT,
             p_subtexno, TexmapIdClearcoat,
-            p_accessor, &g_texture_accessor,
             p_ui, ParamMapIdDisney, TYPE_TEXMAPBUTTON, IDC_TEXMAP_CLEARCOAT,
         p_end,
 
@@ -332,7 +296,6 @@ namespace
         p_end,
         ParamIdClearcoatGlossTexmap, L"clearcoat_gloss_texmap", TYPE_TEXMAP, P_NO_AUTO_LABELS, IDS_TEXMAP_CLEARCOAT_GLOSS,
             p_subtexno, TexmapIdClearcoatGloss,
-            p_accessor, &g_texture_accessor,
             p_ui, ParamMapIdDisney, TYPE_TEXMAPBUTTON, IDC_TEXMAP_CLEARCOAT_GLOSS,
         p_end,
 
@@ -343,7 +306,6 @@ namespace
         p_end,
         ParamIdAlphaTexmap, L"alpha_texmap", TYPE_TEXMAP, P_NO_AUTO_LABELS, IDS_TEXMAP_ALPHA,
             p_subtexno, TexmapIdAlpha,
-            p_accessor, &g_texture_accessor,
             p_ui, ParamMapIdDisney, TYPE_TEXMAPBUTTON, IDC_TEXMAP_ALPHA,
         p_end,
 
@@ -549,6 +511,15 @@ void AppleseedDisneyMtl::SetSubTexmap(int i, Texmap* texmap)
     const auto texmap_id = static_cast<TexmapId>(i);
     const auto param_id = g_texmap_id_to_param_id[texmap_id];
     m_pblock->SetValue(param_id, 0, texmap);
+
+    IParamMap2* map = m_pblock->GetMap(ParamMapIdDisney);
+    if (map != nullptr)
+    {
+        if (texmap != nullptr)
+            map->SetText(param_id, L"M", 0);
+        else
+            map->SetText(param_id, L"", 0);
+    }
 }
 
 int AppleseedDisneyMtl::MapSlotType(int i)
@@ -629,7 +600,8 @@ Interval AppleseedDisneyMtl::Validity(TimeValue t)
 ParamDlg* AppleseedDisneyMtl::CreateParamDlg(HWND hwMtlEdit, IMtlParams* imp)
 {
     ParamDlg* param_dialog = g_appleseed_disneymtl_classdesc.CreateParamDlgs(hwMtlEdit, imp, this);
-    update_map_buttons(m_pblock);
+    if (m_pblock != nullptr)
+        update_map_buttons(m_pblock->GetMap(ParamMapIdDisney));
     g_block_desc.SetUserDlgProc(ParamMapIdBump, new BumpParamMapDlgProc());
     return param_dialog;
 }
@@ -955,35 +927,6 @@ asf::auto_release_ptr<asr::Material> AppleseedDisneyMtl::create_builtin_material
     }
 
     return asr::GenericMaterialFactory().create(name, material_params);
-}
-
-
-//
-// TexturePBAccessor class implementation
-//
-
-void TexturePBAccessor::Set(
-    PB2Value&         v,
-    ReferenceMaker*   owner,
-    ParamID           id,
-    int               tabIndex,
-    TimeValue         t)
-{
-    if (id == ParamIdBaseColorTexmap)
-        return;
-
-    IParamBlock2* pblock = static_cast<AppleseedDisneyMtl*>(owner)->GetParamBlock(0);
-    if (pblock == nullptr)
-        return;
-
-    IParamMap2* map = pblock->GetMap(ParamMapIdDisney);
-    if (map == nullptr)
-        return;
-
-    if (v.r == nullptr)
-        map->SetText(id, L"", 0);
-    else
-        map->SetText(id, L"M", 0);
 }
 
 

--- a/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
+++ b/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
@@ -515,10 +515,7 @@ void AppleseedDisneyMtl::SetSubTexmap(int i, Texmap* texmap)
     IParamMap2* map = m_pblock->GetMap(ParamMapIdDisney);
     if (map != nullptr)
     {
-        if (texmap != nullptr)
-            map->SetText(param_id, L"M", 0);
-        else
-            map->SetText(param_id, L"", 0);
+        map->SetText(param_id, texmap == nullptr ? L"" : L"M");
     }
 }
 
@@ -600,8 +597,8 @@ Interval AppleseedDisneyMtl::Validity(TimeValue t)
 ParamDlg* AppleseedDisneyMtl::CreateParamDlg(HWND hwMtlEdit, IMtlParams* imp)
 {
     ParamDlg* param_dialog = g_appleseed_disneymtl_classdesc.CreateParamDlgs(hwMtlEdit, imp, this);
-    if (m_pblock != nullptr)
-        update_map_buttons(m_pblock->GetMap(ParamMapIdDisney));
+    DbgAssert(m_pblock != nullptr);
+    update_map_buttons(m_pblock->GetMap(ParamMapIdDisney));
     g_block_desc.SetUserDlgProc(ParamMapIdBump, new BumpParamMapDlgProc());
     return param_dialog;
 }

--- a/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.h
+++ b/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.h
@@ -174,6 +174,16 @@ class AppleseedDisneyMtl
         const char*         name);
 };
 
+//
+// Texture parameter accessor class declaration
+//
+
+class TexturePBAccessor
+    : public PBAccessor
+{
+public:
+    void Set(PB2Value& v, ReferenceMaker* owner, ParamID id, int tabIndex, TimeValue t) override;
+};
 
 //
 // AppleseedDisneyMtl material browser info.

--- a/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.h
+++ b/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.h
@@ -174,16 +174,6 @@ class AppleseedDisneyMtl
         const char*         name);
 };
 
-//
-// Texture parameter accessor class declaration
-//
-
-class TexturePBAccessor
-    : public PBAccessor
-{
-public:
-    void Set(PB2Value& v, ReferenceMaker* owner, ParamID id, int tabIndex, TimeValue t) override;
-};
 
 //
 // AppleseedDisneyMtl material browser info.

--- a/src/appleseed-max-impl/utilities.cpp
+++ b/src/appleseed-max-impl/utilities.cpp
@@ -136,18 +136,14 @@ void update_map_buttons(IParamMap2* param_map)
 
     IParamBlock2* param_block = param_map->GetParamBlock();
 
-    const int count = param_block->NumParams();
-    for (int i = 0; i < count; ++i)
+    for (int i = 0, e = param_block->NumParams(); i < e; ++i)
     {
         const int param_id = param_block->IndextoID(i);
         const ParamDef& param_def = param_block->GetParamDef(param_id);
         if (param_def.type == TYPE_TEXMAP && (param_def.flags & P_NO_AUTO_LABELS))
         {
             const auto texmap = param_block->GetTexmap(param_id, GetCOREInterface()->GetTime(), FOREVER);
-            if (texmap == nullptr)
-                param_map->SetText(param_id, L"");
-            else
-                param_map->SetText(param_id, L"M");
+            param_map->SetText(param_id, texmap == nullptr ? L"" : L"M");
         }
     }
 }

--- a/src/appleseed-max-impl/utilities.cpp
+++ b/src/appleseed-max-impl/utilities.cpp
@@ -49,6 +49,7 @@
 #include <assert1.h>
 #include <bitmap.h>
 #include <imtl.h>
+#include <iparamm2.h>
 #include <maxapi.h>
 #include <plugapi.h>
 #include <stdmat.h>
@@ -126,6 +127,29 @@ WStr replace_extension(const WStr& file_path, const WStr& new_ext)
     WStr new_file_path = i == -1 ? file_path : file_path.Substr(0, i);
     new_file_path.Append(new_ext);
     return new_file_path;
+}
+
+void update_map_buttons(IParamMap2* param_map)
+{
+    if (param_map == nullptr)
+        return;
+
+    IParamBlock2* param_block = param_map->GetParamBlock();
+
+    const int count = param_block->NumParams();
+    for (int i = 0; i < count; ++i)
+    {
+        const int param_id = param_block->IndextoID(i);
+        const ParamDef& param_def = param_block->GetParamDef(param_id);
+        if (param_def.type == TYPE_TEXMAP && (param_def.flags & P_NO_AUTO_LABELS))
+        {
+            const auto texmap = param_block->GetTexmap(param_id, GetCOREInterface()->GetTime(), FOREVER);
+            if (texmap == nullptr)
+                param_map->SetText(param_id, L"");
+            else
+                param_map->SetText(param_id, L"M");
+        }
+    }
 }
 
 bool is_bitmap_texture(Texmap* map)

--- a/src/appleseed-max-impl/utilities.h
+++ b/src/appleseed-max-impl/utilities.h
@@ -134,6 +134,7 @@ BOOL get_paramblock_value_by_name(
     Interval&               validity,
     const int               tab_index = 0);
 
+void update_map_buttons(IParamMap2* param_map);
 
 //
 // Bitmap functions.

--- a/src/appleseed-max-impl/utilities.h
+++ b/src/appleseed-max-impl/utilities.h
@@ -136,6 +136,7 @@ BOOL get_paramblock_value_by_name(
 
 void update_map_buttons(IParamMap2* param_map);
 
+
 //
 // Bitmap functions.
 //


### PR DESCRIPTION
Hi, 
this is small interface change, should fix #11

![image](https://user-images.githubusercontent.com/1850877/33943538-71e21d10-dfe7-11e7-951f-71c145252803.png)

I thought it's good time to fix it before other materials are added.
Thanks,
Sergo.