### PR TITLE
Add 2018 solution and projects

### DIFF
--- a/src/appleseed-max-impl/appleseed-max2018-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2018-impl.vcxproj
@@ -1,0 +1,363 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Ship|x64">
+      <Configuration>Ship</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{62C41566-DBCB-49D3-943A-4DD53222269E}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>appleseedmax</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>appleseed-max2018-impl</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>appleseed-max2018-impl</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>appleseed-max2018-impl</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>WIN32;WIN64;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;BOOST_FILESYSTEM_VERSION=3;BOOST_FILESYSTEM_NO_DEPRECATED;APPLESEED_WITH_OIIO;OIIO_STATIC_BUILD;APPLESEED_WITH_OSL;OSL_STATIC_LIBRARY;APPLESEED_WITH_DISNEY_MATERIAL;APPLESEED_WITH_NORMALIZED_DIFFUSION_BSSRDF;XERCES_STATIC_LIBRARY;BOOST_PYTHON_STATIC_LIB;APPLESEED_X86;APPLESEED_USE_SSE;DEBUG;APPLESEED_ENABLE_IMATH_INTEROP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(ProjectDir);C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\include;$(SolutionDir)..\..\boost_1_55_0;$(SolutionDir)..\..\appleseed\src\appleseed;$(SolutionDir)..\..\appleseed-deps\stage\vc14\ilmbase-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc14\openexr-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc14\oiio-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc14\osl-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc14\SeExpr-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc14\SeExpr-release\include</AdditionalIncludeDirectories>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\v140\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc14;$(SolutionDir)..\..\boost_1_55_0\stage\lib</AdditionalLibraryDirectories>
+      <AdditionalDependencies>wininet.lib;bmm.lib;core.lib;geom.lib;maxutil.lib;mesh.lib;Paramblk2.lib;ShLwApi.Lib;appleseed.lib;ilmbase-debug\lib\Half.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <DelayLoadDLLs>
+      </DelayLoadDLLs>
+    </Link>
+    <PostBuildEvent>
+      <Command>mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)" 2&gt;nul
+mkdir "$(SolutionDir)..\sandbox\max2018\Current" 2&gt;nul
+
+copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
+copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\Current\"
+
+if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
+if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\Current\"
+
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2018\Current\"
+
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2018\Current\"
+
+mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\max\" 2&gt;nul
+mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\appleseed\" 2&gt;nul
+mkdir "$(SolutionDir)..\sandbox\max2018\Current\shaders\max\" 2&gt;nul
+mkdir "$(SolutionDir)..\sandbox\max2018\Current\shaders\appleseed\" 2&gt;nul
+
+del /Q "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\max\*.oso" 2&gt;nul
+del /Q "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\appleseed\*.oso" 2&gt;nul
+del /Q "$(SolutionDir)..\sandbox\max2018\Current\shaders\max\*.oso" 2&gt;nul
+del /Q "$(SolutionDir)..\sandbox\max2018\Current\shaders\appleseed\*.oso" 2&gt;nul
+
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\max\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\appleseed\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2018\Current\shaders\max\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2018\Current\shaders\appleseed\"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>Full</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;WIN64;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;BOOST_FILESYSTEM_VERSION=3;BOOST_FILESYSTEM_NO_DEPRECATED;APPLESEED_WITH_OIIO;OIIO_STATIC_BUILD;APPLESEED_WITH_OSL;OSL_STATIC_LIBRARY;APPLESEED_WITH_DISNEY_MATERIAL;APPLESEED_WITH_NORMALIZED_DIFFUSION_BSSRDF;XERCES_STATIC_LIBRARY;BOOST_PYTHON_STATIC_LIB;APPLESEED_X86;APPLESEED_USE_SSE;APPLESEED_ENABLE_IMATH_INTEROP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(ProjectDir);C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\include;$(SolutionDir)..\..\appleseed\src\appleseed;$(SolutionDir)..\..\boost_1_55_0;$(SolutionDir)..\..\appleseed-deps\stage\vc14\ilmbase-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc142\openexr-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc14\oiio-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc14\osl-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc14\SeExpr-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc14\SeExpr-release\include</AdditionalIncludeDirectories>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <StringPooling>true</StringPooling>
+      <FunctionLevelLinking>false</FunctionLevelLinking>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\v140\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc14;$(SolutionDir)..\..\boost_1_55_0\stage\lib</AdditionalLibraryDirectories>
+      <AdditionalDependencies>wininet.lib;bmm.lib;core.lib;geom.lib;maxutil.lib;mesh.lib;Paramblk2.lib;ShLwApi.Lib;appleseed.lib;ilmbase-release\lib\Half.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>
+      </DelayLoadDLLs>
+    </Link>
+    <PostBuildEvent>
+      <Command>mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)" 2&gt;nul
+mkdir "$(SolutionDir)..\sandbox\max2018\Current" 2&gt;nul
+
+copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
+copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\Current\"
+
+if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
+if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\Current\"
+
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2018\Current\"
+
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2018\Current\"
+
+mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\max\" 2&gt;nul
+mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\appleseed\" 2&gt;nul
+mkdir "$(SolutionDir)..\sandbox\max2018\Current\shaders\max\" 2&gt;nul
+mkdir "$(SolutionDir)..\sandbox\max2018\Current\shaders\appleseed\" 2&gt;nul
+
+del /Q "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\max\*.oso" 2&gt;nul
+del /Q "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\appleseed\*.oso" 2&gt;nul
+del /Q "$(SolutionDir)..\sandbox\max2018\Current\shaders\max\*.oso" 2&gt;nul
+del /Q "$(SolutionDir)..\sandbox\max2018\Current\shaders\appleseed\*.oso" 2&gt;nul
+
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\max\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\appleseed\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2018\Current\shaders\max\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2018\Current\shaders\appleseed\"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>Full</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;WIN64;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;BOOST_FILESYSTEM_VERSION=3;BOOST_FILESYSTEM_NO_DEPRECATED;APPLESEED_WITH_OIIO;OIIO_STATIC_BUILD;APPLESEED_WITH_OSL;OSL_STATIC_LIBRARY;APPLESEED_WITH_DISNEY_MATERIAL;APPLESEED_WITH_NORMALIZED_DIFFUSION_BSSRDF;XERCES_STATIC_LIBRARY;BOOST_PYTHON_STATIC_LIB;APPLESEED_X86;APPLESEED_USE_SSE;APPLESEED_ENABLE_IMATH_INTEROP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(ProjectDir);C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\include;$(SolutionDir)..\..\appleseed\src\appleseed;$(SolutionDir)..\..\boost_1_55_0;$(SolutionDir)..\..\appleseed-deps\stage\vc14\ilmbase-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc142\openexr-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc14\oiio-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc14\osl-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc14\SeExpr-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc14\SeExpr-release\include</AdditionalIncludeDirectories>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <StringPooling>true</StringPooling>
+      <FunctionLevelLinking>false</FunctionLevelLinking>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\v140\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc14;$(SolutionDir)..\..\boost_1_55_0\stage\lib</AdditionalLibraryDirectories>
+      <AdditionalDependencies>wininet.lib;bmm.lib;core.lib;geom.lib;maxutil.lib;mesh.lib;Paramblk2.lib;ShLwApi.Lib;appleseed.lib;ilmbase-release\lib\Half.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>
+      </DelayLoadDLLs>
+    </Link>
+    <PostBuildEvent>
+      <Command>mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)" 2&gt;nul
+mkdir "$(SolutionDir)..\sandbox\max2018\Current" 2&gt;nul
+
+copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
+copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\Current\"
+
+if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
+if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\Current\"
+
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2018\Current\"
+
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2018\Current\"
+
+mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\max\" 2&gt;nul
+mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\appleseed\" 2&gt;nul
+mkdir "$(SolutionDir)..\sandbox\max2018\Current\shaders\max\" 2&gt;nul
+mkdir "$(SolutionDir)..\sandbox\max2018\Current\shaders\appleseed\" 2&gt;nul
+
+del /Q "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\max\*.oso" 2&gt;nul
+del /Q "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\appleseed\*.oso" 2&gt;nul
+del /Q "$(SolutionDir)..\sandbox\max2018\Current\shaders\max\*.oso" 2&gt;nul
+del /Q "$(SolutionDir)..\sandbox\max2018\Current\shaders\appleseed\*.oso" 2&gt;nul
+
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\max\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\appleseed\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2018\Current\shaders\max\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2018\Current\shaders\appleseed\"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="appleseedblendmtl\appleseedblendmtl.cpp" />
+    <ClCompile Include="appleseedenvmap\appleseedenvmap.cpp" />
+    <ClCompile Include="appleseedinteractive\appleseedinteractive.cpp" />
+    <ClCompile Include="appleseedinteractive\interactiverenderercontroller.cpp" />
+    <ClCompile Include="appleseedinteractive\interactivesession.cpp" />
+    <ClCompile Include="appleseedinteractive\interactivetilecallback.cpp" />
+    <ClCompile Include="appleseedmetalmtl\appleseedmetalmtl.cpp" />
+    <ClCompile Include="appleseedobjpropsmod\appleseedobjpropsmod.cpp" />
+    <ClCompile Include="appleseedoslplugin\osltexture.cpp" />
+    <ClCompile Include="appleseedoslplugin\oslclassdesc.cpp" />
+    <ClCompile Include="appleseedoslplugin\oslmaterial.cpp" />
+    <ClCompile Include="appleseedoslplugin\oslshadermetadata.cpp" />
+    <ClCompile Include="appleseedoslplugin\oslshaderregistry.cpp" />
+    <ClCompile Include="appleseedoslplugin\oslparamdlg.cpp" />
+    <ClCompile Include="appleseedplasticmtl\appleseedplasticmtl.cpp" />
+    <ClCompile Include="appleseeddisneymtl\appleseeddisneymtl.cpp" />
+    <ClCompile Include="appleseedglassmtl\appleseedglassmtl.cpp" />
+    <ClCompile Include="appleseedrenderer\dialoglogtarget.cpp" />
+    <ClCompile Include="builtinmapsupport.cpp" />
+    <ClCompile Include="iappleseedmtl.cpp" />
+    <ClCompile Include="appleseedlightmtl\appleseedlightmtl.cpp" />
+    <ClCompile Include="logtarget.cpp" />
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="osloutputselectormap\osloutputselector.cpp" />
+    <ClCompile Include="oslutils.cpp" />
+    <ClCompile Include="plugin.cpp" />
+    <ClCompile Include="appleseedrenderer\appleseedrenderer.cpp" />
+    <ClCompile Include="appleseedrenderer\appleseedrendererparamdlg.cpp" />
+    <ClCompile Include="appleseedrenderer\maxsceneentities.cpp" />
+    <ClCompile Include="appleseedrenderer\projectbuilder.cpp" />
+    <ClCompile Include="appleseedrenderer\renderercontroller.cpp" />
+    <ClCompile Include="appleseedrenderer\renderersettings.cpp" />
+    <ClCompile Include="appleseedrenderer\tilecallback.cpp" />
+    <ClCompile Include="appleseedrenderer\updatechecker.cpp" />
+    <ClCompile Include="appleseedsssmtl\appleseedsssmtl.cpp" />
+    <ClCompile Include="seexprutils.cpp" />
+    <ClCompile Include="utilities.cpp" />
+    <ClCompile Include="version.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="appleseedblendmtl\appleseedblendmtl.h" />
+    <ClInclude Include="appleseedblendmtl\datachunks.h" />
+    <ClInclude Include="appleseedblendmtl\resource.h" />
+    <ClInclude Include="appleseedenvmap\appleseedenvmap.h" />
+    <ClInclude Include="appleseedenvmap\datachunks.h" />
+    <ClInclude Include="appleseedenvmap\resource.h" />
+    <ClInclude Include="appleseedinteractive\appleseedinteractive.h" />
+    <ClInclude Include="appleseedinteractive\interactiverenderercontroller.h" />
+    <ClInclude Include="appleseedinteractive\interactivesession.h" />
+    <ClInclude Include="appleseedinteractive\interactivetilecallback.h" />
+    <ClInclude Include="appleseedmetalmtl\appleseedmetalmtl.h" />
+    <ClInclude Include="appleseedmetalmtl\datachunks.h" />
+    <ClInclude Include="appleseedmetalmtl\resource.h" />
+    <ClInclude Include="appleseedobjpropsmod\appleseedobjpropsmod.h" />
+    <ClInclude Include="appleseedobjpropsmod\resource.h" />
+    <ClInclude Include="appleseedoslplugin\osltexture.h" />
+    <ClInclude Include="appleseedoslplugin\oslclassdesc.h" />
+    <ClInclude Include="appleseedoslplugin\oslmaterial.h" />
+    <ClInclude Include="appleseedoslplugin\oslshadermetadata.h" />
+    <ClInclude Include="appleseedoslplugin\oslshaderregistry.h" />
+    <ClInclude Include="appleseedoslplugin\oslparamdlg.h" />
+    <ClInclude Include="appleseedoslplugin\templategenerator.h" />
+    <ClInclude Include="appleseedplasticmtl\appleseedplasticmtl.h" />
+    <ClInclude Include="appleseedplasticmtl\datachunks.h" />
+    <ClInclude Include="appleseedplasticmtl\resource.h" />
+    <ClInclude Include="appleseedrenderer\dialoglogtarget.h" />
+    <ClInclude Include="builtinmapsupport.h" />
+    <ClInclude Include="bump\bumpparammapdlgproc.h" />
+    <ClInclude Include="bump\resource.h" />
+    <ClInclude Include="appleseeddisneymtl\appleseeddisneymtl.h" />
+    <ClInclude Include="appleseeddisneymtl\datachunks.h" />
+    <ClInclude Include="appleseeddisneymtl\resource.h" />
+    <ClInclude Include="appleseedglassmtl\appleseedglassmtl.h" />
+    <ClInclude Include="appleseedglassmtl\datachunks.h" />
+    <ClInclude Include="appleseedglassmtl\resource.h" />
+    <ClInclude Include="iappleseedmtl.h" />
+    <ClInclude Include="appleseedlightmtl\appleseedlightmtl.h" />
+    <ClInclude Include="appleseedlightmtl\datachunks.h" />
+    <ClInclude Include="appleseedlightmtl\resource.h" />
+    <ClInclude Include="logtarget.h" />
+    <ClInclude Include="main.h" />
+    <ClInclude Include="appleseedrenderer\appleseedrenderer.h" />
+    <ClInclude Include="appleseedrenderer\appleseedrendererparamdlg.h" />
+    <ClInclude Include="appleseedrenderer\datachunks.h" />
+    <ClInclude Include="appleseedrenderer\maxsceneentities.h" />
+    <ClInclude Include="appleseedrenderer\projectbuilder.h" />
+    <ClInclude Include="appleseedrenderer\renderercontroller.h" />
+    <ClInclude Include="appleseedrenderer\renderersettings.h" />
+    <ClInclude Include="appleseedrenderer\resource.h" />
+    <ClInclude Include="appleseedrenderer\tilecallback.h" />
+    <ClInclude Include="appleseedrenderer\updatechecker.h" />
+    <ClInclude Include="appleseedsssmtl\appleseedsssmtl.h" />
+    <ClInclude Include="appleseedsssmtl\datachunks.h" />
+    <ClInclude Include="appleseedsssmtl\resource.h" />
+    <ClInclude Include="osloutputselectormap\datachunks.h" />
+    <ClInclude Include="osloutputselectormap\osloutputselector.h" />
+    <ClInclude Include="osloutputselectormap\resource.h" />    
+    <ClInclude Include="oslutils.h" />
+    <ClInclude Include="seexprutils.h" />
+    <ClInclude Include="utilities.h" />
+    <ClInclude Include="version.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="appleseedblendmtl\appleseedblendmtl.rc" />
+    <ResourceCompile Include="appleseedenvmap\appleseedenvmap.rc" />
+    <ResourceCompile Include="appleseedmetalmtl\appleseedmetalmtl.rc" />
+    <ResourceCompile Include="appleseedobjpropsmod\appleseedobjpropsmod.rc" />
+    <ResourceCompile Include="appleseedplasticmtl\appleseedplasticmtl.rc" />
+    <ResourceCompile Include="bump\bump.rc" />
+    <ResourceCompile Include="appleseeddisneymtl\appleseeddisneymtl.rc" />
+    <ResourceCompile Include="appleseedglassmtl\appleseedglassmtl.rc" />
+    <ResourceCompile Include="appleseedlightmtl\appleseedlightmtl.rc" />
+    <ResourceCompile Include="appleseedrenderer\appleseedrenderer.rc" />
+    <ResourceCompile Include="appleseedsssmtl\appleseedsssmtl.rc" />
+    <ResourceCompile Include="osloutputselectormap\osloutputselector.rc" />    
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/appleseed-max-impl/appleseed-max2018-impl.vcxproj.filters
+++ b/src/appleseed-max-impl/appleseed-max2018-impl.vcxproj.filters
@@ -1,0 +1,350 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="appleseedrenderer\appleseedrenderer.cpp">
+      <Filter>appleseedrenderer</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedrenderer\appleseedrendererparamdlg.cpp">
+      <Filter>appleseedrenderer</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedrenderer\maxsceneentities.cpp">
+      <Filter>appleseedrenderer</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedrenderer\projectbuilder.cpp">
+      <Filter>appleseedrenderer</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedrenderer\renderercontroller.cpp">
+      <Filter>appleseedrenderer</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedrenderer\renderersettings.cpp">
+      <Filter>appleseedrenderer</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedrenderer\tilecallback.cpp">
+      <Filter>appleseedrenderer</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedrenderer\updatechecker.cpp">
+      <Filter>appleseedrenderer</Filter>
+    </ClCompile>
+    <ClCompile Include="iappleseedmtl.cpp" />
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="plugin.cpp" />
+    <ClCompile Include="utilities.cpp" />
+    <ClCompile Include="version.cpp" />
+    <ClCompile Include="appleseeddisneymtl\appleseeddisneymtl.cpp">
+      <Filter>appleseeddisneymtl</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedsssmtl\appleseedsssmtl.cpp">
+      <Filter>appleseedsssmtl</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedglassmtl\appleseedglassmtl.cpp">
+      <Filter>appleseedglassmtl</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedlightmtl\appleseedlightmtl.cpp">
+      <Filter>appleseedlightmtl</Filter>
+    </ClCompile>
+    <ClCompile Include="logtarget.cpp" />
+    <ClCompile Include="appleseedobjpropsmod\appleseedobjpropsmod.cpp">
+      <Filter>appleseedobjpropsmod</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedenvmap\appleseedenvmap.cpp">
+      <Filter>appleseedenvmap</Filter>
+    </ClCompile>
+    <ClCompile Include="seexprutils.cpp" />
+    <ClCompile Include="oslutils.cpp" />
+    <ClCompile Include="appleseedinteractive\appleseedinteractive.cpp">
+      <Filter>appleseedinteractive</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedinteractive\interactiverenderercontroller.cpp">
+      <Filter>appleseedinteractive</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedinteractive\interactivesession.cpp">
+      <Filter>appleseedinteractive</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedinteractive\interactivetilecallback.cpp">
+      <Filter>appleseedinteractive</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedblendmtl\appleseedblendmtl.cpp">
+      <Filter>appleseedblendmtl</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedrenderer\dialoglogtarget.cpp">
+      <Filter>appleseedrenderer</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedoslplugin\oslclassdesc.cpp">
+      <Filter>appleseedoslplugin</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedoslplugin\oslmaterial.cpp">
+      <Filter>appleseedoslplugin</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedoslplugin\oslparamdlg.cpp">
+      <Filter>appleseedoslplugin</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedoslplugin\oslshadermetadata.cpp">
+      <Filter>appleseedoslplugin</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedoslplugin\oslshaderregistry.cpp">
+      <Filter>appleseedoslplugin</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedoslplugin\osltexture.cpp">
+      <Filter>appleseedoslplugin</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedmetalmtl\appleseedmetalmtl.cpp">
+      <Filter>appleseedmetalmtl</Filter>
+    </ClCompile>
+    <ClCompile Include="appleseedplasticmtl\appleseedplasticmtl.cpp">
+      <Filter>appleseedplasticmtl</Filter>
+    </ClCompile>
+    <ClCompile Include="builtinmapsupport.cpp" />
+    <ClCompile Include="osloutputselectormap\osloutputselector.cpp">
+      <Filter>osloutputselectormap</Filter>
+    </ClCompile>    
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="appleseedrenderer\appleseedrenderer.h">
+      <Filter>appleseedrenderer</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedrenderer\appleseedrendererparamdlg.h">
+      <Filter>appleseedrenderer</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedrenderer\datachunks.h">
+      <Filter>appleseedrenderer</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedrenderer\maxsceneentities.h">
+      <Filter>appleseedrenderer</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedrenderer\projectbuilder.h">
+      <Filter>appleseedrenderer</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedrenderer\renderercontroller.h">
+      <Filter>appleseedrenderer</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedrenderer\renderersettings.h">
+      <Filter>appleseedrenderer</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedrenderer\resource.h">
+      <Filter>appleseedrenderer</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedrenderer\tilecallback.h">
+      <Filter>appleseedrenderer</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedrenderer\updatechecker.h">
+      <Filter>appleseedrenderer</Filter>
+    </ClInclude>
+    <ClInclude Include="iappleseedmtl.h" />
+    <ClInclude Include="main.h" />
+    <ClInclude Include="utilities.h" />
+    <ClInclude Include="version.h" />
+    <ClInclude Include="appleseeddisneymtl\appleseeddisneymtl.h">
+      <Filter>appleseeddisneymtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseeddisneymtl\datachunks.h">
+      <Filter>appleseeddisneymtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseeddisneymtl\resource.h">
+      <Filter>appleseeddisneymtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedsssmtl\appleseedsssmtl.h">
+      <Filter>appleseedsssmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedsssmtl\datachunks.h">
+      <Filter>appleseedsssmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedsssmtl\resource.h">
+      <Filter>appleseedsssmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedglassmtl\appleseedglassmtl.h">
+      <Filter>appleseedglassmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedglassmtl\datachunks.h">
+      <Filter>appleseedglassmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedglassmtl\resource.h">
+      <Filter>appleseedglassmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedlightmtl\appleseedlightmtl.h">
+      <Filter>appleseedlightmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedlightmtl\datachunks.h">
+      <Filter>appleseedlightmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedlightmtl\resource.h">
+      <Filter>appleseedlightmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="logtarget.h" />
+    <ClInclude Include="bump\resource.h">
+      <Filter>bump</Filter>
+    </ClInclude>
+    <ClInclude Include="bump\bumpparammapdlgproc.h">
+      <Filter>bump</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedobjpropsmod\appleseedobjpropsmod.h">
+      <Filter>appleseedobjpropsmod</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedobjpropsmod\resource.h">
+      <Filter>appleseedobjpropsmod</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedenvmap\appleseedenvmap.h">
+      <Filter>appleseedenvmap</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedenvmap\datachunks.h">
+      <Filter>appleseedenvmap</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedenvmap\resource.h">
+      <Filter>appleseedenvmap</Filter>
+    </ClInclude>
+    <ClInclude Include="seexprutils.h" />
+    <ClInclude Include="oslutils.h" />
+    <ClInclude Include="appleseedinteractive\appleseedinteractive.h">
+      <Filter>appleseedinteractive</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedinteractive\interactiverenderercontroller.h">
+      <Filter>appleseedinteractive</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedinteractive\interactivesession.h">
+      <Filter>appleseedinteractive</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedinteractive\interactivetilecallback.h">
+      <Filter>appleseedinteractive</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedblendmtl\appleseedblendmtl.h">
+      <Filter>appleseedblendmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedblendmtl\datachunks.h">
+      <Filter>appleseedblendmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedblendmtl\resource.h">
+      <Filter>appleseedblendmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedrenderer\dialoglogtarget.h">
+      <Filter>appleseedrenderer</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedoslplugin\templategenerator.h" />
+    <ClInclude Include="appleseedoslplugin\oslclassdesc.h">
+      <Filter>appleseedoslplugin</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedoslplugin\oslmaterial.h">
+      <Filter>appleseedoslplugin</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedoslplugin\oslparamdlg.h">
+      <Filter>appleseedoslplugin</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedoslplugin\oslshadermetadata.h">
+      <Filter>appleseedoslplugin</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedoslplugin\oslshaderregistry.h">
+      <Filter>appleseedoslplugin</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedoslplugin\osltexture.h">
+      <Filter>appleseedoslplugin</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedmetalmtl\appleseedmetalmtl.h">
+      <Filter>appleseedmetalmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedplasticmtl\appleseedplasticmtl.h">
+      <Filter>appleseedplasticmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedmetalmtl\datachunks.h">
+      <Filter>appleseedmetalmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedplasticmtl\datachunks.h">
+      <Filter>appleseedplasticmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedplasticmtl\resource.h">
+      <Filter>appleseedplasticmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="appleseedmetalmtl\resource.h">
+      <Filter>appleseedmetalmtl</Filter>
+    </ClInclude>
+    <ClInclude Include="builtinmapsupport.h" />
+    <ClInclude Include="osloutputselectormap\datachunks.h">
+      <Filter>osloutputselectormap</Filter>
+    </ClInclude>
+    <ClInclude Include="osloutputselectormap\osloutputselector.h">
+      <Filter>osloutputselectormap</Filter>
+    </ClInclude>
+    <ClInclude Include="osloutputselectormap\resource.h">
+      <Filter>osloutputselectormap</Filter>
+    </ClInclude>    
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="appleseedrenderer\appleseedrenderer.rc">
+      <Filter>appleseedrenderer</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="appleseeddisneymtl\appleseeddisneymtl.rc">
+      <Filter>appleseeddisneymtl</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="appleseedsssmtl\appleseedsssmtl.rc">
+      <Filter>appleseedsssmtl</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="appleseedglassmtl\appleseedglassmtl.rc">
+      <Filter>appleseedglassmtl</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="appleseedlightmtl\appleseedlightmtl.rc">
+      <Filter>appleseedlightmtl</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="bump\bump.rc">
+      <Filter>bump</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="appleseedobjpropsmod\appleseedobjpropsmod.rc">
+      <Filter>appleseedobjpropsmod</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="appleseedenvmap\appleseedenvmap.rc">
+      <Filter>appleseedenvmap</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="appleseedblendmtl\appleseedblendmtl.rc">
+      <Filter>appleseedblendmtl</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="appleseedmetalmtl\appleseedmetalmtl.rc">
+      <Filter>appleseedmetalmtl</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="appleseedplasticmtl\appleseedplasticmtl.rc">
+      <Filter>appleseedplasticmtl</Filter>
+    </ResourceCompile>
+    <ResourceCompile Include="osloutputselectormap\osloutputselector.rc">
+      <Filter>osloutputselectormap</Filter>
+    </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="bump">
+      <UniqueIdentifier>{28dbdbb6-9693-4bb5-bedf-e5f0e52c57ca}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="appleseedobjpropsmod">
+      <UniqueIdentifier>{de4af110-ea41-4ea2-a8be-f22563cd66aa}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="appleseedlightmtl">
+      <UniqueIdentifier>{f7d6f5af-25a2-427e-bf28-a4e46d2ddaf2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="appleseedglassmtl">
+      <UniqueIdentifier>{666a1c7e-ebcb-42b1-b62e-a57419733d4a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="appleseeddisneymtl">
+      <UniqueIdentifier>{0f63c39e-3c84-4009-a32b-ae9dfec1dc15}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="appleseedrenderer">
+      <UniqueIdentifier>{3b53d01d-35e2-4c3e-a0a4-6d9921c729a1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="appleseedsssmtl">
+      <UniqueIdentifier>{4e79312e-d35e-43b5-bc53-f2bd6ad9d984}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="appleseedenvmap">
+      <UniqueIdentifier>{41c47cf2-0141-4542-8ceb-f7dd8cd6da1f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="appleseedinteractive">
+      <UniqueIdentifier>{738b8ba2-d1ad-4c0e-b3f6-6f374cd418ea}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="appleseedblendmtl">
+      <UniqueIdentifier>{d115203b-d27f-49e3-9aee-6676110ffc63}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="appleseedoslplugin">
+      <UniqueIdentifier>{a83159d6-f9c3-48db-a640-3631607e2b3f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="appleseedmetalmtl">
+      <UniqueIdentifier>{da72b6d2-5882-474f-99fd-1c886bc53188}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="appleseedplasticmtl">
+      <UniqueIdentifier>{209beda5-1f93-4d87-87ff-e3db75f8b79e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="osloutputselectormap">
+      <UniqueIdentifier>{318596f7-e094-4f52-95b8-a84b79e03602}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+</Project>

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
@@ -140,7 +140,7 @@ BaseInterface* AppleseedRenderer::GetInterface(Interface_ID id)
     else return Renderer::GetInterface(id);
 }
 
-#if MAX_RELEASE == MAX_RELEASE_R19
+#if MAX_RELEASE > MAX_RELEASE_R18
 
 bool AppleseedRenderer::IsStopSupported() const
 {

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.h
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.h
@@ -72,7 +72,7 @@ class AppleseedRenderer
     virtual void* GetInterface(ULONG id) override;
     virtual BaseInterface* GetInterface(Interface_ID id) override;
 
-#if MAX_RELEASE == MAX_RELEASE_R19
+#if MAX_RELEASE > MAX_RELEASE_R18
 
     virtual bool IsStopSupported() const override;
     virtual void StopRendering() override;

--- a/src/appleseed-max/appleseed-max2018.vcxproj
+++ b/src/appleseed-max/appleseed-max2018.vcxproj
@@ -1,0 +1,193 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Ship|x64">
+      <Configuration>Ship</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="plugin.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="main.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{F43B3C0E-2A72-4B30-9016-DEC6B022D135}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>appleseedmax</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>appleseed-max2018</TargetName>
+    <TargetExt>.dlr</TargetExt>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>appleseed-max2018</TargetName>
+    <TargetExt>.dlr</TargetExt>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>appleseed-max2018</TargetName>
+    <TargetExt>.dlr</TargetExt>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <PreprocessorDefinitions>WIN32;WIN64;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;BOOST_FILESYSTEM_VERSION=3;BOOST_FILESYSTEM_NO_DEPRECATED;APPLESEED_WITH_OIIO;OIIO_STATIC_BUILD;APPLESEED_WITH_OSL;OSL_STATIC_LIBRARY;APPLESEED_WITH_DISNEY_MATERIAL;APPLESEED_WITH_NORMALIZED_DIFFUSION_BSSRDF;XERCES_STATIC_LIBRARY;BOOST_PYTHON_STATIC_LIB;APPLESEED_X86;APPLESEED_USE_SSE;DEBUG;APPLESEED_ENABLE_IMATH_INTEROP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir);C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\include;$(SolutionDir)..\..\appleseed\src\appleseed</AdditionalIncludeDirectories>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <StringPooling>true</StringPooling>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\lib\x64\Release</AdditionalLibraryDirectories>
+      <AdditionalDependencies>wininet.lib;bmm.lib;core.lib;maxutil.lib;Paramblk2.lib;ShLwApi.Lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <DelayLoadDLLs>
+      </DelayLoadDLLs>
+    </Link>
+    <PostBuildEvent>
+      <Command>mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)" 2&gt;nul
+mkdir "$(SolutionDir)..\sandbox\max2018\Current" 2&gt;nul
+
+copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
+copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\Current\"
+
+if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
+if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\Current\"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>Full</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;WIN64;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;BOOST_FILESYSTEM_VERSION=3;BOOST_FILESYSTEM_NO_DEPRECATED;APPLESEED_WITH_OIIO;OIIO_STATIC_BUILD;APPLESEED_WITH_OSL;OSL_STATIC_LIBRARY;APPLESEED_WITH_DISNEY_MATERIAL;APPLESEED_WITH_NORMALIZED_DIFFUSION_BSSRDF;XERCES_STATIC_LIBRARY;BOOST_PYTHON_STATIC_LIB;APPLESEED_X86;APPLESEED_USE_SSE;APPLESEED_ENABLE_IMATH_INTEROP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir);C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\include;$(SolutionDir)..\..\appleseed\src\appleseed</AdditionalIncludeDirectories>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <StringPooling>true</StringPooling>
+      <FunctionLevelLinking>false</FunctionLevelLinking>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\lib\x64\Release</AdditionalLibraryDirectories>
+      <AdditionalDependencies>wininet.lib;bmm.lib;core.lib;maxutil.lib;Paramblk2.lib;ShLwApi.Lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>
+      </DelayLoadDLLs>
+    </Link>
+    <PostBuildEvent>
+      <Command>mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)" 2&gt;nul
+mkdir "$(SolutionDir)..\sandbox\max2018\Current" 2&gt;nul
+
+copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
+copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\Current\"
+
+if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
+if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\Current\"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>Full</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;WIN64;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;BOOST_FILESYSTEM_VERSION=3;BOOST_FILESYSTEM_NO_DEPRECATED;APPLESEED_WITH_OIIO;OIIO_STATIC_BUILD;APPLESEED_WITH_OSL;OSL_STATIC_LIBRARY;APPLESEED_WITH_DISNEY_MATERIAL;APPLESEED_WITH_NORMALIZED_DIFFUSION_BSSRDF;XERCES_STATIC_LIBRARY;BOOST_PYTHON_STATIC_LIB;APPLESEED_X86;APPLESEED_USE_SSE;APPLESEED_ENABLE_IMATH_INTEROP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir);C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\include;$(SolutionDir)..\..\appleseed\src\appleseed</AdditionalIncludeDirectories>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>true</OmitFramePointers>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <StringPooling>true</StringPooling>
+      <FunctionLevelLinking>false</FunctionLevelLinking>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\lib\x64\Release</AdditionalLibraryDirectories>
+      <AdditionalDependencies>wininet.lib;bmm.lib;core.lib;maxutil.lib;Paramblk2.lib;ShLwApi.Lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <DelayLoadDLLs>
+      </DelayLoadDLLs>
+    </Link>
+    <PostBuildEvent>
+      <Command>mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)" 2&gt;nul
+mkdir "$(SolutionDir)..\sandbox\max2018\Current" 2&gt;nul
+
+copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
+copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\Current\"
+
+if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
+if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\Current\"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/appleseed-max/appleseed-max2018.vcxproj.filters
+++ b/src/appleseed-max/appleseed-max2018.vcxproj.filters
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="plugin.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="main.h" />
+  </ItemGroup>
+</Project>

--- a/src/appleseed-max/plugin.cpp
+++ b/src/appleseed-max/plugin.cpp
@@ -135,6 +135,8 @@ extern "C"
         static const wchar_t PluginImplDLLFilename[] = L"appleseed-max2016-impl.dll";
 #elif MAX_RELEASE == MAX_RELEASE_R19
         static const wchar_t PluginImplDLLFilename[] = L"appleseed-max2017-impl.dll";
+#elif MAX_RELEASE == MAX_RELEASE_R20
+        static const wchar_t PluginImplDLLFilename[] = L"appleseed-max2018-impl.dll";
 #else
 #error This version of 3ds Max is not supported by the appleseed plugin.
 #endif

--- a/src/appleseed-max2018.sln
+++ b/src/appleseed-max2018.sln
@@ -1,0 +1,33 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "appleseed-max-impl", "appleseed-max-impl\appleseed-max2018-impl.vcxproj", "{62C41566-DBCB-49D3-943A-4DD53222269E}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "appleseed-max", "appleseed-max\appleseed-max2018.vcxproj", "{F43B3C0E-2A72-4B30-9016-DEC6B022D135}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+		Ship|x64 = Ship|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{62C41566-DBCB-49D3-943A-4DD53222269E}.Debug|x64.ActiveCfg = Debug|x64
+		{62C41566-DBCB-49D3-943A-4DD53222269E}.Debug|x64.Build.0 = Debug|x64
+		{62C41566-DBCB-49D3-943A-4DD53222269E}.Release|x64.ActiveCfg = Release|x64
+		{62C41566-DBCB-49D3-943A-4DD53222269E}.Release|x64.Build.0 = Release|x64
+		{62C41566-DBCB-49D3-943A-4DD53222269E}.Ship|x64.ActiveCfg = Ship|x64
+		{62C41566-DBCB-49D3-943A-4DD53222269E}.Ship|x64.Build.0 = Ship|x64
+		{F43B3C0E-2A72-4B30-9016-DEC6B022D135}.Debug|x64.ActiveCfg = Debug|x64
+		{F43B3C0E-2A72-4B30-9016-DEC6B022D135}.Debug|x64.Build.0 = Debug|x64
+		{F43B3C0E-2A72-4B30-9016-DEC6B022D135}.Release|x64.ActiveCfg = Release|x64
+		{F43B3C0E-2A72-4B30-9016-DEC6B022D135}.Release|x64.Build.0 = Release|x64
+		{F43B3C0E-2A72-4B30-9016-DEC6B022D135}.Ship|x64.ActiveCfg = Ship|x64
+		{F43B3C0E-2A72-4B30-9016-DEC6B022D135}.Ship|x64.Build.0 = Ship|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Support for 3ds max 2018 sdk. I've compiled with vs2017 and it worked. 
Same (v140) platform toolset is used as for max2017 plugin so no changes to appleseed.dll required.

Thanks for review.