### PR TITLE
Fix bump in "use procedural maps" mode

### DIFF
--- a/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
+++ b/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
@@ -914,7 +914,7 @@ asf::auto_release_ptr<asr::Material> AppleseedDisneyMtl::create_builtin_material
         {
           case 0:
             material_params.insert("bump_amplitude", m_bump_amount);
-            material_params.insert("bump_offset", 0.5f / 512);
+            material_params.insert("bump_offset", 0.5f);
             break;
 
           case 1:

--- a/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.cpp
+++ b/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.cpp
@@ -808,7 +808,7 @@ asf::auto_release_ptr<asr::Material> AppleseedGlassMtl::create_builtin_material(
         {
           case 0:
             material_params.insert("bump_amplitude", m_bump_amount);
-            material_params.insert("bump_offset", 0.0009765625f);     // 0.5/512 - value that should work for non-image sources
+            material_params.insert("bump_offset", 0.5f);
             break;
 
           case 1:

--- a/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
+++ b/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
@@ -832,12 +832,12 @@ asf::auto_release_ptr<asr::Material> AppleseedSSSMtl::create_builtin_material(
 
         switch (m_bump_method)
         {
-        case 0:
+          case 0:
             material_params.insert("bump_amplitude", m_bump_amount);
-            material_params.insert("bump_offset", 0.0009765625f);     // 0.5/512 - value that should work for non-image sources
+            material_params.insert("bump_offset", 0.5f);
             break;
 
-        case 1:
+          case 1:
             material_params.insert("normal_map_up", m_bump_up_vector == 0 ? "y" : "z");
             break;
         }


### PR DESCRIPTION
Hi @dictoon,
I think this fixes bump and normal problem when renderer is in "use max procedural maps" mode. At least bump and normal are showing in render, both with bitmaps and procedural textures.
I remember we use some dummy values for procedural textures, and then this offset was divided by that value. But now for some reason division is not required.