### PR TITLE
Reset spinner to the default value, accept output map in bump

### DIFF
--- a/src/appleseed-max-impl/oslutils.cpp
+++ b/src/appleseed-max-impl/oslutils.cpp
@@ -391,7 +391,7 @@ void connect_bump_map(
     Texmap*             texmap,
     const float         amount)
 {
-    if (is_osl_texture(texmap))
+    if (is_supported_procedural_texture(texmap, false) || is_osl_texture(texmap))
     {
         auto bump_map_layer_name = asf::format("{0}_bump_map", material_node_name);
 
@@ -453,7 +453,7 @@ void connect_normal_map(
     Texmap*             texmap,
     const int           up_vector)
 {
-    if (is_osl_texture(texmap))
+    if (is_supported_procedural_texture(texmap, false) || is_osl_texture(texmap))
     {
         auto normal_map_layer_name = asf::format("{0}_normal_map", material_node_name);
 


### PR DESCRIPTION
Hi @dictoon 
Small PR with two fixes:
1. Reset spinners of OSL plugins to the default value on right click
2. Bump map accepts Output map (and other "supported" textures in future)

Thanks,
Sergo.