### PR TITLE
Output Selector plugin

### DIFF
--- a/src/appleseed-max-impl/appleseed-max2015-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2015-impl.vcxproj
@@ -268,6 +268,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
     <ClCompile Include="appleseedlightmtl\appleseedlightmtl.cpp" />
     <ClCompile Include="logtarget.cpp" />
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="osloutputselectormap\osloutputselector.cpp" />    
     <ClCompile Include="oslutils.cpp" />
     <ClCompile Include="plugin.cpp" />
     <ClCompile Include="appleseedrenderer\appleseedrenderer.cpp" />
@@ -338,6 +339,9 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
     <ClInclude Include="appleseedsssmtl\appleseedsssmtl.h" />
     <ClInclude Include="appleseedsssmtl\datachunks.h" />
     <ClInclude Include="appleseedsssmtl\resource.h" />
+    <ClInclude Include="osloutputselectormap\datachunks.h" />
+    <ClInclude Include="osloutputselectormap\osloutputselector.h" />
+    <ClInclude Include="osloutputselectormap\resource.h" />
     <ClInclude Include="oslutils.h" />
     <ClInclude Include="seexprutils.h" />
     <ClInclude Include="utilities.h" />
@@ -355,6 +359,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
     <ResourceCompile Include="appleseedlightmtl\appleseedlightmtl.rc" />
     <ResourceCompile Include="appleseedrenderer\appleseedrenderer.rc" />
     <ResourceCompile Include="appleseedsssmtl\appleseedsssmtl.rc" />
+    <ResourceCompile Include="osloutputselectormap\osloutputselector.rc" />    
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/appleseed-max-impl/appleseed-max2015-impl.vcxproj.filters
+++ b/src/appleseed-max-impl/appleseed-max2015-impl.vcxproj.filters
@@ -94,6 +94,9 @@
       <Filter>appleseedplasticmtl</Filter>
     </ClCompile>
     <ClCompile Include="builtinmapsupport.cpp" />
+    <ClCompile Include="osloutputselectormap\osloutputselector.cpp">
+      <Filter>osloutputselectormap</Filter>
+    </ClCompile>    
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="appleseedrenderer\appleseedrenderer.h">
@@ -252,6 +255,15 @@
       <Filter>appleseedplasticmtl</Filter>
     </ClInclude>
     <ClInclude Include="builtinmapsupport.h" />
+    <ClInclude Include="osloutputselectormap\datachunks.h">
+      <Filter>osloutputselectormap</Filter>
+    </ClInclude>
+    <ClInclude Include="osloutputselectormap\osloutputselector.h">
+      <Filter>osloutputselectormap</Filter>
+    </ClInclude>
+    <ClInclude Include="osloutputselectormap\resource.h">
+      <Filter>osloutputselectormap</Filter>
+    </ClInclude>    
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="appleseedrenderer\appleseedrenderer.rc">
@@ -286,6 +298,9 @@
     </ResourceCompile>
     <ResourceCompile Include="appleseedplasticmtl\appleseedplasticmtl.rc">
       <Filter>appleseedplasticmtl</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="osloutputselectormap\osloutputselector.rc">
+      <Filter>osloutputselectormap</Filter>
     </ResourceCompile>
   </ItemGroup>
   <ItemGroup>
@@ -327,6 +342,9 @@
     </Filter>
     <Filter Include="appleseedplasticmtl">
       <UniqueIdentifier>{caf24c4c-64a6-49b1-9441-497c747c7374}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="osloutputselectormap">
+      <UniqueIdentifier>{318596f7-e094-4f52-95b8-a84b79e03602}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/src/appleseed-max-impl/appleseed-max2016-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2016-impl.vcxproj
@@ -268,6 +268,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
     <ClCompile Include="appleseedlightmtl\appleseedlightmtl.cpp" />
     <ClCompile Include="logtarget.cpp" />
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="osloutputselectormap\osloutputselector.cpp" />
     <ClCompile Include="oslutils.cpp" />
     <ClCompile Include="plugin.cpp" />
     <ClCompile Include="appleseedrenderer\appleseedrenderer.cpp" />
@@ -338,6 +339,9 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
     <ClInclude Include="appleseedsssmtl\appleseedsssmtl.h" />
     <ClInclude Include="appleseedsssmtl\datachunks.h" />
     <ClInclude Include="appleseedsssmtl\resource.h" />
+    <ClInclude Include="osloutputselectormap\datachunks.h" />
+    <ClInclude Include="osloutputselectormap\osloutputselector.h" />
+    <ClInclude Include="osloutputselectormap\resource.h" />
     <ClInclude Include="oslutils.h" />
     <ClInclude Include="seexprutils.h" />
     <ClInclude Include="utilities.h" />
@@ -355,6 +359,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
     <ResourceCompile Include="appleseedlightmtl\appleseedlightmtl.rc" />
     <ResourceCompile Include="appleseedrenderer\appleseedrenderer.rc" />
     <ResourceCompile Include="appleseedsssmtl\appleseedsssmtl.rc" />
+    <ResourceCompile Include="osloutputselectormap\osloutputselector.rc" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/appleseed-max-impl/appleseed-max2016-impl.vcxproj.filters
+++ b/src/appleseed-max-impl/appleseed-max2016-impl.vcxproj.filters
@@ -94,6 +94,9 @@
       <Filter>appleseedoslplugin</Filter>
     </ClCompile>
     <ClCompile Include="builtinmapsupport.cpp" />
+    <ClCompile Include="osloutputselectormap\osloutputselector.cpp">
+      <Filter>osloutputselectormap</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="appleseedrenderer\appleseedrenderer.h">
@@ -254,6 +257,15 @@
       <Filter>appleseedoslplugin</Filter>
     </ClInclude>
     <ClInclude Include="builtinmapsupport.h" />
+    <ClInclude Include="osloutputselectormap\datachunks.h">
+      <Filter>osloutputselectormap</Filter>
+    </ClInclude>
+    <ClInclude Include="osloutputselectormap\osloutputselector.h">
+      <Filter>osloutputselectormap</Filter>
+    </ClInclude>
+    <ClInclude Include="osloutputselectormap\resource.h">
+      <Filter>osloutputselectormap</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="appleseedrenderer\appleseedrenderer.rc">
@@ -288,6 +300,9 @@
     </ResourceCompile>
     <ResourceCompile Include="appleseedplasticmtl\appleseedplasticmtl.rc">
       <Filter>appleseedplasticmtl</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="osloutputselectormap\osloutputselector.rc">
+      <Filter>osloutputselectormap</Filter>
     </ResourceCompile>
   </ItemGroup>
   <ItemGroup>
@@ -329,6 +344,9 @@
     </Filter>
     <Filter Include="appleseedoslplugin">
       <UniqueIdentifier>{bcc045f6-90ff-4a2a-8998-855b413f2deb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="osloutputselectormap">
+      <UniqueIdentifier>{318596f7-e094-4f52-95b8-a84b79e03602}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj
@@ -264,6 +264,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
     <ClCompile Include="appleseedlightmtl\appleseedlightmtl.cpp" />
     <ClCompile Include="logtarget.cpp" />
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="osloutputselectormap\osloutputselector.cpp" />
     <ClCompile Include="oslutils.cpp" />
     <ClCompile Include="plugin.cpp" />
     <ClCompile Include="appleseedrenderer\appleseedrenderer.cpp" />
@@ -334,6 +335,9 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
     <ClInclude Include="appleseedsssmtl\appleseedsssmtl.h" />
     <ClInclude Include="appleseedsssmtl\datachunks.h" />
     <ClInclude Include="appleseedsssmtl\resource.h" />
+    <ClInclude Include="osloutputselectormap\datachunks.h" />
+    <ClInclude Include="osloutputselectormap\osloutputselector.h" />
+    <ClInclude Include="osloutputselectormap\resource.h" />    
     <ClInclude Include="oslutils.h" />
     <ClInclude Include="seexprutils.h" />
     <ClInclude Include="utilities.h" />
@@ -351,6 +355,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
     <ResourceCompile Include="appleseedlightmtl\appleseedlightmtl.rc" />
     <ResourceCompile Include="appleseedrenderer\appleseedrenderer.rc" />
     <ResourceCompile Include="appleseedsssmtl\appleseedsssmtl.rc" />
+    <ResourceCompile Include="osloutputselectormap\osloutputselector.rc" />    
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj.filters
+++ b/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj.filters
@@ -94,6 +94,9 @@
       <Filter>appleseedplasticmtl</Filter>
     </ClCompile>
     <ClCompile Include="builtinmapsupport.cpp" />
+    <ClCompile Include="osloutputselectormap\osloutputselector.cpp">
+      <Filter>osloutputselectormap</Filter>
+    </ClCompile>    
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="appleseedrenderer\appleseedrenderer.h">
@@ -252,6 +255,15 @@
       <Filter>appleseedmetalmtl</Filter>
     </ClInclude>
     <ClInclude Include="builtinmapsupport.h" />
+    <ClInclude Include="osloutputselectormap\datachunks.h">
+      <Filter>osloutputselectormap</Filter>
+    </ClInclude>
+    <ClInclude Include="osloutputselectormap\osloutputselector.h">
+      <Filter>osloutputselectormap</Filter>
+    </ClInclude>
+    <ClInclude Include="osloutputselectormap\resource.h">
+      <Filter>osloutputselectormap</Filter>
+    </ClInclude>    
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="appleseedrenderer\appleseedrenderer.rc">
@@ -286,6 +298,9 @@
     </ResourceCompile>
     <ResourceCompile Include="appleseedplasticmtl\appleseedplasticmtl.rc">
       <Filter>appleseedplasticmtl</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="osloutputselectormap\osloutputselector.rc">
+      <Filter>osloutputselectormap</Filter>
     </ResourceCompile>
   </ItemGroup>
   <ItemGroup>
@@ -327,6 +342,9 @@
     </Filter>
     <Filter Include="appleseedplasticmtl">
       <UniqueIdentifier>{209beda5-1f93-4d87-87ff-e3db75f8b79e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="osloutputselectormap">
+      <UniqueIdentifier>{318596f7-e094-4f52-95b8-a84b79e03602}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshaderregistry.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshaderregistry.cpp
@@ -381,7 +381,7 @@ namespace
     {
         pb_desc->AddParam(
             param_id,
-            L"Output",
+            L"OSLOutputIndex",
             TYPE_INT,
             0,
             string_id,

--- a/src/appleseed-max-impl/appleseedoslplugin/osltexture.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/osltexture.cpp
@@ -220,7 +220,6 @@ RefResult OSLTexture::NotifyRefChanged(
         if (hTarget == m_pblock)
             m_pblock = nullptr;
         break;
-
       case REFMSG_CHANGE:
           if (hTarget == m_pblock)
               m_class_desc->GetParamBlockDesc(0)->InvalidateUI(m_pblock->LastNotifyParamID());
@@ -416,7 +415,8 @@ UVGen* OSLTexture::GetTheUVGen()
 void OSLTexture::create_osl_texture(
     asr::ShaderGroup&   shader_group,
     const char*         material_node_name,
-    const char*         material_input_name)
+    const char*         material_input_name,
+    const int           output_slot_index)
 {
     auto layer_name = asf::format("{0}_{1}", material_node_name, material_input_name);
 
@@ -444,10 +444,32 @@ void OSLTexture::create_osl_texture(
         m_pblock,
         m_shader_info);
 
-    int output_slot_index = GetParamBlock(0)->GetInt(m_shader_info->m_output_param.m_max_param_id);
     shader_group.add_connection(
         layer_name.c_str(),
         m_shader_info->m_output_params[output_slot_index].m_param_name.c_str(),
         material_node_name,
         material_input_name);
+}
+
+void OSLTexture::create_osl_texture(
+    asr::ShaderGroup&   shader_group,
+    const char*         material_node_name,
+    const char*         material_input_name)
+{
+    const int output_slot_index = GetParamBlock(0)->GetInt(m_shader_info->m_output_param.m_max_param_id);
+    create_osl_texture(
+        shader_group,
+        material_node_name,
+        material_input_name,
+        output_slot_index);
+}
+
+std::vector<std::string> OSLTexture::get_output_names() const
+{
+    std::vector<std::string> output_names;
+
+    for (const auto& output_param : m_shader_info->m_output_params)
+        output_names.push_back(output_param.m_param_name);
+
+    return output_names;
 }

--- a/src/appleseed-max-impl/appleseedoslplugin/osltexture.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/osltexture.h
@@ -41,6 +41,10 @@
 #include <maxtypes.h>
 #undef base_type
 
+// Standard headers.
+#include <string>
+#include <vector>
+
 // Forward declarations.
 namespace renderer { class ShaderGroup; }
 class OSLPluginClassDesc;
@@ -105,7 +109,15 @@ class OSLTexture
     void create_osl_texture(
         renderer::ShaderGroup&  shader_group,
         const char*             material_node_name,
+        const char*             material_input_name,
+        const int               output_slot_index);
+
+    void create_osl_texture(
+        renderer::ShaderGroup&  shader_group,
+        const char*             material_node_name,
         const char*             material_input_name);
+
+    std::vector<std::string> get_output_names() const;
 
   protected:
     virtual void SetReference(int i, RefTargetHandle rtarg) override;

--- a/src/appleseed-max-impl/appleseedoslplugin/osltexture.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/osltexture.h
@@ -105,7 +105,7 @@ class OSLTexture
     Point3 EvalNormalPerturb(ShadeContext& sc) override;
     UVGen* GetTheUVGen() override;
 
-    // Connect output to a material.
+    // Create OSL shader and connect to a given output.
     void create_osl_texture(
         renderer::ShaderGroup&  shader_group,
         const char*             material_node_name,

--- a/src/appleseed-max-impl/builtinmapsupport.cpp
+++ b/src/appleseed-max-impl/builtinmapsupport.cpp
@@ -54,15 +54,16 @@ void connect_output_selector(
 
     Texmap* input_map = nullptr;
     get_paramblock_value_by_name(texmap->GetParamBlock(0), L"source_map", t, input_map, FOREVER);
-    int output_index = 0;
-    get_paramblock_value_by_name(texmap->GetParamBlock(0), L"output_index", t, output_index, FOREVER);
-
     if (input_map != nullptr && is_osl_texture(input_map))
     {
         OSLTexture* osl_texture = static_cast<OSLTexture*>(input_map);
         auto output_names = osl_texture->get_output_names();
 
-        if (output_index > 0 && --output_index < output_names.size())
+        int output_index = 0;
+        get_paramblock_value_by_name(texmap->GetParamBlock(0), L"output_index", t, output_index, FOREVER);
+        DbgAssert(output_index >= 1);
+        output_index -= 1;
+        if (output_index < output_names.size())
         {
             osl_texture->create_osl_texture(
                 shader_group,

--- a/src/appleseed-max-impl/builtinmapsupport.cpp
+++ b/src/appleseed-max-impl/builtinmapsupport.cpp
@@ -62,7 +62,7 @@ void connect_output_selector(
         OSLTexture* osl_texture = static_cast<OSLTexture*>(input_map);
         auto output_names = osl_texture->get_output_names();
 
-        if (--output_index < output_names.size())
+        if (output_index > 0 && --output_index < output_names.size())
         {
             osl_texture->create_osl_texture(
                 shader_group,
@@ -74,7 +74,7 @@ void connect_output_selector(
 }
 
 void connect_output_map(
-    asr::ShaderGroup&  shader_group,
+    asr::ShaderGroup&   shader_group,
     const char*         material_node_name,
     const char*         material_input_name,
     Texmap*             texmap,

--- a/src/appleseed-max-impl/builtinmapsupport.cpp
+++ b/src/appleseed-max-impl/builtinmapsupport.cpp
@@ -62,11 +62,14 @@ void connect_output_selector(
         OSLTexture* osl_texture = static_cast<OSLTexture*>(input_map);
         auto output_names = osl_texture->get_output_names();
 
-        osl_texture->create_osl_texture(
-            shader_group,
-            material_node_name,
-            material_input_name,
-            static_cast<int>((output_index - 1) % output_names.size()));
+        if (--output_index < output_names.size())
+        {
+            osl_texture->create_osl_texture(
+                shader_group,
+                material_node_name,
+                material_input_name,
+                output_index);
+        }
     }
 }
 

--- a/src/appleseed-max-impl/builtinmapsupport.cpp
+++ b/src/appleseed-max-impl/builtinmapsupport.cpp
@@ -30,6 +30,7 @@
 #include "builtinmapsupport.h"
 
 // appleseed-max headers.
+#include "appleseedoslplugin/osltexture.h"
 #include "oslutils.h"
 #include "utilities.h"
 
@@ -42,6 +43,47 @@
 
 namespace asf = foundation;
 namespace asr = renderer;
+
+void connect_output_selector(
+    renderer::ShaderGroup&  shader_group,
+    const char*             material_node_name,
+    const char*             material_input_name,
+    Texmap*                 texmap,
+    const Color             const_value)
+{
+    const auto t = GetCOREInterface()->GetTime();
+
+    Texmap* input_map = nullptr;
+    get_paramblock_value_by_name(texmap->GetParamBlock(0), L"source_map", t, input_map, FOREVER);
+    int output_index = 0;
+    get_paramblock_value_by_name(texmap->GetParamBlock(0), L"output_index", t, output_index, FOREVER);
+
+    if (input_map != nullptr && is_osl_texture(input_map))
+    {
+        auto output_names = static_cast<OSLTexture*>(input_map)->get_output_names();
+
+        static_cast<OSLTexture*>(input_map)->create_osl_texture(
+            shader_group,
+            material_node_name,
+            material_input_name,
+            static_cast<int>((output_index - 1) % output_names.size()));
+    }
+}
+
+void connect_output_selector(
+    renderer::ShaderGroup&  shader_group,
+    const char*             material_node_name,
+    const char*             material_input_name,
+    Texmap*                 texmap,
+    const float             const_value)
+{
+    connect_output_selector(
+        shader_group,
+        material_node_name,
+        material_input_name,
+        texmap,
+        Color());
+}
 
 void connect_output_map(
     renderer::ShaderGroup&  shader_group,

--- a/src/appleseed-max-impl/builtinmapsupport.cpp
+++ b/src/appleseed-max-impl/builtinmapsupport.cpp
@@ -45,11 +45,10 @@ namespace asf = foundation;
 namespace asr = renderer;
 
 void connect_output_selector(
-    renderer::ShaderGroup&  shader_group,
-    const char*             material_node_name,
-    const char*             material_input_name,
-    Texmap*                 texmap,
-    const Color             const_value)
+    asr::ShaderGroup&   shader_group,
+    const char*         material_node_name,
+    const char*         material_input_name,
+    Texmap*             texmap)
 {
     const auto t = GetCOREInterface()->GetTime();
 
@@ -60,9 +59,10 @@ void connect_output_selector(
 
     if (input_map != nullptr && is_osl_texture(input_map))
     {
-        auto output_names = static_cast<OSLTexture*>(input_map)->get_output_names();
+        OSLTexture* osl_texture = static_cast<OSLTexture*>(input_map);
+        auto output_names = osl_texture->get_output_names();
 
-        static_cast<OSLTexture*>(input_map)->create_osl_texture(
+        osl_texture->create_osl_texture(
             shader_group,
             material_node_name,
             material_input_name,
@@ -70,27 +70,12 @@ void connect_output_selector(
     }
 }
 
-void connect_output_selector(
-    renderer::ShaderGroup&  shader_group,
-    const char*             material_node_name,
-    const char*             material_input_name,
-    Texmap*                 texmap,
-    const float             const_value)
-{
-    connect_output_selector(
-        shader_group,
-        material_node_name,
-        material_input_name,
-        texmap,
-        Color());
-}
-
 void connect_output_map(
-    renderer::ShaderGroup&  shader_group,
-    const char*             material_node_name,
-    const char*             material_input_name,
-    Texmap*                 texmap,
-    const Color             const_value)
+    asr::ShaderGroup&  shader_group,
+    const char*         material_node_name,
+    const char*         material_input_name,
+    Texmap*             texmap,
+    const Color         const_value)
 {
     const auto t = GetCOREInterface()->GetTime();
     auto color_balance_layer_name = foundation::format("{0}_{1}_color_balance", material_node_name, material_input_name);
@@ -111,11 +96,11 @@ void connect_output_map(
 }
 
 void connect_output_map(
-    renderer::ShaderGroup&  shader_group,
-    const char*             material_node_name,
-    const char*             material_input_name,
-    Texmap*                 texmap,
-    const float             const_value)
+    asr::ShaderGroup&   shader_group,
+    const char*         material_node_name,
+    const char*         material_input_name,
+    Texmap*             texmap,
+    const float         const_value)
 {
     const auto t = GetCOREInterface()->GetTime();
     auto color_balance_layer_name = foundation::format("{0}_{1}_color_balance", material_node_name, material_input_name);

--- a/src/appleseed-max-impl/builtinmapsupport.h
+++ b/src/appleseed-max-impl/builtinmapsupport.h
@@ -64,15 +64,7 @@ void connect_output_selector(
     renderer::ShaderGroup&  shader_group,
     const char*             material_node_name,
     const char*             material_input_name,
-    Texmap*                 texmap,
-    const Color             const_value);
-
-void connect_output_selector(
-    renderer::ShaderGroup&  shader_group,
-    const char*             material_node_name,
-    const char*             material_input_name,
-    Texmap*                 texmap,
-    const float             const_value);
+    Texmap*                 texmap);
 
 template <typename T>
 void create_supported_texture(
@@ -91,8 +83,7 @@ void create_supported_texture(
             shader_group,
             material_node_name,
             material_input_name,
-            texmap,
-            const_value);
+            texmap);
         return;
     }
 

--- a/src/appleseed-max-impl/builtinmapsupport.h
+++ b/src/appleseed-max-impl/builtinmapsupport.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// appleseed-max headers.
+#include "osloutputselectormap/osloutputselector.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 #include "foundation/image/color.h"
@@ -57,6 +60,20 @@ void connect_output_map(
     Texmap*                 texmap,
     const float             const_value);
 
+void connect_output_selector(
+    renderer::ShaderGroup&  shader_group,
+    const char*             material_node_name,
+    const char*             material_input_name,
+    Texmap*                 texmap,
+    const Color             const_value);
+
+void connect_output_selector(
+    renderer::ShaderGroup&  shader_group,
+    const char*             material_node_name,
+    const char*             material_input_name,
+    Texmap*                 texmap,
+    const float             const_value);
+
 template <typename T>
 void create_supported_texture(
     renderer::ShaderGroup&  shader_group,
@@ -67,6 +84,17 @@ void create_supported_texture(
 {
     auto part_a = texmap->ClassID().PartA();
     auto part_b = texmap->ClassID().PartB();
+
+    if (texmap->ClassID() == OSLOutputSelector::get_class_id())
+    {
+        connect_output_selector(
+            shader_group,
+            material_node_name,
+            material_input_name,
+            texmap,
+            const_value);
+        return;
+    }
 
     switch (part_a)
     {

--- a/src/appleseed-max-impl/osloutputselectormap/datachunks.h
+++ b/src/appleseed-max-impl/osloutputselectormap/datachunks.h
@@ -1,0 +1,41 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Sergo Pogosyan, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+// appleseed.foundation headers.
+#include "foundation/platform/windows.h"
+
+//
+// Changing the values of these constants WILL break compatibility
+// with 3ds Max files saved with older versions of the plugin.
+//
+
+const USHORT ChunkFileFormatVersion                 = 0x0001;
+
+const USHORT ChunkMtlBase                           = 0x1000;

--- a/src/appleseed-max-impl/osloutputselectormap/osloutputselector.cpp
+++ b/src/appleseed-max-impl/osloutputselectormap/osloutputselector.cpp
@@ -137,6 +137,7 @@ namespace
         ParamBlockRefOutputSelector,                // parameter block's reference number
 
         // --- P_AUTO_UI arguments for Parameters rollup ---
+
         IDD_OUTPUTSELECTOR_PANEL,                   // ID of the dialog template
         IDS_OUTPUTSELECTOR_PARAMS,                  // ID of the dialog's title string
         0,                                          // IParamMap2 creation/deletion flag mask
@@ -187,9 +188,9 @@ namespace
     }
 
     class OutputSelectorDlgProc
-        : public ParamMap2UserDlgProc
+      : public ParamMap2UserDlgProc
     {
-    public:
+      public:
         virtual void DeleteThis() override
         {
             delete this;

--- a/src/appleseed-max-impl/osloutputselectormap/osloutputselector.cpp
+++ b/src/appleseed-max-impl/osloutputselectormap/osloutputselector.cpp
@@ -1,0 +1,604 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Sergo Pogosyan, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+// Interface header.
+#include "osloutputselector.h"
+
+// appleseed-max headers.
+#include "appleseedoslplugin/osltexture.h"
+#include "appleseedrenderer/appleseedrenderer.h"
+#include "main.h"
+#include "osloutputselectormap/datachunks.h"
+#include "osloutputselectormap/resource.h"
+#include "utilities.h"
+#include "version.h"
+
+namespace asf = foundation;
+namespace asr = renderer;
+
+namespace
+{
+    const wchar_t* OSLOutputSelectorFriendlyClassName = L"OSL Output Selector";
+
+    enum { ParamBlockIdOutputSelector };
+    enum { ParamBlockRefOutputSelector };
+
+    enum ParamId
+    {
+        ParamIdSourceMap = 0,
+        ParamIdOutputIndex = 1,
+    };
+
+    enum TexmapId
+    {
+        TexmapIdSourceMap = 0,
+        TexmapCount                 // keep last
+    };
+
+    const MSTR g_texmap_slot_names[TexmapCount] =
+    {
+        L"SourceMap",
+    };
+
+    const ParamId g_texmap_id_to_param_id[TexmapCount] =
+    {
+        ParamIdSourceMap
+    };
+
+    class OutputIndexAccessor
+      : public PBAccessor
+    {
+      public:
+        void Set(PB2Value& v, ReferenceMaker* owner, ParamID id, int tabIndex, TimeValue t) override
+        {
+            IParamBlock2* pblock = static_cast<OSLOutputSelector*>(owner)->GetParamBlock(0);
+            if (pblock == nullptr)
+                return;
+
+            IParamMap2* map = pblock->GetMap();
+            if (map == nullptr)
+                return;
+
+            switch (id)
+            {
+                case ParamIdOutputIndex:
+                {
+                    Texmap* texmap = nullptr;
+                    pblock->GetValue(ParamIdSourceMap, t, texmap, FOREVER);
+
+                    if (texmap != nullptr && is_osl_texture(texmap))
+                    {
+                        auto output_names = static_cast<OSLTexture*>(texmap)->get_output_names();
+
+                        int output_index = v.i;
+                        if (!output_names.empty())
+                        {
+                            HWND dlg_hwnd = 0;
+                            dlg_hwnd = map->GetHWnd();
+                            if (dlg_hwnd != 0)
+                            {
+                                SendMessage(
+                                    GetDlgItem(dlg_hwnd, IDC_COMBO_OUTPUT_NAME),
+                                    CB_SETCURSEL,
+                                    (output_index - 1) % output_names.size(),
+                                    0);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+}
+
+OSLOutputSelectorClassDesc g_appleseed_outputselector_classdesc;
+OutputIndexAccessor g_output_index_accessor;
+
+//
+// OSLOutputSelector class implementation.
+//
+
+namespace
+{
+    ParamBlockDesc2 g_block_desc(
+        // --- Required arguments ---
+        ParamBlockIdOutputSelector,                 // parameter block's ID
+        L"appleseedOuputSelectorParams",            // internal parameter block's name
+        0,                                          // ID of the localized name string
+        &g_appleseed_outputselector_classdesc,      // class descriptor
+        P_AUTO_CONSTRUCT + P_AUTO_UI,               // block flags
+
+         // --- P_AUTO_CONSTRUCT arguments ---
+        ParamBlockRefOutputSelector,                // parameter block's reference number
+
+        // --- P_AUTO_UI arguments for Parameters rollup ---
+        IDD_OUTPUTSELECTOR_PANEL,                   // ID of the dialog template
+        IDS_OUTPUTSELECTOR_PARAMS,                  // ID of the dialog's title string
+        0,                                          // IParamMap2 creation/deletion flag mask
+        0,                                          // rollup creation flag
+        nullptr,
+
+        // --- Parameters specifications for Parameters rollup ---
+        ParamIdOutputIndex, L"output_index", TYPE_INT, P_ANIMATABLE, IDS_OUTPUT_INDEX,
+            p_default, 1,
+            p_range, 1, 100,
+            p_ui, TYPE_SPINNER, EDITTYPE_INT, IDC_EDIT_OUTPUT_INDEX, IDC_SPIN_OUTPUT_INDEX, 1,
+            p_accessor, &g_output_index_accessor,
+        p_end,
+
+        ParamIdSourceMap, L"source_map", TYPE_TEXMAP, 0, IDS_SOURCE_MAP,
+            p_subtexno, TexmapIdSourceMap,
+            p_ui, TYPE_TEXMAPBUTTON, IDC_SOURCE_MAP,
+        p_end,
+        
+        p_end
+    );
+
+    void init_combo_box(IParamMap2* param_map)
+    {
+        HWND dlg_hwnd = 0;
+        if (param_map != nullptr)
+            dlg_hwnd = param_map->GetHWnd();
+        if (dlg_hwnd == 0)
+            return;
+
+        const auto time = GetCOREInterface()->GetTime();
+        Texmap* texmap = nullptr;
+        param_map->GetParamBlock()->GetValue(ParamIdSourceMap, time, texmap, FOREVER);
+
+        if (texmap != nullptr && is_osl_texture(texmap))
+        {
+            auto output_names = static_cast<OSLTexture*>(texmap)->get_output_names();
+            for (const auto& name : output_names)
+                SendMessage(GetDlgItem(dlg_hwnd, IDC_COMBO_OUTPUT_NAME), CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(utf8_to_wide(name).c_str()));
+
+            int output_index = param_map->GetParamBlock()->GetInt(ParamIdOutputIndex, time, FOREVER);
+            SendMessage(GetDlgItem(dlg_hwnd, IDC_COMBO_OUTPUT_NAME), CB_SETCURSEL, (output_index - 1) % output_names.size(), 0);
+        }
+        else
+        {
+            SendMessage(GetDlgItem(dlg_hwnd, IDC_COMBO_OUTPUT_NAME), CB_RESETCONTENT, 0, 0);
+        }
+    }
+
+    class OutputSelectorDlgProc
+        : public ParamMap2UserDlgProc
+    {
+    public:
+        virtual void DeleteThis() override
+        {
+            delete this;
+        }
+
+        virtual INT_PTR DlgProc(
+            TimeValue   t,
+            IParamMap2* map,
+            HWND        hwnd,
+            UINT        umsg,
+            WPARAM      wparam,
+            LPARAM      lparam) override
+        {
+            switch (umsg)
+            {
+              case WM_INITDIALOG:
+                init_combo_box(map);
+                return TRUE;
+
+              case WM_COMMAND:
+                switch (LOWORD(wparam))
+                {
+                  case IDC_COMBO_OUTPUT_NAME:
+                    switch (HIWORD(wparam))
+                    {
+                      case CBN_SELCHANGE:
+                        {
+                            LRESULT selected = SendMessage(GetDlgItem(hwnd, IDC_COMBO_OUTPUT_NAME), CB_GETCURSEL, 0, 0);
+                            map->GetParamBlock()->SetValue(ParamIdOutputIndex, t, static_cast<int>(selected + 1));
+                        }
+                        return TRUE;
+
+                      default:
+                        return FALSE;
+                    }
+
+                  default:
+                    return FALSE;
+                }
+
+              default:
+                return FALSE;
+            }
+        }
+    };
+}
+
+Class_ID OSLOutputSelector::get_class_id()
+{
+    return Class_ID(0x53035b67, 0x7b906906);
+}
+
+OSLOutputSelector::OSLOutputSelector()
+  : m_pblock(nullptr)
+{
+    g_appleseed_outputselector_classdesc.MakeAutoParamBlocks(this);
+    Reset();
+}
+
+void OSLOutputSelector::DeleteThis()
+{
+    delete this;
+}
+
+void OSLOutputSelector::GetClassName(TSTR& s)
+{
+    s = L"appleseedOSLOutputSelector";
+}
+
+SClass_ID OSLOutputSelector::SuperClassID()
+{
+    return TEXMAP_CLASS_ID;
+}
+
+Class_ID OSLOutputSelector::ClassID()
+{
+    return get_class_id();
+}
+
+int OSLOutputSelector::NumSubs()
+{
+    return 1;   // pblock
+}
+
+Animatable* OSLOutputSelector::SubAnim(int i)
+{
+    switch (i)
+    {
+      case 0:
+        return m_pblock;
+      
+      default:
+        return nullptr;
+    }
+}
+
+TSTR OSLOutputSelector::SubAnimName(int i)
+{
+    switch (i)
+    {
+      case 0:
+        return L"Parameters";
+
+      default:
+        return nullptr;
+    }
+}
+
+int OSLOutputSelector::SubNumToRefNum(int subNum)
+{
+    return subNum;
+}
+
+int OSLOutputSelector::NumParamBlocks()
+{
+    return 1;
+}
+
+IParamBlock2* OSLOutputSelector::GetParamBlock(int i)
+{
+    return i == 0 ? m_pblock : nullptr;
+}
+
+IParamBlock2* OSLOutputSelector::GetParamBlockByID(BlockID id)
+{
+    return id == m_pblock->ID() ? m_pblock : nullptr;
+}
+
+int OSLOutputSelector::NumRefs()
+{
+    return 1;   // pblock
+}
+
+RefTargetHandle OSLOutputSelector::GetReference(int i)
+{
+    switch (i)
+    {
+      case ParamBlockIdOutputSelector:
+        return m_pblock;
+
+      default:
+        return nullptr;
+    }
+}
+
+void OSLOutputSelector::SetReference(int i, RefTargetHandle rtarg)
+{
+    switch (i)
+    {
+      case ParamBlockIdOutputSelector:
+        m_pblock = (IParamBlock2 *)rtarg;
+        break;
+    }
+}
+
+RefResult OSLOutputSelector::NotifyRefChanged(
+    const Interval&   /*changeInt*/,
+    RefTargetHandle   hTarget,
+    PartID&           partID,
+    RefMessage        message,
+    BOOL              /*propagate*/)
+{
+    switch (message)
+    {
+      case REFMSG_TARGET_DELETED:
+        if (hTarget == m_pblock)
+            m_pblock = nullptr;
+        break;
+
+      case REFMSG_CHANGE:
+        if (hTarget == m_pblock)
+            g_block_desc.InvalidateUI(m_pblock->LastNotifyParamID());
+        break;
+    }
+
+    return REF_SUCCEED;
+}
+
+RefTargetHandle OSLOutputSelector::Clone(RemapDir& remap)
+{
+    OSLOutputSelector* mnew = new OSLOutputSelector();
+    *static_cast<MtlBase*>(mnew) = *static_cast<MtlBase*>(this);
+    BaseClone(this, mnew, remap);
+
+    mnew->ReplaceReference(0, remap.CloneRef(m_pblock));
+
+    return (RefTargetHandle)mnew;
+}
+
+int OSLOutputSelector::NumSubTexmaps()
+{
+    return TexmapCount;
+}
+
+Texmap* OSLOutputSelector::GetSubTexmap(int i)
+{
+    Texmap* texmap = nullptr;
+    Interval iv;
+    if (i == 0)
+    {
+        m_pblock->GetValue(ParamIdSourceMap, 0, texmap, iv);
+    }
+    return texmap;
+}
+
+void OSLOutputSelector::SetSubTexmap(int i, Texmap* texmap)
+{
+    if (i == 0)
+    {
+        const auto texmap_id = static_cast<TexmapId>(i);
+        const auto param_id = g_texmap_id_to_param_id[texmap_id];
+        m_pblock->SetValue(param_id, 0, texmap);
+
+        init_combo_box(m_pblock->GetMap(ParamBlockIdOutputSelector));
+
+        g_block_desc.InvalidateUI(param_id);
+    }
+}
+
+int OSLOutputSelector::MapSlotType(int i)
+{
+    return MAPSLOT_TEXTURE;
+}
+
+TSTR OSLOutputSelector::GetSubTexmapSlotName(int i)
+{
+    const auto texmap_id = static_cast<TexmapId>(i);
+    return g_texmap_slot_names[texmap_id];
+}
+
+void OSLOutputSelector::Update(TimeValue t, Interval& valid)
+{
+    if (!m_params_validity.InInterval(t))
+    {
+        NotifyDependents(FOREVER, PART_ALL, REFMSG_CHANGE);
+    }
+    m_params_validity.SetInfinite();
+
+    Texmap* source_map;
+    m_pblock->GetValue(ParamIdSourceMap, t, source_map, m_params_validity);
+
+    if (source_map)
+        source_map->Update(t, m_params_validity);
+
+    valid = m_params_validity;
+}
+
+void OSLOutputSelector::Reset()
+{
+    m_params_validity.SetEmpty();
+}
+
+Interval OSLOutputSelector::Validity(TimeValue t)
+{
+    Interval valid = FOREVER;
+    Update(t, valid);
+    return valid;
+}
+
+ParamDlg* OSLOutputSelector::CreateParamDlg(HWND hwMtlEdit, IMtlParams* imp)
+{
+    IAutoMParamDlg* master_dlg = g_appleseed_outputselector_classdesc.CreateParamDlgs(hwMtlEdit, imp, this);
+    g_block_desc.SetUserDlgProc(ParamBlockIdOutputSelector, new OutputSelectorDlgProc());
+    return master_dlg;
+}
+
+IOResult OSLOutputSelector::Save(ISave* isave)
+{
+    bool success = true;
+
+    isave->BeginChunk(ChunkFileFormatVersion);
+    success &= write(isave, &FileFormatVersion, sizeof(FileFormatVersion));
+    isave->EndChunk();
+
+    isave->BeginChunk(ChunkMtlBase);
+    success &= MtlBase::Save(isave) == IO_OK;
+    isave->EndChunk();
+
+    return success ? IO_OK : IO_ERROR;
+}
+
+IOResult OSLOutputSelector::Load(ILoad* iload)
+{
+    IOResult result = IO_OK;
+
+    while (true)
+    {
+        result = iload->OpenChunk();
+        if (result == IO_END)
+            return IO_OK;
+        if (result != IO_OK)
+            break;
+
+        switch (iload->CurChunkID())
+        {
+          case ChunkFileFormatVersion:
+            {
+                USHORT version;
+                result = read<USHORT>(iload, &version);
+            }
+            break;
+
+          case ChunkMtlBase:
+            result = MtlBase::Load(iload);
+            break;
+        }
+
+        if (result != IO_OK)
+            break;
+
+        result = iload->CloseChunk();
+        if (result != IO_OK)
+            break;
+    }
+
+    return result;
+}
+
+AColor OSLOutputSelector::EvalColor(ShadeContext& sc)
+{
+    return Color(0.13f, 0.58f, 1.0f);
+}
+
+Point3 OSLOutputSelector::EvalNormalPerturb(ShadeContext& /*sc*/)
+{
+    return Point3(0.0f, 0.0f, 0.0f);
+}
+
+
+//
+// OSLOutputSelectorBrowserEntryInfo class implementation.
+//
+
+const MCHAR* OSLOutputSelectorBrowserEntryInfo::GetEntryName() const
+{
+    return OSLOutputSelectorFriendlyClassName;
+}
+
+const MCHAR* OSLOutputSelectorBrowserEntryInfo::GetEntryCategory() const
+{
+    return L"Maps\\appleseed OSL";
+}
+
+Bitmap* OSLOutputSelectorBrowserEntryInfo::GetEntryThumbnail() const
+{
+    return nullptr;
+}
+
+
+//
+// OSLOutputSelectorClassDesc class implementation.
+//
+
+OSLOutputSelectorClassDesc::OSLOutputSelectorClassDesc()
+{
+    IMtlRender_Compatibility_MtlBase::Init(*this);
+}
+
+int OSLOutputSelectorClassDesc::IsPublic()
+{
+    return TRUE;
+}
+
+void* OSLOutputSelectorClassDesc::Create(BOOL loading)
+{
+    return new OSLOutputSelector();
+}
+
+const MCHAR* OSLOutputSelectorClassDesc::ClassName()
+{
+    return OSLOutputSelectorFriendlyClassName;
+}
+
+SClass_ID OSLOutputSelectorClassDesc::SuperClassID()
+{
+    return TEXMAP_CLASS_ID;
+}
+
+Class_ID OSLOutputSelectorClassDesc::ClassID()
+{
+    return OSLOutputSelector::get_class_id();
+}
+
+const MCHAR* OSLOutputSelectorClassDesc::Category()
+{
+    return L"";
+}
+
+const MCHAR* OSLOutputSelectorClassDesc::InternalName()
+{
+    // Parsable name used by MAXScript.
+    return L"OSLOutputSelector";
+}
+
+FPInterface* OSLOutputSelectorClassDesc::GetInterface(Interface_ID id)
+{
+    if (id == IMATERIAL_BROWSER_ENTRY_INFO_INTERFACE)
+        return &m_browser_entry_info;
+
+    return ClassDesc2::GetInterface(id);
+}
+
+HINSTANCE OSLOutputSelectorClassDesc::HInstance()
+{
+    return g_module;
+}
+
+bool OSLOutputSelectorClassDesc::IsCompatibleWithRenderer(ClassDesc& renderer_class_desc)
+{
+    // Before 3ds Max 2017, Class_ID::operator==() returned an int.
+    return renderer_class_desc.ClassID() == AppleseedRenderer::get_class_id() ? true : false;
+}

--- a/src/appleseed-max-impl/osloutputselectormap/osloutputselector.cpp
+++ b/src/appleseed-max-impl/osloutputselectormap/osloutputselector.cpp
@@ -95,18 +95,29 @@ namespace
                     {
                         auto output_names = static_cast<OSLTexture*>(texmap)->get_output_names();
 
-                        int output_index = v.i;
+                        int output_index = v.i - 1;
                         if (!output_names.empty())
                         {
                             HWND dlg_hwnd = 0;
                             dlg_hwnd = map->GetHWnd();
                             if (dlg_hwnd != 0)
                             {
-                                SendMessage(
-                                    GetDlgItem(dlg_hwnd, IDC_COMBO_OUTPUT_NAME),
-                                    CB_SETCURSEL,
-                                    (output_index - 1) % output_names.size(),
-                                    0);
+                                if (output_index < output_names.size())
+                                {
+                                    SendMessage(
+                                        GetDlgItem(dlg_hwnd, IDC_COMBO_OUTPUT_NAME),
+                                        CB_SETCURSEL,
+                                        output_index,
+                                        0);
+                                }
+                                else
+                                {
+                                    SendMessage(
+                                        GetDlgItem(dlg_hwnd, IDC_COMBO_OUTPUT_NAME),
+                                        CB_SETCURSEL,
+                                        -1,
+                                        0);
+                                }
                             }
                         }
                     }
@@ -172,6 +183,7 @@ namespace
         Texmap* texmap = nullptr;
         param_map->GetParamBlock()->GetValue(ParamIdSourceMap, time, texmap, FOREVER);
 
+        SendMessage(GetDlgItem(dlg_hwnd, IDC_COMBO_OUTPUT_NAME), CB_RESETCONTENT, 0, 0);
         if (texmap != nullptr && is_osl_texture(texmap))
         {
             auto output_names = static_cast<OSLTexture*>(texmap)->get_output_names();
@@ -179,11 +191,10 @@ namespace
                 SendMessage(GetDlgItem(dlg_hwnd, IDC_COMBO_OUTPUT_NAME), CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(utf8_to_wide(name).c_str()));
 
             int output_index = param_map->GetParamBlock()->GetInt(ParamIdOutputIndex, time, FOREVER);
-            SendMessage(GetDlgItem(dlg_hwnd, IDC_COMBO_OUTPUT_NAME), CB_SETCURSEL, (output_index - 1) % output_names.size(), 0);
-        }
-        else
-        {
-            SendMessage(GetDlgItem(dlg_hwnd, IDC_COMBO_OUTPUT_NAME), CB_RESETCONTENT, 0, 0);
+            if (--output_index < output_names.size())
+                SendMessage(GetDlgItem(dlg_hwnd, IDC_COMBO_OUTPUT_NAME), CB_SETCURSEL, output_index, 0);
+            else
+                SendMessage(GetDlgItem(dlg_hwnd, IDC_COMBO_OUTPUT_NAME), CB_SETCURSEL, -1, 0);
         }
     }
 

--- a/src/appleseed-max-impl/osloutputselectormap/osloutputselector.cpp
+++ b/src/appleseed-max-impl/osloutputselectormap/osloutputselector.cpp
@@ -191,7 +191,9 @@ namespace
                 SendMessage(GetDlgItem(dlg_hwnd, IDC_COMBO_OUTPUT_NAME), CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(utf8_to_wide(name).c_str()));
 
             int output_index = param_map->GetParamBlock()->GetInt(ParamIdOutputIndex, time, FOREVER);
-            if (output_index > 0 && --output_index < output_names.size())
+            DbgAssert(output_index >= 1);
+            output_index -= 1;
+            if (output_index < output_names.size())
                 SendMessage(GetDlgItem(dlg_hwnd, IDC_COMBO_OUTPUT_NAME), CB_SETCURSEL, output_index, 0);
             else
                 SendMessage(GetDlgItem(dlg_hwnd, IDC_COMBO_OUTPUT_NAME), CB_SETCURSEL, -1, 0);

--- a/src/appleseed-max-impl/osloutputselectormap/osloutputselector.cpp
+++ b/src/appleseed-max-impl/osloutputselectormap/osloutputselector.cpp
@@ -191,7 +191,7 @@ namespace
                 SendMessage(GetDlgItem(dlg_hwnd, IDC_COMBO_OUTPUT_NAME), CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(utf8_to_wide(name).c_str()));
 
             int output_index = param_map->GetParamBlock()->GetInt(ParamIdOutputIndex, time, FOREVER);
-            if (--output_index < output_names.size())
+            if (output_index > 0 && --output_index < output_names.size())
                 SendMessage(GetDlgItem(dlg_hwnd, IDC_COMBO_OUTPUT_NAME), CB_SETCURSEL, output_index, 0);
             else
                 SendMessage(GetDlgItem(dlg_hwnd, IDC_COMBO_OUTPUT_NAME), CB_SETCURSEL, -1, 0);
@@ -525,7 +525,7 @@ AColor OSLOutputSelector::EvalColor(ShadeContext& sc)
     return Color(0.13f, 0.58f, 1.0f);
 }
 
-Point3 OSLOutputSelector::EvalNormalPerturb(ShadeContext& /*sc*/)
+Point3 OSLOutputSelector::EvalNormalPerturb(ShadeContext& sc)
 {
     return Point3(0.0f, 0.0f, 0.0f);
 }

--- a/src/appleseed-max-impl/osloutputselectormap/osloutputselector.h
+++ b/src/appleseed-max-impl/osloutputselectormap/osloutputselector.h
@@ -1,0 +1,150 @@
+
+//
+// This source file is part of appleseed.
+// Visit http://appleseedhq.net/ for additional information and resources.
+//
+// This software is released under the MIT license.
+//
+// Copyright (c) 2018 Sergo Pogosyan, The appleseedhq Organization
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+// appleseed.foundation headers.
+#include "foundation/platform/windows.h"    // include before 3ds Max headers
+#include "foundation/utility/autoreleaseptr.h"
+
+// 3ds Max headers.
+#include <IMaterialBrowserEntryInfo.h>
+#include <IMtlRender_Compatibility.h>
+#include <imtl.h>
+#include <iparamb2.h>
+#include <iparamm2.h>
+#include <istdplug.h>
+#include <maxtypes.h>
+#include <stdmat.h>
+#undef base_type
+
+class OSLOutputSelector
+  : public Texmap
+{
+  public:
+    static Class_ID get_class_id();
+
+    // Constructor.
+    OSLOutputSelector();
+
+    // Animatable methods.
+    virtual void DeleteThis() override;
+    virtual void GetClassName(TSTR& s) override;
+    virtual SClass_ID SuperClassID() override;
+    virtual Class_ID  ClassID() override;
+    virtual int NumSubs() override;
+    virtual Animatable* SubAnim(int i) override;
+    virtual TSTR SubAnimName(int i) override;
+    virtual int SubNumToRefNum(int subNum) override;
+    virtual int NumParamBlocks() override;
+    virtual IParamBlock2* GetParamBlock(int i) override;
+    virtual IParamBlock2* GetParamBlockByID(BlockID id) override;
+
+    // ReferenceMaker methods.
+    virtual int NumRefs() override;
+    virtual RefTargetHandle GetReference(int i) override;
+    virtual RefResult NotifyRefChanged(
+        const Interval&     changeInt,
+        RefTargetHandle     hTarget,
+        PartID&             partID,
+        RefMessage          message,
+        BOOL                propagate) override;
+
+    // ReferenceTarget methods.
+    virtual RefTargetHandle Clone(RemapDir& remap) override;
+
+    // ISubMap methods.
+    virtual int NumSubTexmaps() override;
+    virtual Texmap* GetSubTexmap(int i) override;
+    virtual void SetSubTexmap(int i, Texmap* texmap) override;
+    virtual int MapSlotType(int i) override;
+    virtual MSTR GetSubTexmapSlotName(int i) override;
+
+    // MtlBase methods.
+    virtual void Update(TimeValue t, Interval& valid) override;
+    virtual void Reset() override;
+    virtual Interval Validity(TimeValue t) override;
+    virtual ParamDlg* CreateParamDlg(HWND hwMtlEdit, IMtlParams* imp) override;
+    virtual IOResult Save(ISave* isave) override;
+    virtual IOResult Load(ILoad* iload) override;
+
+    // Texmap methods.
+    virtual RGBA EvalColor(ShadeContext& sc) override;
+    virtual Point3 EvalNormalPerturb(ShadeContext& sc) override;
+
+  protected:
+    virtual void SetReference(int i, RefTargetHandle rtarg) override;
+
+  private:
+    IParamBlock2*   m_pblock;          // ref 0
+    Interval        m_params_validity;
+};
+
+
+//
+// OSLOutputSelector material browser info.
+//
+
+class OSLOutputSelectorBrowserEntryInfo
+  : public IMaterialBrowserEntryInfo
+{
+  public:
+    virtual const MCHAR* GetEntryName() const override;
+    virtual const MCHAR* GetEntryCategory() const override;
+    virtual Bitmap* GetEntryThumbnail() const override;
+};
+
+
+//
+// OSLOutputSelector class descriptor.
+//
+
+class OSLOutputSelectorClassDesc
+  : public ClassDesc2
+  , public IMtlRender_Compatibility_MtlBase
+{
+  public:
+    OSLOutputSelectorClassDesc();
+    virtual int IsPublic() override;
+    virtual void* Create(BOOL loading) override;
+    virtual const wchar_t* ClassName() override;
+    virtual SClass_ID SuperClassID() override;
+    virtual Class_ID ClassID() override;
+    virtual const wchar_t* Category() override;
+    virtual const wchar_t* InternalName() override;
+    virtual FPInterface* GetInterface(Interface_ID id) override;
+    virtual HINSTANCE HInstance() override;
+
+    // IMtlRender_Compatibility_MtlBase methods.
+    virtual bool IsCompatibleWithRenderer(ClassDesc& renderer_class_desc) override;
+
+  private:
+    OSLOutputSelectorBrowserEntryInfo m_browser_entry_info;
+};
+
+extern OSLOutputSelectorClassDesc g_appleseed_outputselector_classdesc;

--- a/src/appleseed-max-impl/osloutputselectormap/osloutputselector.rc
+++ b/src/appleseed-max-impl/osloutputselectormap/osloutputselector.rc
@@ -1,0 +1,125 @@
+// Microsoft Visual C++ generated resource script.
+//
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "windows.h"
+#define IDC_STATIC -1
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// English (United States) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+#pragma code_page(1252)
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Dialog
+//
+
+IDD_OUTPUTSELECTOR_PANEL DIALOGEX 0, 0, 217, 56
+STYLE DS_SETFONT | WS_CHILD | WS_VISIBLE
+FONT 8, "MS Sans Serif", 0, 0, 0x0
+BEGIN
+    LTEXT           "Source Map:",IDC_STATIC,10,9,50,8
+    CONTROL         "Source Map",IDC_SOURCE_MAP,"CustButton",WS_TABSTOP,85,9,94,10
+    LTEXT           "Output Index:",IDC_STATIC,10,21,50,8,SS_CENTERIMAGE
+    CONTROL         "Output Index Edit",IDC_EDIT_OUTPUT_INDEX,"CustEdit",WS_TABSTOP,85,21,30,10
+    CONTROL         "Output Index Spinner",IDC_SPIN_OUTPUT_INDEX,"SpinnerControl",0x0,117,21,7,10
+    LTEXT           "Output Name:",IDC_STATIC,10,34,50,8
+    COMBOBOX        IDC_COMBO_OUTPUT_NAME,85,34,94,30,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+END
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// DESIGNINFO
+//
+
+#ifdef APSTUDIO_INVOKED
+GUIDELINES DESIGNINFO
+BEGIN
+    IDD_OUTPUTSELECTOR_PANEL, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 210
+        TOPMARGIN, 7
+    END
+END
+#endif    // APSTUDIO_INVOKED
+
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#include ""windows.h""\r\n"
+    "#define IDC_STATIC -1\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// AFX_DIALOG_LAYOUT
+//
+
+IDD_OUTPUTSELECTOR_PANEL AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// String Table
+//
+
+STRINGTABLE
+BEGIN
+    IDS_OUTPUTSELECTOR_PARAMS "Output Selector Parameters"
+    IDS_SOURCE_MAP          "Source Map"
+    IDS_OUTPUT_INDEX        "Output Index"
+    IDS_OUTPUT_NAMES        "Output Name"
+END
+
+#endif    // English (United States) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED
+

--- a/src/appleseed-max-impl/osloutputselectormap/resource.h
+++ b/src/appleseed-max-impl/osloutputselectormap/resource.h
@@ -1,0 +1,24 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by osloutputselector.rc
+//
+#define IDD_OUTPUTSELECTOR_PANEL        12000
+#define IDS_OUTPUTSELECTOR_PARAMS       12001
+#define IDC_COMBO_OUTPUT_NAME           12002
+#define IDC_SOURCE_MAP                  12003
+#define IDS_SOURCE_MAP                  12004
+#define IDS_OUTPUT_INDEX                12005
+#define IDS_OUTPUT_NAMES                12006
+#define IDC_EDIT_OUTPUT_INDEX           12007
+#define IDC_SPIN_OUTPUT_INDEX           12008
+
+// Next default values for new objects
+// 
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        103
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         1006
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif

--- a/src/appleseed-max-impl/plugin.cpp
+++ b/src/appleseed-max-impl/plugin.cpp
@@ -38,9 +38,9 @@
 #include "appleseedplasticmtl/appleseedplasticmtl.h"
 #include "appleseedrenderer/appleseedrenderer.h"
 #include "appleseedsssmtl/appleseedsssmtl.h"
-#include "osloutputselectormap/osloutputselector.h"
 #include "logtarget.h"
 #include "main.h"
+#include "osloutputselectormap/osloutputselector.h"
 #include "utilities.h"
 #include "version.h"
 

--- a/src/appleseed-max-impl/plugin.cpp
+++ b/src/appleseed-max-impl/plugin.cpp
@@ -38,6 +38,7 @@
 #include "appleseedplasticmtl/appleseedplasticmtl.h"
 #include "appleseedrenderer/appleseedrenderer.h"
 #include "appleseedsssmtl/appleseedsssmtl.h"
+#include "osloutputselectormap/osloutputselector.h"
 #include "logtarget.h"
 #include "main.h"
 #include "utilities.h"
@@ -84,7 +85,7 @@ extern "C"
     __declspec(dllexport)
     int LibNumberClasses()
     {
-        return 10 + g_shader_registry.get_size();
+        return 11 + g_shader_registry.get_size();
     }
 
     __declspec(dllexport)
@@ -102,6 +103,7 @@ extern "C"
           case 7: return &g_appleseed_blendmtl_classdesc;
           case 8: return &g_appleseed_metalmtl_classdesc;
           case 9: return &g_appleseed_plasticmtl_classdesc;
+          case 10: return &g_appleseed_outputselector_classdesc;
 
           // Make sure to update LibNumberClasses() if you add classes here.
 

--- a/src/appleseed-max-impl/utilities.cpp
+++ b/src/appleseed-max-impl/utilities.cpp
@@ -31,6 +31,7 @@
 
 // appleseed-max headers.
 #include "appleseedoslplugin/osltexture.h"
+#include "osloutputselectormap/osloutputselector.h"
 #include "main.h"
 
 // appleseed.renderer headers.
@@ -184,10 +185,14 @@ bool is_supported_procedural_texture(Texmap* map, const bool use_max_procedural_
 
     if (!use_max_procedural_maps)
     {
+        if (map->ClassID() == OSLOutputSelector::get_class_id())
+            return true;
+
         switch (part_a)
         {
           case OUTPUT_CLASS_ID:
             return true;
+
           default:
             return false;
         }


### PR DESCRIPTION
Hi @dictoon 

This PR adds Output Selector plugin for OSL Textures. Now in order to connect OSL texture to an input user can choose an output from texture's UI or user can add this plugin and choose output in the plugin's UI.
This basically compensates lack of multiple outputs on OSL textures.

Thanks,
Sergo.