### PR TITLE
Support Output rollout, support Output map

### DIFF
--- a/src/appleseed-max-impl/appleseed-max2015-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2015-impl.vcxproj
@@ -263,6 +263,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
     <ClCompile Include="appleseedoslplugin\oslparamdlg.cpp" />
     <ClCompile Include="appleseedplasticmtl\appleseedplasticmtl.cpp" />
     <ClCompile Include="appleseedrenderer\dialoglogtarget.cpp" />
+    <ClCompile Include="builtinmapsupport.cpp" />
     <ClCompile Include="iappleseedmtl.cpp" />
     <ClCompile Include="appleseedlightmtl\appleseedlightmtl.cpp" />
     <ClCompile Include="logtarget.cpp" />
@@ -309,6 +310,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
     <ClInclude Include="appleseedplasticmtl\datachunks.h" />
     <ClInclude Include="appleseedplasticmtl\resource.h" />
     <ClInclude Include="appleseedrenderer\dialoglogtarget.h" />
+    <ClInclude Include="builtinmapsupport.h" />
     <ClInclude Include="bump\bumpparammapdlgproc.h" />
     <ClInclude Include="bump\resource.h" />
     <ClInclude Include="appleseeddisneymtl\appleseeddisneymtl.h" />

--- a/src/appleseed-max-impl/appleseed-max2015-impl.vcxproj.filters
+++ b/src/appleseed-max-impl/appleseed-max2015-impl.vcxproj.filters
@@ -93,6 +93,7 @@
     <ClCompile Include="appleseedplasticmtl\appleseedplasticmtl.cpp">
       <Filter>appleseedplasticmtl</Filter>
     </ClCompile>
+    <ClCompile Include="builtinmapsupport.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="appleseedrenderer\appleseedrenderer.h">
@@ -250,6 +251,7 @@
     <ClInclude Include="appleseedplasticmtl\resource.h">
       <Filter>appleseedplasticmtl</Filter>
     </ClInclude>
+    <ClInclude Include="builtinmapsupport.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="appleseedrenderer\appleseedrenderer.rc">

--- a/src/appleseed-max-impl/appleseed-max2016-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2016-impl.vcxproj
@@ -263,6 +263,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
     <ClCompile Include="appleseedoslplugin\oslparamdlg.cpp" />
     <ClCompile Include="appleseedplasticmtl\appleseedplasticmtl.cpp" />
     <ClCompile Include="appleseedrenderer\dialoglogtarget.cpp" />
+    <ClCompile Include="builtinmapsupport.cpp" />
     <ClCompile Include="iappleseedmtl.cpp" />
     <ClCompile Include="appleseedlightmtl\appleseedlightmtl.cpp" />
     <ClCompile Include="logtarget.cpp" />
@@ -309,6 +310,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
     <ClInclude Include="appleseedplasticmtl\datachunks.h" />
     <ClInclude Include="appleseedplasticmtl\resource.h" />
     <ClInclude Include="appleseedrenderer\dialoglogtarget.h" />
+    <ClInclude Include="builtinmapsupport.h" />
     <ClInclude Include="bump\bumpparammapdlgproc.h" />
     <ClInclude Include="bump\resource.h" />
     <ClInclude Include="appleseeddisneymtl\appleseeddisneymtl.h" />

--- a/src/appleseed-max-impl/appleseed-max2016-impl.vcxproj.filters
+++ b/src/appleseed-max-impl/appleseed-max2016-impl.vcxproj.filters
@@ -93,6 +93,7 @@
     <ClCompile Include="appleseedoslplugin\oslparamdlg.cpp">
       <Filter>appleseedoslplugin</Filter>
     </ClCompile>
+    <ClCompile Include="builtinmapsupport.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="appleseedrenderer\appleseedrenderer.h">
@@ -252,6 +253,7 @@
     <ClInclude Include="appleseedoslplugin\oslparamdlg.h">
       <Filter>appleseedoslplugin</Filter>
     </ClInclude>
+    <ClInclude Include="builtinmapsupport.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="appleseedrenderer\appleseedrenderer.rc">

--- a/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj
@@ -259,6 +259,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
     <ClCompile Include="appleseeddisneymtl\appleseeddisneymtl.cpp" />
     <ClCompile Include="appleseedglassmtl\appleseedglassmtl.cpp" />
     <ClCompile Include="appleseedrenderer\dialoglogtarget.cpp" />
+    <ClCompile Include="builtinmapsupport.cpp" />
     <ClCompile Include="iappleseedmtl.cpp" />
     <ClCompile Include="appleseedlightmtl\appleseedlightmtl.cpp" />
     <ClCompile Include="logtarget.cpp" />
@@ -305,6 +306,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
     <ClInclude Include="appleseedplasticmtl\datachunks.h" />
     <ClInclude Include="appleseedplasticmtl\resource.h" />
     <ClInclude Include="appleseedrenderer\dialoglogtarget.h" />
+    <ClInclude Include="builtinmapsupport.h" />
     <ClInclude Include="bump\bumpparammapdlgproc.h" />
     <ClInclude Include="bump\resource.h" />
     <ClInclude Include="appleseeddisneymtl\appleseeddisneymtl.h" />

--- a/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj.filters
+++ b/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj.filters
@@ -93,6 +93,7 @@
     <ClCompile Include="appleseedplasticmtl\appleseedplasticmtl.cpp">
       <Filter>appleseedplasticmtl</Filter>
     </ClCompile>
+    <ClCompile Include="builtinmapsupport.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="appleseedrenderer\appleseedrenderer.h">
@@ -250,6 +251,7 @@
     <ClInclude Include="appleseedmetalmtl\resource.h">
       <Filter>appleseedmetalmtl</Filter>
     </ClInclude>
+    <ClInclude Include="builtinmapsupport.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="appleseedrenderer\appleseedrenderer.rc">

--- a/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.cpp
+++ b/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.cpp
@@ -613,20 +613,19 @@ asf::auto_release_ptr<asr::Material> AppleseedBlendMtl::create_osl_material(
 
         Texmap* tex = nullptr;
         m_pblock->GetValue(ParamIdMaskTex, time, tex, FOREVER, i);
+        const float mask_amount = m_pblock->GetFloat(ParamIdMaskAmount, time, i) / 100.0f;
         if (tex != nullptr)
         {
-            const float mask_amount = m_pblock->GetFloat(ParamIdMaskAmount, time, i) / 100.0f;
-            connect_float_texture(shader_group.ref(), name, asf::format("MaskColor_{0}", layer_index).c_str(), tex, mask_amount);
-            shader_params.insert(
-                asf::format("MixAmount_{0}", layer_index).c_str(), 
-                fmt_osl_expr(1.0f));
+            connect_float_texture(
+                shader_group.ref(),
+                name,
+                asf::format("MaskColor_{0}", layer_index).c_str(),
+                tex,
+                mask_amount);
         }
-        else
-        {
-            const float mix_amount = m_pblock->GetFloat(ParamIdMaskAmount, time, i) / 100.0f;
-            shader_params.insert(
-                asf::format("MixAmount_{0}", layer_index).c_str(), fmt_osl_expr(mix_amount));
-        }
+
+        shader_params.insert(
+            asf::format("MixAmount_{0}", layer_index).c_str(), fmt_osl_expr(mask_amount));
 
         ++layer_index;
     }

--- a/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
+++ b/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
@@ -750,6 +750,18 @@ asf::auto_release_ptr<asr::Material> AppleseedDisneyMtl::create_osl_material(
     connect_float_texture(shader_group.ref(), name, "Clearcoat", m_clearcoat_texmap, m_clearcoat / 100.0f);
     connect_float_texture(shader_group.ref(), name, "ClearcoatGloss", m_clearcoat_gloss_texmap, m_clearcoat_gloss / 100.0f);
 
+    auto params = asr::ParamArray()
+        .insert("BaseColor", fmt_osl_expr(to_color3f(m_base_color)))
+        .insert("Metallic", fmt_osl_expr(m_metallic / 100.0f))
+        .insert("Specular", fmt_osl_expr(m_specular / 100.0f))
+        .insert("SpecularTint", fmt_osl_expr(m_specular_tint / 100.0f))
+        .insert("Roughness", fmt_osl_expr(m_roughness / 100.0f))
+        .insert("Sheen", fmt_osl_expr(m_sheen / 100.0f))
+        .insert("SheenTint", fmt_osl_expr(m_sheen_tint / 100.0f))
+        .insert("Anisotropic", fmt_osl_expr(m_anisotropy))
+        .insert("Clearcoat", fmt_osl_expr(m_clearcoat / 100.0f))
+        .insert("ClearcoatGloss", fmt_osl_expr(m_clearcoat_gloss / 100.0f));
+
     if (m_bump_texmap != nullptr)
     {
         if (m_bump_method == 0)
@@ -764,7 +776,7 @@ asf::auto_release_ptr<asr::Material> AppleseedDisneyMtl::create_osl_material(
         }
     }
 
-    shader_group->add_shader("surface", "as_max_disney_material", name, asr::ParamArray());
+    shader_group->add_shader("surface", "as_max_disney_material", name, params);
 
     std::string closure2surface_name = asf::format("{0}_closure2surface", name);
     shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());

--- a/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
+++ b/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
@@ -766,16 +766,16 @@ asf::auto_release_ptr<asr::Material> AppleseedDisneyMtl::create_osl_material(
 
     shader_group->add_shader("surface", "as_max_disney_material", name, 
         asr::ParamArray()
-        .insert("BaseColor", fmt_osl_expr(to_color3f(m_base_color)))
-        .insert("Metallic", fmt_osl_expr(m_metallic / 100.0f))
-        .insert("Specular", fmt_osl_expr(m_specular / 100.0f))
-        .insert("SpecularTint", fmt_osl_expr(m_specular_tint / 100.0f))
-        .insert("Roughness", fmt_osl_expr(m_roughness / 100.0f))
-        .insert("Sheen", fmt_osl_expr(m_sheen / 100.0f))
-        .insert("SheenTint", fmt_osl_expr(m_sheen_tint / 100.0f))
-        .insert("Anisotropic", fmt_osl_expr(m_anisotropy))
-        .insert("Clearcoat", fmt_osl_expr(m_clearcoat / 100.0f))
-        .insert("ClearcoatGloss", fmt_osl_expr(m_clearcoat_gloss / 100.0f)));
+            .insert("BaseColor", fmt_osl_expr(to_color3f(m_base_color)))
+            .insert("Metallic", fmt_osl_expr(m_metallic / 100.0f))
+            .insert("Specular", fmt_osl_expr(m_specular / 100.0f))
+            .insert("SpecularTint", fmt_osl_expr(m_specular_tint / 100.0f))
+            .insert("Roughness", fmt_osl_expr(m_roughness / 100.0f))
+            .insert("Sheen", fmt_osl_expr(m_sheen / 100.0f))
+            .insert("SheenTint", fmt_osl_expr(m_sheen_tint / 100.0f))
+            .insert("Anisotropic", fmt_osl_expr(m_anisotropy))
+            .insert("Clearcoat", fmt_osl_expr(m_clearcoat / 100.0f))
+            .insert("ClearcoatGloss", fmt_osl_expr(m_clearcoat_gloss / 100.0f)));
 
     std::string closure2surface_name = asf::format("{0}_closure2surface", name);
     shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());

--- a/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
+++ b/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
@@ -750,18 +750,6 @@ asf::auto_release_ptr<asr::Material> AppleseedDisneyMtl::create_osl_material(
     connect_float_texture(shader_group.ref(), name, "Clearcoat", m_clearcoat_texmap, m_clearcoat / 100.0f);
     connect_float_texture(shader_group.ref(), name, "ClearcoatGloss", m_clearcoat_gloss_texmap, m_clearcoat_gloss / 100.0f);
 
-    auto params = asr::ParamArray()
-        .insert("BaseColor", fmt_osl_expr(to_color3f(m_base_color)))
-        .insert("Metallic", fmt_osl_expr(m_metallic / 100.0f))
-        .insert("Specular", fmt_osl_expr(m_specular / 100.0f))
-        .insert("SpecularTint", fmt_osl_expr(m_specular_tint / 100.0f))
-        .insert("Roughness", fmt_osl_expr(m_roughness / 100.0f))
-        .insert("Sheen", fmt_osl_expr(m_sheen / 100.0f))
-        .insert("SheenTint", fmt_osl_expr(m_sheen_tint / 100.0f))
-        .insert("Anisotropic", fmt_osl_expr(m_anisotropy))
-        .insert("Clearcoat", fmt_osl_expr(m_clearcoat / 100.0f))
-        .insert("ClearcoatGloss", fmt_osl_expr(m_clearcoat_gloss / 100.0f));
-
     if (m_bump_texmap != nullptr)
     {
         if (m_bump_method == 0)
@@ -776,7 +764,18 @@ asf::auto_release_ptr<asr::Material> AppleseedDisneyMtl::create_osl_material(
         }
     }
 
-    shader_group->add_shader("surface", "as_max_disney_material", name, params);
+    shader_group->add_shader("surface", "as_max_disney_material", name, 
+        asr::ParamArray()
+        .insert("BaseColor", fmt_osl_expr(to_color3f(m_base_color)))
+        .insert("Metallic", fmt_osl_expr(m_metallic / 100.0f))
+        .insert("Specular", fmt_osl_expr(m_specular / 100.0f))
+        .insert("SpecularTint", fmt_osl_expr(m_specular_tint / 100.0f))
+        .insert("Roughness", fmt_osl_expr(m_roughness / 100.0f))
+        .insert("Sheen", fmt_osl_expr(m_sheen / 100.0f))
+        .insert("SheenTint", fmt_osl_expr(m_sheen_tint / 100.0f))
+        .insert("Anisotropic", fmt_osl_expr(m_anisotropy))
+        .insert("Clearcoat", fmt_osl_expr(m_clearcoat / 100.0f))
+        .insert("ClearcoatGloss", fmt_osl_expr(m_clearcoat_gloss / 100.0f)));
 
     std::string closure2surface_name = asf::format("{0}_closure2surface", name);
     shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());

--- a/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.cpp
+++ b/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.cpp
@@ -683,15 +683,15 @@ asf::auto_release_ptr<asr::Material> AppleseedGlassMtl::create_osl_material(
 
     shader_group->add_shader("surface", "as_max_glass_material", name, 
         asr::ParamArray()
-        .insert("SurfaceTransmittance", fmt_osl_expr(to_color3f(m_surface_color)))
-        .insert("ReflectionTint", fmt_osl_expr(to_color3f(m_reflection_tint)))
-        .insert("RefractionTint", fmt_osl_expr(to_color3f(m_refraction_tint)))
-        .insert("VolumeTransmittance", fmt_osl_expr(to_color3f(m_volume_color)))
-        .insert("Roughness", fmt_osl_expr(m_roughness / 100.0f))
-        .insert("Anisotropic", fmt_osl_expr(m_anisotropy / 100.0f))
-        .insert("Ior", fmt_osl_expr(m_ior))
-        .insert("VolumeTransmittanceDistance", fmt_osl_expr(m_scale))
-        .insert("Distribution", fmt_osl_expr("ggx")));
+            .insert("SurfaceTransmittance", fmt_osl_expr(to_color3f(m_surface_color)))
+            .insert("ReflectionTint", fmt_osl_expr(to_color3f(m_reflection_tint)))
+            .insert("RefractionTint", fmt_osl_expr(to_color3f(m_refraction_tint)))
+            .insert("VolumeTransmittance", fmt_osl_expr(to_color3f(m_volume_color)))
+            .insert("Roughness", fmt_osl_expr(m_roughness / 100.0f))
+            .insert("Anisotropic", fmt_osl_expr(m_anisotropy / 100.0f))
+            .insert("Ior", fmt_osl_expr(m_ior))
+            .insert("VolumeTransmittanceDistance", fmt_osl_expr(m_scale))
+            .insert("Distribution", fmt_osl_expr("ggx")));
 
     std::string closure2surface_name = asf::format("{0}_closure2surface", name);
     shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());

--- a/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.cpp
+++ b/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.cpp
@@ -511,8 +511,8 @@ asf::auto_release_ptr<asr::Material> AppleseedLightMtl::create_osl_material(
     
     shader_group->add_shader("surface", "as_max_light_material", name, 
         asr::ParamArray()
-        .insert("Color", fmt_osl_expr(to_color3f(m_light_color)))
-        .insert("Emission", fmt_osl_expr(m_light_power)));
+            .insert("Color", fmt_osl_expr(to_color3f(m_light_color)))
+            .insert("Emission", fmt_osl_expr(m_light_power)));
 
     std::string closure2surface_name = asf::format("{0}_closure2surface", name);
     shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());

--- a/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.cpp
+++ b/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.cpp
@@ -504,15 +504,15 @@ asf::auto_release_ptr<asr::Material> AppleseedLightMtl::create_osl_material(
     //
     // Shader group.
     //
-    asr::ParamArray shader_params;
-
     auto shader_group_name = make_unique_name(assembly.shader_groups(), std::string(name) + "_shader_group");
     auto shader_group = asr::ShaderGroupFactory::create(shader_group_name.c_str());
 
     connect_color_texture(shader_group.ref(), name, "Color", m_light_color_texmap, m_light_color);
-    shader_params.insert("Emission", fmt_osl_expr(m_light_power));
     
-    shader_group->add_shader("surface", "as_max_light_material", name, shader_params);
+    shader_group->add_shader("surface", "as_max_light_material", name, 
+        asr::ParamArray()
+        .insert("Color", fmt_osl_expr(to_color3f(m_light_color)))
+        .insert("Emission", fmt_osl_expr(m_light_power)));
 
     std::string closure2surface_name = asf::format("{0}_closure2surface", name);
     shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());

--- a/src/appleseed-max-impl/appleseedmetalmtl/appleseedmetalmtl.cpp
+++ b/src/appleseed-max-impl/appleseedmetalmtl/appleseedmetalmtl.cpp
@@ -660,7 +660,13 @@ asf::auto_release_ptr<asr::Material> AppleseedMetalMtl::create_osl_material(
         }
     }
 
-    shader_group->add_shader("surface", "as_max_metal_material", name, asr::ParamArray());
+    shader_group->add_shader("surface", "as_max_metal_material", name, 
+        asr::ParamArray()
+        .insert("NormalReflectance", fmt_osl_expr(to_color3f(m_facing_tint_color)))
+        .insert("EdgeTint", fmt_osl_expr(to_color3f(m_edge_tint_color)))
+        .insert("Reflectance", fmt_osl_expr(m_reflectance / 100.0f))
+        .insert("Roughness", fmt_osl_expr(m_roughness / 100.0f))
+        .insert("Anisotropic", fmt_osl_expr(m_anisotropy)));
 
     std::string closure2surface_name = asf::format("{0}_closure2surface", name);
     shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());

--- a/src/appleseed-max-impl/appleseedmetalmtl/appleseedmetalmtl.cpp
+++ b/src/appleseed-max-impl/appleseedmetalmtl/appleseedmetalmtl.cpp
@@ -662,11 +662,11 @@ asf::auto_release_ptr<asr::Material> AppleseedMetalMtl::create_osl_material(
 
     shader_group->add_shader("surface", "as_max_metal_material", name, 
         asr::ParamArray()
-        .insert("NormalReflectance", fmt_osl_expr(to_color3f(m_facing_tint_color)))
-        .insert("EdgeTint", fmt_osl_expr(to_color3f(m_edge_tint_color)))
-        .insert("Reflectance", fmt_osl_expr(m_reflectance / 100.0f))
-        .insert("Roughness", fmt_osl_expr(m_roughness / 100.0f))
-        .insert("Anisotropic", fmt_osl_expr(m_anisotropy)));
+            .insert("NormalReflectance", fmt_osl_expr(to_color3f(m_facing_tint_color)))
+            .insert("EdgeTint", fmt_osl_expr(to_color3f(m_edge_tint_color)))
+            .insert("Reflectance", fmt_osl_expr(m_reflectance / 100.0f))
+            .insert("Roughness", fmt_osl_expr(m_roughness / 100.0f))
+            .insert("Anisotropic", fmt_osl_expr(m_anisotropy)));
 
     std::string closure2surface_name = asf::format("{0}_closure2surface", name);
     shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());

--- a/src/appleseed-max-impl/appleseedoslplugin/oslmaterial.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslmaterial.cpp
@@ -511,27 +511,30 @@ asf::auto_release_ptr<asr::Material> OSLMaterial::create_osl_material(
             GetParamBlock(0)->GetValue(max_param.m_max_param_id + 1, t, texmap, FOREVER);
             if (texmap != nullptr)
             {
+                float output_amount = get_output_amount(texmap, t);
                 switch (max_param.m_param_type)
                 {
                   case MaxParam::Float:
                     {
+                        float constant_value = GetParamBlock(0)->GetFloat(max_param.m_max_param_id, t);
                         connect_float_texture(
                             shader_group.ref(),
                             name,
                             max_param.m_osl_param_name.c_str(),
                             texmap,
-                            GetParamBlock(0)->GetFloat(max_param.m_max_param_id, t));
+                            asf::mix(constant_value, 1.0f, output_amount));
                     }
                     break;
-
                   case MaxParam::Color:
                     {
+                        Color constant_color = GetParamBlock(0)->GetColor(max_param.m_max_param_id, t);
+                        auto mix_amount = asf::mix(to_color3f(constant_color), asf::Color3f(1.0f), output_amount);
                         connect_color_texture(
                             shader_group.ref(),
                             name,
                             max_param.m_osl_param_name.c_str(),
                             texmap,
-                            GetParamBlock(0)->GetColor(max_param.m_max_param_id, t));
+                            Color(mix_amount.r, mix_amount.g, mix_amount.b));
                     }
                     break;
 

--- a/src/appleseed-max-impl/appleseedoslplugin/oslmaterial.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslmaterial.cpp
@@ -528,13 +528,12 @@ asf::auto_release_ptr<asr::Material> OSLMaterial::create_osl_material(
                   case MaxParam::Color:
                     {
                         Color constant_color = GetParamBlock(0)->GetColor(max_param.m_max_param_id, t);
-                        auto mix_amount = asf::mix(to_color3f(constant_color), asf::Color3f(1.0f), output_amount);
                         connect_color_texture(
                             shader_group.ref(),
                             name,
                             max_param.m_osl_param_name.c_str(),
                             texmap,
-                            Color(mix_amount.r, mix_amount.g, mix_amount.b));
+                            constant_color);
                     }
                     break;
 

--- a/src/appleseed-max-impl/appleseedoslplugin/oslmaterial.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslmaterial.cpp
@@ -87,8 +87,8 @@ OSLMaterial::OSLMaterial(Class_ID class_id, OSLPluginClassDesc* class_desc)
     m_texture_id_map = m_shader_info->m_texture_id_map;
     m_submaterial_map = m_shader_info->m_material_id_map;
     
-    auto tn_vec = m_shader_info->find_param("Tn");
-    m_has_bump_params = tn_vec != nullptr;
+    m_has_bump_params = m_shader_info->find_maya_attribute("normalCamera") != nullptr;
+    m_has_normal_params = m_shader_info->find_param("Tn") != nullptr;
 
     class_desc->MakeAutoParamBlocks(this);
     Reset();
@@ -635,18 +635,17 @@ asf::auto_release_ptr<asr::Material> OSLMaterial::create_osl_material(
                 get_paramblock_value_by_name(bump_param_block, L"bump_amount", t, bump_amount, FOREVER);
                 get_paramblock_value_by_name(bump_param_block, L"bump_up_vector", t, bump_up_vector, FOREVER);
 
-                const char* bump_input = m_shader_info->find_param("in_bump_normal_substrate") != nullptr ?
-                    "in_bump_normal_substrate" : "in_bump_normal";
+                const auto* bump_param = m_shader_info->find_maya_attribute("normalCamera");
 
                 if (bump_method == 0)
                 {
                     // Bump mapping.
-                    connect_bump_map(shader_group.ref(), name, bump_input, "Tn", bump_texmap, bump_amount);
+                    connect_bump_map(shader_group.ref(), name, bump_param->m_param_name.c_str(), "Tn", bump_texmap, bump_amount);
                 }
-                else
+                else if (m_has_normal_params)
                 {
                     // Normal mapping.
-                    connect_normal_map(shader_group.ref(), name, bump_input, "Tn", bump_texmap, bump_up_vector);
+                    connect_normal_map(shader_group.ref(), name, bump_param->m_param_name.c_str(), "Tn", bump_texmap, bump_up_vector);
                 }
             }
         }

--- a/src/appleseed-max-impl/appleseedoslplugin/oslmaterial.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslmaterial.cpp
@@ -522,7 +522,7 @@ asf::auto_release_ptr<asr::Material> OSLMaterial::create_osl_material(
                             name,
                             max_param.m_osl_param_name.c_str(),
                             texmap,
-                            asf::mix(constant_value, 1.0f, output_amount));
+                            constant_value);
                     }
                     break;
                   case MaxParam::Color:

--- a/src/appleseed-max-impl/appleseedoslplugin/oslmaterial.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslmaterial.h
@@ -135,6 +135,7 @@ class OSLMaterial
     Class_ID                m_classid;
     OSLPluginClassDesc*     m_class_desc;
     bool                    m_has_bump_params;
+    bool                    m_has_normal_params;
     Interval                m_params_validity;
     IParamBlock2*           m_pblock;
     IParamBlock2*           m_bump_pblock;

--- a/src/appleseed-max-impl/appleseedoslplugin/oslparamdlg.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslparamdlg.cpp
@@ -217,7 +217,7 @@ void OSLParamDlg::create_dialog()
     {
         if (osl_param.m_page != "" &&
             osl_param.m_widget != "null" &&
-            !osl_param.max_hidden_attr)
+            !osl_param.m_max_hidden_attr)
         {
             const int param_height = osl_param.m_max_param.m_param_type == MaxParam::IntMapper ||
                 osl_param.m_max_param.m_param_type == MaxParam::StringPopup ? 15 : 12;
@@ -249,7 +249,7 @@ void OSLParamDlg::create_dialog()
     for (auto& osl_param : m_shader_info->m_params)
     {
         if (osl_param.m_widget != "null" &&
-            !osl_param.max_hidden_attr)
+            !osl_param.m_max_hidden_attr)
             add_ui_parameter(dialogTemplate, osl_param.m_max_param, pages);
     }
 
@@ -270,8 +270,7 @@ void OSLParamDlg::create_dialog()
     auto bump_normal = m_shader_info->find_maya_attribute("normalCamera");
 
     if (!m_shader_info->m_is_texture &&
-        (tn_vec != nullptr ||
-        bump_normal != nullptr))
+        (tn_vec != nullptr || bump_normal != nullptr))
     {
         m_bump_pmap = CreateMParamMap2(
             m_osl_plugin->GetParamBlock(1),

--- a/src/appleseed-max-impl/appleseedoslplugin/oslparamdlg.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslparamdlg.cpp
@@ -267,8 +267,11 @@ void OSLParamDlg::create_dialog()
         0);
 
     auto tn_vec = m_shader_info->find_param("Tn");
-    
-    if (!m_shader_info->m_is_texture && tn_vec != nullptr)
+    auto bump_normal = m_shader_info->find_maya_attribute("normalCamera");
+
+    if (!m_shader_info->m_is_texture &&
+        (tn_vec != nullptr ||
+        bump_normal != nullptr))
     {
         m_bump_pmap = CreateMParamMap2(
             m_osl_plugin->GetParamBlock(1),

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.cpp
@@ -172,6 +172,7 @@ OSLParamInfo::OSLParamInfo(const asf::Dictionary& param_info)
         m_has_soft_max = metadata.get_value("softmax", m_soft_max_value);
         metadata.get_value("divider", m_divider);
 
+        metadata.get_value("as_maya_attribute_name", m_maya_attribute_name);
         metadata.get_value("as_maya_attribute_connectable", m_connectable);
         max_hidden_attr = false;
         metadata.get_value("as_max_attribute_hidden", max_hidden_attr);
@@ -293,6 +294,17 @@ const OSLParamInfo* OSLShaderInfo::find_param(const char* param_name) const
     for (size_t i = 0, e = m_params.size(); i < e; ++i)
     {
         if (m_params[i].m_param_name == param_name)
+            return &m_params[i];
+    }
+
+    return nullptr;
+}
+
+const OSLParamInfo* OSLShaderInfo::find_maya_attribute(const char* attr_name) const
+{
+    for (size_t i = 0, e = m_params.size(); i < e; ++i)
+    {
+        if (m_params[i].m_maya_attribute_name == attr_name)
             return &m_params[i];
     }
 

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.cpp
@@ -174,8 +174,8 @@ OSLParamInfo::OSLParamInfo(const asf::Dictionary& param_info)
 
         metadata.get_value("as_maya_attribute_name", m_maya_attribute_name);
         metadata.get_value("as_maya_attribute_connectable", m_connectable);
-        max_hidden_attr = false;
-        metadata.get_value("as_max_attribute_hidden", max_hidden_attr);
+        m_max_hidden_attr = false;
+        metadata.get_value("as_max_attribute_hidden", m_max_hidden_attr);
     }
 }
 

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.h
@@ -161,6 +161,7 @@ class OSLParamInfo
     double m_soft_max_value;
     bool m_divider;
 
+    std::string m_maya_attribute_name;
     bool m_connectable;
     bool max_hidden_attr;
     MaxParam m_max_param;
@@ -183,6 +184,7 @@ class OSLShaderInfo
         const std::string               filename);
 
     const OSLParamInfo* find_param(const char* param_name) const;
+    const OSLParamInfo* find_maya_attribute(const char* param_name) const;
 
     Class_ID                    m_class_id;
     bool                        m_is_texture;

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.h
@@ -163,7 +163,7 @@ class OSLParamInfo
 
     std::string m_maya_attribute_name;
     bool m_connectable;
-    bool max_hidden_attr;
+    bool m_max_hidden_attr;
     MaxParam m_max_param;
 };
 

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshaderregistry.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshaderregistry.cpp
@@ -466,8 +466,11 @@ void OSLShaderRegistry::create_class_descriptors()
             string_id);
 
         auto tn_vec = shader.find_param("Tn");
+        auto bump_normal = shader.find_maya_attribute("normalCamera");
 
-        if (!shader.m_is_texture && tn_vec != nullptr)
+        if (!shader.m_is_texture && 
+            (tn_vec != nullptr || 
+            bump_normal != nullptr))
         {
             ParamBlockDesc2* bump_param_block_descr(new ParamBlockDesc2(
                 // --- Required arguments ---

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshaderregistry.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshaderregistry.cpp
@@ -100,9 +100,9 @@ namespace
     }
 
     class TextureAccessorShort
-        : public PBAccessor
+      : public PBAccessor
     {
-    public:
+      public:
         void Set(
             PB2Value&         v,
             ReferenceMaker*   owner,
@@ -496,8 +496,7 @@ void OSLShaderRegistry::create_class_descriptors()
         auto bump_normal = shader.find_maya_attribute("normalCamera");
 
         if (!shader.m_is_texture && 
-            (tn_vec != nullptr || 
-            bump_normal != nullptr))
+            (tn_vec != nullptr || bump_normal != nullptr))
         {
             ParamBlockDesc2* bump_param_block_descr(new ParamBlockDesc2(
                 // --- Required arguments ---

--- a/src/appleseed-max-impl/appleseedoslplugin/osltexture.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/osltexture.cpp
@@ -86,8 +86,9 @@ OSLTexture::OSLTexture(Class_ID class_id, OSLPluginClassDesc* class_desc)
     m_shader_info = m_class_desc->m_shader_info;
     m_texture_id_map = m_shader_info->m_texture_id_map;
 
-    m_has_uv_coords = m_shader_info->find_param("in_uvCoord") != nullptr;
-    m_has_xyz_coords = m_shader_info->find_param("in_placementMatrix") != nullptr;
+    m_has_uv_coords = m_shader_info->find_maya_attribute("uvCoord") != nullptr && 
+        m_shader_info->find_maya_attribute("uvFilterSize") != nullptr;
+    m_has_xyz_coords = m_shader_info->find_maya_attribute("placementMatrix") != nullptr;
     m_class_desc->MakeAutoParamBlocks(this);
     Reset();
 }
@@ -536,13 +537,16 @@ void OSLTexture::create_osl_texture(
         auto uv_transform_layer_name = asf::format("{0}_{1}_uv_transform", material_node_name, material_input_name);
         shader_group.add_shader("shader", "as_max_uv_transform", uv_transform_layer_name.c_str(), get_uv_params(this));
 
+        auto* uv_coord_input = m_shader_info->find_maya_attribute("uvCoord");
+        auto* uv_filter_input = m_shader_info->find_maya_attribute("uvFilterSize");
+
         shader_group.add_connection(
             uv_transform_layer_name.c_str(), "out_outUV",
-            layer_name.c_str(), "in_uvCoord");
+            layer_name.c_str(), uv_coord_input->m_param_name.c_str());
 
         shader_group.add_connection(
             uv_transform_layer_name.c_str(), "out_outUvFilterSize",
-            layer_name.c_str(), "in_uvFilterSize");
+            layer_name.c_str(), uv_filter_input->m_param_name.c_str());
     }
 
     shader_group.add_shader("shader", m_shader_info->m_shader_name.c_str(), layer_name.c_str(), params);

--- a/src/appleseed-max-impl/appleseedoslplugin/osltexture.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/osltexture.cpp
@@ -86,7 +86,8 @@ OSLTexture::OSLTexture(Class_ID class_id, OSLPluginClassDesc* class_desc)
     m_shader_info = m_class_desc->m_shader_info;
     m_texture_id_map = m_shader_info->m_texture_id_map;
 
-    m_has_uv_coords = m_shader_info->find_maya_attribute("uvCoord") != nullptr && 
+    m_has_uv_coords = 
+        m_shader_info->find_maya_attribute("uvCoord") != nullptr && 
         m_shader_info->find_maya_attribute("uvFilterSize") != nullptr;
     m_has_xyz_coords = m_shader_info->find_maya_attribute("placementMatrix") != nullptr;
     m_class_desc->MakeAutoParamBlocks(this);
@@ -443,7 +444,6 @@ void OSLTexture::create_osl_texture(
         m_pblock,
         m_shader_info);
 
-    //TODO: Choose right type of output based on expected input type.
     int output_slot_index = GetParamBlock(0)->GetInt(m_shader_info->m_output_param.m_max_param_id);
     shader_group.add_connection(
         layer_name.c_str(),

--- a/src/appleseed-max-impl/appleseedoslplugin/osltexture.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/osltexture.cpp
@@ -441,23 +441,25 @@ void OSLTexture::create_osl_texture(
                 {
                   case MaxParam::Float:
                     {
+                        float constant_value = GetParamBlock(0)->GetFloat(max_param.m_max_param_id, t);
                         connect_float_texture(
                             shader_group,
                             layer_name.c_str(),
                             max_param.m_osl_param_name.c_str(),
                             texmap,
-                            1.0f);
+                            constant_value);
                     }
                     break;
 
                   case MaxParam::Color:
                     {
+                        Color constant_color = GetParamBlock(0)->GetColor(max_param.m_max_param_id, t);
                         connect_color_texture(
                             shader_group,
                             layer_name.c_str(),
                             max_param.m_osl_param_name.c_str(),
                             texmap,
-                            Color(1.0f, 1.0f, 1.0f));
+                            constant_color);
                     }
                     break;
 

--- a/src/appleseed-max-impl/appleseedplasticmtl/appleseedplasticmtl.cpp
+++ b/src/appleseed-max-impl/appleseedplasticmtl/appleseedplasticmtl.cpp
@@ -683,11 +683,11 @@ asf::auto_release_ptr<asr::Material> AppleseedPlasticMtl::create_osl_material(
 
     shader_group->add_shader("surface", "as_max_plastic_material", name, 
         asr::ParamArray()
-        .insert("SpecularWeight", fmt_osl_expr(m_specular_weight / 100.0f))
-        .insert("DiffuseWeight", fmt_osl_expr(m_diffuse_weight / 100.0f))
-        .insert("Spread", fmt_osl_expr(m_highlight_falloff / 100.0f))
-        .insert("Scattering", fmt_osl_expr(m_scattering / 100.0f))
-        .insert("IOR", fmt_osl_expr(m_ior)));
+            .insert("SpecularWeight", fmt_osl_expr(m_specular_weight / 100.0f))
+            .insert("DiffuseWeight", fmt_osl_expr(m_diffuse_weight / 100.0f))
+            .insert("Spread", fmt_osl_expr(m_highlight_falloff / 100.0f))
+            .insert("Scattering", fmt_osl_expr(m_scattering / 100.0f))
+            .insert("IOR", fmt_osl_expr(m_ior)));
 
     std::string closure2surface_name = asf::format("{0}_closure2surface", name);
     shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());

--- a/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
+++ b/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
@@ -703,17 +703,17 @@ asf::auto_release_ptr<asr::Material> AppleseedSSSMtl::create_osl_material(
 
     shader_group->add_shader("surface", "as_max_sss_material", name, 
         asr::ParamArray()
-        .insert("Radius", fmt_osl_expr(to_color3f(m_sss_scattering_color)))
-        .insert("SSSColor", fmt_osl_expr(to_color3f(m_sss_color)))
-        .insert("SpecularColor", fmt_osl_expr(to_color3f(m_specular_color)))
-        .insert("SpecularReflectance", fmt_osl_expr(m_specular_amount / 100.0f))
-        .insert("Roughness", fmt_osl_expr(m_specular_roughness / 100.0f))
-        .insert("Anisotropic", fmt_osl_expr(m_specular_anisotropy / 100.0f))
-        .insert("RadiusScale", fmt_osl_expr(m_sss_scale))
-        .insert("Profile", fmt_osl_expr("normalized_diffusion"))
-        .insert("SSSReflectance", fmt_osl_expr(m_sss_amount / 100.0f))
-        .insert("Distribution", fmt_osl_expr("ggx"))
-        .insert("Ior", fmt_osl_expr(m_sss_ior)));
+            .insert("Radius", fmt_osl_expr(to_color3f(m_sss_scattering_color)))
+            .insert("SSSColor", fmt_osl_expr(to_color3f(m_sss_color)))
+            .insert("SpecularColor", fmt_osl_expr(to_color3f(m_specular_color)))
+            .insert("SpecularReflectance", fmt_osl_expr(m_specular_amount / 100.0f))
+            .insert("Roughness", fmt_osl_expr(m_specular_roughness / 100.0f))
+            .insert("Anisotropic", fmt_osl_expr(m_specular_anisotropy / 100.0f))
+            .insert("RadiusScale", fmt_osl_expr(m_sss_scale))
+            .insert("Profile", fmt_osl_expr("normalized_diffusion"))
+            .insert("SSSReflectance", fmt_osl_expr(m_sss_amount / 100.0f))
+            .insert("Distribution", fmt_osl_expr("ggx"))
+            .insert("Ior", fmt_osl_expr(m_sss_ior)));
 
     std::string closure2surface_name = asf::format("{0}_closure2surface", name);
     shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());

--- a/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
+++ b/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
@@ -673,7 +673,6 @@ asf::auto_release_ptr<asr::Material> AppleseedSSSMtl::create_osl_material(
     //
     // Shader group.
     //
-    asr::ParamArray shader_params;
 
     auto shader_group_name = make_unique_name(assembly.shader_groups(), std::string(name) + "_shader_group");
     auto shader_group = asr::ShaderGroupFactory::create(shader_group_name.c_str());
@@ -681,18 +680,12 @@ asf::auto_release_ptr<asr::Material> AppleseedSSSMtl::create_osl_material(
     // BSSRDF.
     connect_color_texture(shader_group.ref(), name, "Radius", m_sss_scattering_color_texmap, m_sss_scattering_color);
     connect_color_texture(shader_group.ref(), name, "SSSColor", m_sss_color_texmap, m_sss_color);
-    shader_params.insert("RadiusScale", fmt_osl_expr(m_sss_scale));
-    shader_params.insert("Profile", fmt_osl_expr("normalized_diffusion"));
-    shader_params.insert("SSSReflectance", fmt_osl_expr(m_sss_amount / 100.0f));
     
     // BRDF.
     connect_color_texture(shader_group.ref(), name, "SpecularColor", m_specular_color_texmap, m_specular_color);
     connect_float_texture(shader_group.ref(), name, "SpecularReflectance", m_specular_amount_texmap, m_specular_amount / 100.0f);
     connect_float_texture(shader_group.ref(), name, "Roughness", m_specular_roughness_texmap, m_specular_roughness / 100.0f);
     connect_float_texture(shader_group.ref(), name, "Anisotropic", m_specular_anisotropy_texmap, m_specular_anisotropy / 100.0f);
-    shader_params.insert("Distribution", fmt_osl_expr("ggx"));
-
-    shader_params.insert("Ior", fmt_osl_expr(m_sss_ior));
 
     if (m_bump_texmap != nullptr)
     {
@@ -708,7 +701,19 @@ asf::auto_release_ptr<asr::Material> AppleseedSSSMtl::create_osl_material(
         }
     }
 
-    shader_group->add_shader("surface", "as_max_sss_material", name, shader_params);
+    shader_group->add_shader("surface", "as_max_sss_material", name, 
+        asr::ParamArray()
+        .insert("Radius", fmt_osl_expr(to_color3f(m_sss_scattering_color)))
+        .insert("SSSColor", fmt_osl_expr(to_color3f(m_sss_color)))
+        .insert("SpecularColor", fmt_osl_expr(to_color3f(m_specular_color)))
+        .insert("SpecularReflectance", fmt_osl_expr(m_specular_amount / 100.0f))
+        .insert("Roughness", fmt_osl_expr(m_specular_roughness / 100.0f))
+        .insert("Anisotropic", fmt_osl_expr(m_specular_anisotropy / 100.0f))
+        .insert("RadiusScale", fmt_osl_expr(m_sss_scale))
+        .insert("Profile", fmt_osl_expr("normalized_diffusion"))
+        .insert("SSSReflectance", fmt_osl_expr(m_sss_amount / 100.0f))
+        .insert("Distribution", fmt_osl_expr("ggx"))
+        .insert("Ior", fmt_osl_expr(m_sss_ior)));
 
     std::string closure2surface_name = asf::format("{0}_closure2surface", name);
     shader_group.ref().add_shader("shader", "as_max_closure2surface", closure2surface_name.c_str(), asr::ParamArray());

--- a/src/appleseed-max-impl/builtinmapsupport.cpp
+++ b/src/appleseed-max-impl/builtinmapsupport.cpp
@@ -1,0 +1,95 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Sergo Pogosyan, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// Interface header.
+#include "builtinmapsupport.h"
+
+// appleseed-max headers.
+#include "oslutils.h"
+#include "utilities.h"
+
+// appleseed.renderer headers.
+#include "renderer/api/shadergroup.h"
+#include "renderer/api/utility.h"
+
+// 3ds Max Headers.
+#include <imtl.h>
+#include <maxtypes.h>
+
+namespace asf = foundation;
+namespace asr = renderer;
+
+void connect_output_map(
+    renderer::ShaderGroup&  shader_group,
+    const char*             material_node_name,
+    const char*             material_input_name,
+    Texmap*                 texmap,
+    const Color             const_value)
+{
+    const auto t = GetCOREInterface()->GetTime();
+    auto color_balance_layer_name = foundation::format("{0}_{1}_color_balance", material_node_name, material_input_name);
+
+    Texmap* input_map = nullptr;
+    get_paramblock_value_by_name(texmap->GetParamBlock(0), L"map1", t, input_map, FOREVER);
+
+    connect_color_texture(shader_group, color_balance_layer_name.c_str(), "in_defaultColor", input_map, Color(1.0, 1.0, 1.0));
+
+    renderer::ParamArray output_params = get_output_params(texmap)
+        .insert("in_constantColor", fmt_osl_expr(to_color3f(const_value)));
+
+    shader_group.add_shader("shader", "as_max_color_balance", color_balance_layer_name.c_str(), output_params);
+
+    shader_group.add_connection(
+        color_balance_layer_name.c_str(), "out_outColor",
+        material_node_name, material_input_name);
+}
+
+void connect_output_map(
+    renderer::ShaderGroup&  shader_group,
+    const char*             material_node_name,
+    const char*             material_input_name,
+    Texmap*                 texmap,
+    const float             const_value)
+{
+    const auto t = GetCOREInterface()->GetTime();
+    auto color_balance_layer_name = foundation::format("{0}_{1}_color_balance", material_node_name, material_input_name);
+
+    Texmap* input_map = nullptr;
+    get_paramblock_value_by_name(texmap->GetParamBlock(0), L"map1", t, input_map, FOREVER);
+
+    connect_float_texture(shader_group, color_balance_layer_name.c_str(), "in_defaultFloat", input_map, 1.0f);
+
+    renderer::ParamArray output_params = get_output_params(texmap)
+        .insert("in_constantFloat", fmt_osl_expr(const_value));
+
+    shader_group.add_shader("shader", "as_max_color_balance", color_balance_layer_name.c_str(), output_params);
+
+    shader_group.add_connection(
+        color_balance_layer_name.c_str(), "out_outAlpha",
+        material_node_name, material_input_name);
+}

--- a/src/appleseed-max-impl/builtinmapsupport.cpp
+++ b/src/appleseed-max-impl/builtinmapsupport.cpp
@@ -39,7 +39,6 @@
 
 // 3ds Max Headers.
 #include <imtl.h>
-#include <maxtypes.h>
 
 namespace asf = foundation;
 namespace asr = renderer;

--- a/src/appleseed-max-impl/builtinmapsupport.h
+++ b/src/appleseed-max-impl/builtinmapsupport.h
@@ -1,0 +1,84 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Sergo Pogosyan, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+// appleseed.foundation headers.
+#include "foundation/platform/windows.h"    // include before 3ds Max headers
+#include "foundation/image/color.h"
+
+// 3ds Max Headers.
+#include <color.h>
+#include <maxtypes.h>
+
+// Standard headers.
+#include <string>
+
+// Forward declarations.
+namespace renderer { class ShaderGroup; }
+class Texmap;
+
+void connect_output_map(
+    renderer::ShaderGroup&  shader_group,
+    const char*             material_node_name,
+    const char*             material_input_name,
+    Texmap*                 texmap,
+    const Color             const_value);
+
+void connect_output_map(
+    renderer::ShaderGroup&  shader_group,
+    const char*             material_node_name,
+    const char*             material_input_name,
+    Texmap*                 texmap,
+    const float             const_value);
+
+template<typename T>
+void create_supported_texture(
+    renderer::ShaderGroup&  shader_group,
+    const char*             material_node_name,
+    const char*             material_input_name,
+    Texmap*                 texmap,
+    const T                 const_value)
+{
+    auto part_a = texmap->ClassID().PartA();
+    auto part_b = texmap->ClassID().PartB();
+
+    switch (part_a)
+    {
+      case OUTPUT_CLASS_ID:
+        connect_output_map(
+            shader_group,
+            material_node_name,
+            material_input_name,
+            texmap,
+            const_value);
+
+      default:
+        return;
+    }
+}

--- a/src/appleseed-max-impl/builtinmapsupport.h
+++ b/src/appleseed-max-impl/builtinmapsupport.h
@@ -57,7 +57,7 @@ void connect_output_map(
     Texmap*                 texmap,
     const float             const_value);
 
-template<typename T>
+template <typename T>
 void create_supported_texture(
     renderer::ShaderGroup&  shader_group,
     const char*             material_node_name,
@@ -79,6 +79,6 @@ void create_supported_texture(
             const_value);
 
       default:
-        return;
+        break;
     }
 }

--- a/src/appleseed-max-impl/oslutils.h
+++ b/src/appleseed-max-impl/oslutils.h
@@ -29,7 +29,11 @@
 #pragma once
 
 // appleseed.foundation headers.
+#include "foundation/platform/windows.h"    // include before 3ds Max headers
 #include "foundation/image/color.h"
+
+// 3ds Max Headers.
+#include <maxtypes.h>
 
 // Standard headers.
 #include <string>
@@ -39,7 +43,9 @@ namespace renderer { class Assembly; }
 namespace renderer { class ParamArray; }
 namespace renderer { class ShaderGroup; }
 class Color;
+class IParamBlock2;
 class Mtl;
+class OSLShaderInfo;
 class Texmap;
 
 renderer::ParamArray get_uv_params(Texmap* texmap);
@@ -55,6 +61,10 @@ std::string fmt_osl_expr(const float value);
 std::string fmt_osl_expr(const foundation::Color3f& linear_rgb);
 
 std::string fmt_osl_expr(const foundation::Vector3f& vector);
+
+std::string fmt_osl_normal_expr(const foundation::Vector3f& normal);
+
+std::string fmt_osl_point_expr(const foundation::Vector3f& point);
 
 std::string fmt_osl_expr(Texmap* texmap);
 
@@ -94,3 +104,10 @@ void connect_sub_mtl(
     const char*             shader_name,
     const char*             shader_input,
     Mtl*                    mat);
+
+void create_osl_shader(
+    renderer::Assembly*     assembly,
+    renderer::ShaderGroup&  shader_group,
+    const char*             layer_name,
+    IParamBlock2*           param_block,
+    const OSLShaderInfo*    shader_info);

--- a/src/appleseed-max-impl/oslutils.h
+++ b/src/appleseed-max-impl/oslutils.h
@@ -70,7 +70,7 @@ void connect_color_texture(
     const char*             material_node_name,
     const char*             material_input_name,
     Texmap*                 texmap,
-    const Color             multiplier);
+    const Color             constant_color);
 
 void connect_bump_map(
     renderer::ShaderGroup&  shader_group,

--- a/src/appleseed-max-impl/oslutils.h
+++ b/src/appleseed-max-impl/oslutils.h
@@ -44,6 +44,8 @@ class Texmap;
 
 renderer::ParamArray get_uv_params(Texmap* texmap);
 
+renderer::ParamArray get_output_params(Texmap* texmap);
+
 std::string fmt_osl_expr(const std::string& s);
 
 std::string fmt_osl_expr(const int value);

--- a/src/appleseed-max-impl/oslutils.h
+++ b/src/appleseed-max-impl/oslutils.h
@@ -31,6 +31,7 @@
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 #include "foundation/image/color.h"
+#include "foundation/math/vector.h"
 
 // 3ds Max Headers.
 #include <maxtypes.h>
@@ -73,14 +74,14 @@ void connect_float_texture(
     const char*             material_node_name,
     const char*             material_input_name,
     Texmap*                 texmap,
-    const float             multiplier);
+    const float             const_value);
 
 void connect_color_texture(
     renderer::ShaderGroup&  shader_group,
     const char*             material_node_name,
     const char*             material_input_name,
     Texmap*                 texmap,
-    const Color             constant_color);
+    const Color             const_color);
 
 void connect_bump_map(
     renderer::ShaderGroup&  shader_group,

--- a/src/appleseed-max-impl/utilities.cpp
+++ b/src/appleseed-max-impl/utilities.cpp
@@ -174,7 +174,7 @@ bool is_osl_texture(Texmap* map)
     return dynamic_cast<OSLTexture*>(map) != nullptr;
 }
 
-bool is_supported_procedural_texture(Texmap* map, bool osl_mode)
+bool is_supported_procedural_texture(Texmap* map, const bool use_max_procedural_maps)
 {
     if (map == nullptr)
         return false;
@@ -182,7 +182,7 @@ bool is_supported_procedural_texture(Texmap* map, bool osl_mode)
     auto part_a = map->ClassID().PartA();
     auto part_b = map->ClassID().PartB();
 
-    if (osl_mode)
+    if (!use_max_procedural_maps)
     {
         switch (part_a)
         {
@@ -308,7 +308,7 @@ std::string insert_texture_and_instance(
     asr::ParamArray texture_params,
     asr::ParamArray texture_instance_params)
 {
-    if (use_max_procedural_maps && is_supported_procedural_texture(texmap, !use_max_procedural_maps))
+    if (use_max_procedural_maps && is_supported_procedural_texture(texmap, use_max_procedural_maps))
     {
         return
             insert_procedural_texture_and_instance(

--- a/src/appleseed-max-impl/utilities.cpp
+++ b/src/appleseed-max-impl/utilities.cpp
@@ -153,6 +153,25 @@ void update_map_buttons(IParamMap2* param_map)
     }
 }
 
+float get_output_amount(Texmap* texmap, TimeValue t)
+{
+    float output_value = 1.0f;
+    for (int i = 0, e = texmap->NumRefs(); i < e; ++i)
+    {
+        ReferenceTarget* ref = texmap->GetReference(i);
+        if (ref != nullptr && ref->SuperClassID() == TEXOUTPUT_CLASS_ID)
+        {
+            StdTexoutGen* tex_output = dynamic_cast<StdTexoutGen*>(ref);
+            if (tex_output != nullptr)
+            {
+                tex_output->Update(t, FOREVER);
+                output_value = tex_output->GetOutAmt(t);
+            }
+        }
+    }
+    return output_value;
+}
+
 bool is_bitmap_texture(Texmap* map)
 {
     if (map == nullptr)

--- a/src/appleseed-max-impl/utilities.h
+++ b/src/appleseed-max-impl/utilities.h
@@ -152,7 +152,7 @@ bool is_bitmap_texture(Texmap* map);
 
 bool is_osl_texture(Texmap* map);
 
-bool is_supported_procedural_texture(Texmap* map, bool osl_mode);
+bool is_supported_procedural_texture(Texmap* map, const bool use_max_procedural_maps);
 
 bool is_linear_texture(BitmapTex* bitmap_tex);
 

--- a/src/appleseed-max-impl/utilities.h
+++ b/src/appleseed-max-impl/utilities.h
@@ -147,13 +147,12 @@ void update_map_buttons(IParamMap2* param_map);
 //
 // Bitmap functions.
 //
-float get_output_amount(Texmap* map, TimeValue t);
 
 bool is_bitmap_texture(Texmap* map);
 
 bool is_osl_texture(Texmap* map);
 
-bool is_supported_procedural_texture(Texmap* map);
+bool is_supported_procedural_texture(Texmap* map, bool osl_mode);
 
 bool is_linear_texture(BitmapTex* bitmap_tex);
 

--- a/src/appleseed-max-impl/utilities.h
+++ b/src/appleseed-max-impl/utilities.h
@@ -147,6 +147,7 @@ void update_map_buttons(IParamMap2* param_map);
 //
 // Bitmap functions.
 //
+float get_output_amount(Texmap* map, TimeValue t);
 
 bool is_bitmap_texture(Texmap* map);
 


### PR DESCRIPTION
Hi,
Here are the changes to support max_color_balance shader:
1. Support of Output rollout parameters of bitmap textures
2. Change built-in material plugins to change mixing of color and texture inputs
3. Support of Output map that can be used to change the output of OSL procedural textures

Thanks for review,
Sergo.