### PR TITLE
Support closure2surface shader, fix obj. properties, support Substance materials

### DIFF
--- a/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.cpp
+++ b/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.cpp
@@ -631,9 +631,17 @@ asf::auto_release_ptr<asr::Material> AppleseedBlendMtl::create_osl_material(
         ++layer_index;
     }
     
-    // Must come last.
     shader_group->add_shader("surface", "as_max_blend_material", name, shader_params);
     
+    std::string closure2surface_name = asf::format("{0}_closure2surface_name", name);
+    shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());
+
+    shader_group.ref().add_connection(
+        name,
+        "ClosureOut",
+        closure2surface_name.c_str(),
+        "in_input");
+
     assembly.shader_groups().insert(shader_group);
 
     //

--- a/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.cpp
+++ b/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.cpp
@@ -633,7 +633,7 @@ asf::auto_release_ptr<asr::Material> AppleseedBlendMtl::create_osl_material(
     
     shader_group->add_shader("surface", "as_max_blend_material", name, shader_params);
     
-    std::string closure2surface_name = asf::format("{0}_closure2surface_name", name);
+    std::string closure2surface_name = asf::format("{0}_closure2surface", name);
     shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());
 
     shader_group.ref().add_connection(

--- a/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
+++ b/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
@@ -764,8 +764,16 @@ asf::auto_release_ptr<asr::Material> AppleseedDisneyMtl::create_osl_material(
         }
     }
 
-    // Must come last.
     shader_group->add_shader("surface", "as_max_disney_material", name, asr::ParamArray());
+
+    std::string closure2surface_name = asf::format("{0}_closure2surface_name", name);
+    shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());
+
+    shader_group.ref().add_connection(
+        name,
+        "ClosureOut",
+        closure2surface_name.c_str(),
+        "in_input");
 
     assembly.shader_groups().insert(shader_group);
 

--- a/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
+++ b/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
@@ -766,7 +766,7 @@ asf::auto_release_ptr<asr::Material> AppleseedDisneyMtl::create_osl_material(
 
     shader_group->add_shader("surface", "as_max_disney_material", name, asr::ParamArray());
 
-    std::string closure2surface_name = asf::format("{0}_closure2surface_name", name);
+    std::string closure2surface_name = asf::format("{0}_closure2surface", name);
     shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());
 
     shader_group.ref().add_connection(

--- a/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.cpp
+++ b/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.cpp
@@ -689,7 +689,7 @@ asf::auto_release_ptr<asr::Material> AppleseedGlassMtl::create_osl_material(
 
     shader_group->add_shader("surface", "as_max_glass_material", name, shader_params);
 
-    std::string closure2surface_name = asf::format("{0}_closure2surface_name", name);
+    std::string closure2surface_name = asf::format("{0}_closure2surface", name);
     shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());
 
     shader_group.ref().add_connection(

--- a/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.cpp
+++ b/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.cpp
@@ -687,8 +687,16 @@ asf::auto_release_ptr<asr::Material> AppleseedGlassMtl::create_osl_material(
         }
     }
 
-    // Must come last.
     shader_group->add_shader("surface", "as_max_glass_material", name, shader_params);
+
+    std::string closure2surface_name = asf::format("{0}_closure2surface_name", name);
+    shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());
+
+    shader_group.ref().add_connection(
+        name,
+        "ClosureOut",
+        closure2surface_name.c_str(),
+        "in_input");
 
     assembly.shader_groups().insert(shader_group);
 

--- a/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.cpp
+++ b/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.cpp
@@ -514,7 +514,7 @@ asf::auto_release_ptr<asr::Material> AppleseedLightMtl::create_osl_material(
     
     shader_group->add_shader("surface", "as_max_light_material", name, shader_params);
 
-    std::string closure2surface_name = asf::format("{0}_closure2surface_name", name);
+    std::string closure2surface_name = asf::format("{0}_closure2surface", name);
     shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());
 
     shader_group.ref().add_connection(

--- a/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.cpp
+++ b/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.cpp
@@ -512,8 +512,16 @@ asf::auto_release_ptr<asr::Material> AppleseedLightMtl::create_osl_material(
     connect_color_texture(shader_group.ref(), name, "Color", m_light_color_texmap, m_light_color);
     shader_params.insert("Emission", fmt_osl_expr(m_light_power));
     
-    // Must come last.
     shader_group->add_shader("surface", "as_max_light_material", name, shader_params);
+
+    std::string closure2surface_name = asf::format("{0}_closure2surface_name", name);
+    shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());
+
+    shader_group.ref().add_connection(
+        name,
+        "ClosureOut",
+        closure2surface_name.c_str(),
+        "in_input");
 
     assembly.shader_groups().insert(shader_group);
 

--- a/src/appleseed-max-impl/appleseedmetalmtl/appleseedmetalmtl.cpp
+++ b/src/appleseed-max-impl/appleseedmetalmtl/appleseedmetalmtl.cpp
@@ -662,7 +662,7 @@ asf::auto_release_ptr<asr::Material> AppleseedMetalMtl::create_osl_material(
 
     shader_group->add_shader("surface", "as_max_metal_material", name, asr::ParamArray());
 
-    std::string closure2surface_name = asf::format("{0}_closure2surface_name", name);
+    std::string closure2surface_name = asf::format("{0}_closure2surface", name);
     shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());
 
     shader_group.ref().add_connection(

--- a/src/appleseed-max-impl/appleseedmetalmtl/appleseedmetalmtl.cpp
+++ b/src/appleseed-max-impl/appleseedmetalmtl/appleseedmetalmtl.cpp
@@ -660,8 +660,16 @@ asf::auto_release_ptr<asr::Material> AppleseedMetalMtl::create_osl_material(
         }
     }
 
-    // Must come last.
     shader_group->add_shader("surface", "as_max_metal_material", name, asr::ParamArray());
+
+    std::string closure2surface_name = asf::format("{0}_closure2surface_name", name);
+    shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());
+
+    shader_group.ref().add_connection(
+        name,
+        "ClosureOut",
+        closure2surface_name.c_str(),
+        "in_input");
 
     assembly.shader_groups().insert(shader_group);
 

--- a/src/appleseed-max-impl/appleseedobjpropsmod/appleseedobjpropsmod.cpp
+++ b/src/appleseed-max-impl/appleseedobjpropsmod/appleseedobjpropsmod.cpp
@@ -344,7 +344,7 @@ std::string AppleseedObjPropsMod::get_sss_set(const TimeValue t) const
 {
     const MCHAR* str_value;
     m_pblock->GetValue(ParamIdSSSSet, t, str_value, FOREVER);
-    return wide_to_utf8(str_value);
+    return str_value != nullptr ? wide_to_utf8(str_value) : std::string();
 }
 
 

--- a/src/appleseed-max-impl/appleseedplasticmtl/appleseedplasticmtl.cpp
+++ b/src/appleseed-max-impl/appleseedplasticmtl/appleseedplasticmtl.cpp
@@ -689,7 +689,7 @@ asf::auto_release_ptr<asr::Material> AppleseedPlasticMtl::create_osl_material(
         .insert("Scattering", fmt_osl_expr(m_scattering / 100.0f))
         .insert("IOR", fmt_osl_expr(m_ior)));
 
-    std::string closure2surface_name = asf::format("{0}_closure2surface_name", name);
+    std::string closure2surface_name = asf::format("{0}_closure2surface", name);
     shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());
 
     shader_group.ref().add_connection(

--- a/src/appleseed-max-impl/appleseedplasticmtl/appleseedplasticmtl.cpp
+++ b/src/appleseed-max-impl/appleseedplasticmtl/appleseedplasticmtl.cpp
@@ -681,7 +681,6 @@ asf::auto_release_ptr<asr::Material> AppleseedPlasticMtl::create_osl_material(
         }
     }
 
-    // Must come last.
     shader_group->add_shader("surface", "as_max_plastic_material", name, 
         asr::ParamArray()
         .insert("SpecularWeight", fmt_osl_expr(m_specular_weight / 100.0f))
@@ -689,6 +688,15 @@ asf::auto_release_ptr<asr::Material> AppleseedPlasticMtl::create_osl_material(
         .insert("Spread", fmt_osl_expr(m_highlight_falloff / 100.0f))
         .insert("Scattering", fmt_osl_expr(m_scattering / 100.0f))
         .insert("IOR", fmt_osl_expr(m_ior)));
+
+    std::string closure2surface_name = asf::format("{0}_closure2surface_name", name);
+    shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());
+
+    shader_group.ref().add_connection(
+        name,
+        "ClosureOut",
+        closure2surface_name.c_str(),
+        "in_input");
 
     assembly.shader_groups().insert(shader_group);
 

--- a/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
+++ b/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
@@ -710,7 +710,7 @@ asf::auto_release_ptr<asr::Material> AppleseedSSSMtl::create_osl_material(
 
     shader_group->add_shader("surface", "as_max_sss_material", name, shader_params);
 
-    std::string closure2surface_name = asf::format("{0}_closure2surface_name", name);
+    std::string closure2surface_name = asf::format("{0}_closure2surface", name);
     shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());
 
     shader_group.ref().add_connection(

--- a/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
+++ b/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
@@ -708,8 +708,16 @@ asf::auto_release_ptr<asr::Material> AppleseedSSSMtl::create_osl_material(
         }
     }
 
-    // Must come last.
     shader_group->add_shader("surface", "as_max_sss_material", name, shader_params);
+
+    std::string closure2surface_name = asf::format("{0}_closure2surface_name", name);
+    shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());
+
+    shader_group.ref().add_connection(
+        name,
+        "ClosureOut",
+        closure2surface_name.c_str(),
+        "in_input");
 
     assembly.shader_groups().insert(shader_group);
 

--- a/src/appleseed-max-impl/utilities.cpp
+++ b/src/appleseed-max-impl/utilities.cpp
@@ -178,6 +178,10 @@ bool is_supported_procedural_texture(Texmap* map)
 
     switch (part_a)
     {
+      case 0x896EF2FC:                 // Substance (Built-in)   
+        return part_b == 0x44BD743F;
+      case 0xA661C7FF:                 // Map Output Selector  
+        return part_b == 0x68AB72CD;
       case 0x6769144B:                  // VRayHDRI
         return part_b == 0x02C1017D;
       case 0x58F82B74:                  // VRayColor


### PR DESCRIPTION
- Support of changes to 3ds max shaders made in appleseed [PR 1842](https://github.com/appleseedhq/appleseed/pull/1842)
- Fixes Object Properties modifier errors when SSS Set Id field is empty
- Adds support of Substance maps to "Use Procedural" mode