### PR TITLE
Fix DOF in activeshader rendering, update camera parameters

### DIFF
--- a/src/appleseed-max-impl/appleseedinteractive/appleseedinteractive.h
+++ b/src/appleseed-max-impl/appleseedinteractive/appleseedinteractive.h
@@ -97,7 +97,8 @@ class AppleseedInteractiveRender
     virtual void AbortRender() override;
 #endif
 
-    void update_camera(INode* camera);
+    void update_camera_parameters(INode* camera);
+    void update_camera_transform(INode* camera);
     InteractiveSession* get_render_session();
 
   private:
@@ -121,5 +122,6 @@ class AppleseedInteractiveRender
     foundation::auto_release_ptr<renderer::Project> prepare_project(
         const RendererSettings&     renderer_settings,
         const ViewParams&           view_params,
+        INode*                      camera_node,
         const TimeValue             time);
 };

--- a/src/appleseed-max-impl/appleseedrenderer/projectbuilder.h
+++ b/src/appleseed-max-impl/appleseedrenderer/projectbuilder.h
@@ -44,6 +44,7 @@
 
 // Forward declarations.
 namespace renderer { class Camera; }
+namespace renderer { class ParamArray; }
 namespace renderer { class Project; }
 class Bitmap;
 class FrameRendParams;
@@ -61,6 +62,12 @@ foundation::auto_release_ptr<renderer::Project> build_project(
     const RendParams&                   rend_params,
     const FrameRendParams&              frame_rend_params,
     const RendererSettings&             settings,
+    Bitmap*                             bitmap,
+    const TimeValue                     time);
+
+void set_camera_dof_params(
+    renderer::ParamArray&               params,
+    MaxSDK::IPhysicalCamera*            camera_node,
     Bitmap*                             bitmap,
     const TimeValue                     time);
 


### PR DESCRIPTION
Hi,
This should fix #69. 
Also fixes updating camera parameters during interactive rendering, such as FOV, aperture, blades and so on. Camera type cannot be changed so switching Enable Depth of Field checkbox won't change anything during the rendering.

Thanks,
Sergo.