### PR TITLE
Support normal map amount, enable amount parameter in Normal map mode

### DIFF
--- a/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
+++ b/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
@@ -760,7 +760,7 @@ asf::auto_release_ptr<asr::Material> AppleseedDisneyMtl::create_osl_material(
         else
         {
             // Normal mapping.
-            connect_normal_map(shader_group.ref(), name, "Normal", "Tn", m_bump_texmap, m_bump_up_vector);
+            connect_normal_map(shader_group.ref(), name, "Normal", "Tn", m_bump_texmap, m_bump_up_vector, m_bump_amount);
         }
     }
 

--- a/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.cpp
+++ b/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.cpp
@@ -677,7 +677,7 @@ asf::auto_release_ptr<asr::Material> AppleseedGlassMtl::create_osl_material(
         else
         {
             // Normal mapping.
-            connect_normal_map(shader_group.ref(), name, "Normal", "Tn", m_bump_texmap, m_bump_up_vector);
+            connect_normal_map(shader_group.ref(), name, "Normal", "Tn", m_bump_texmap, m_bump_up_vector, m_bump_amount);
         }
     }
 

--- a/src/appleseed-max-impl/appleseedmetalmtl/appleseedmetalmtl.cpp
+++ b/src/appleseed-max-impl/appleseedmetalmtl/appleseedmetalmtl.cpp
@@ -656,7 +656,7 @@ asf::auto_release_ptr<asr::Material> AppleseedMetalMtl::create_osl_material(
         else
         {
             // Normal mapping.
-            connect_normal_map(shader_group.ref(), name, "Normal", "Tn", m_bump_texmap, m_bump_up_vector);
+            connect_normal_map(shader_group.ref(), name, "Normal", "Tn", m_bump_texmap, m_bump_up_vector, m_bump_amount);
         }
     }
 

--- a/src/appleseed-max-impl/appleseedoslplugin/oslmaterial.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslmaterial.cpp
@@ -518,7 +518,14 @@ asf::auto_release_ptr<asr::Material> OSLMaterial::create_osl_material(
                 else if (m_has_normal_params)
                 {
                     // Normal mapping.
-                    connect_normal_map(shader_group.ref(), name, bump_param->m_param_name.c_str(), "Tn", bump_texmap, bump_up_vector);
+                    connect_normal_map(
+                        shader_group.ref(),
+                        name,
+                        bump_param->m_param_name.c_str(),
+                        "Tn",
+                        bump_texmap,
+                        bump_up_vector,
+                        bump_amount);
                 }
             }
         }

--- a/src/appleseed-max-impl/appleseedplasticmtl/appleseedplasticmtl.cpp
+++ b/src/appleseed-max-impl/appleseedplasticmtl/appleseedplasticmtl.cpp
@@ -677,7 +677,7 @@ asf::auto_release_ptr<asr::Material> AppleseedPlasticMtl::create_osl_material(
         else
         {
             // Normal mapping.
-            connect_normal_map(shader_group.ref(), name, "Normal", "Tn", m_bump_texmap, m_bump_up_vector);
+            connect_normal_map(shader_group.ref(), name, "Normal", "Tn", m_bump_texmap, m_bump_up_vector, m_bump_amount);
         }
     }
 

--- a/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
+++ b/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
@@ -697,7 +697,7 @@ asf::auto_release_ptr<asr::Material> AppleseedSSSMtl::create_osl_material(
         else
         {
             // Normal mapping.
-            connect_normal_map(shader_group.ref(), name, "Normal", "Tn", m_bump_texmap, m_bump_up_vector);
+            connect_normal_map(shader_group.ref(), name, "Normal", "Tn", m_bump_texmap, m_bump_up_vector, m_bump_amount);
         }
     }
 

--- a/src/appleseed-max-impl/bump/bumpparammapdlgproc.h
+++ b/src/appleseed-max-impl/bump/bumpparammapdlgproc.h
@@ -84,8 +84,6 @@ class BumpParamMapDlgProc
     void enable_disable_controls(HWND hwnd)
     {
         auto selected = SendMessage(GetDlgItem(hwnd, IDC_COMBO_BUMP_METHOD), CB_GETCURSEL, 0, 0);
-        EnableWindow(GetDlgItem(hwnd, IDC_EDIT_BUMP_AMOUNT), selected == 0 ? TRUE : FALSE);
-        EnableWindow(GetDlgItem(hwnd, IDC_SPINNER_BUMP_AMOUNT), selected == 0 ? TRUE : FALSE);
         EnableWindow(GetDlgItem(hwnd, IDC_COMBO_BUMP_UP_VECTOR), selected == 1 ? TRUE : FALSE);
     }
 };

--- a/src/appleseed-max-impl/oslutils.cpp
+++ b/src/appleseed-max-impl/oslutils.cpp
@@ -451,7 +451,8 @@ void connect_normal_map(
     const char*         material_normal_input_name,
     const char*         material_tn_input_name,
     Texmap*             texmap,
-    const int           up_vector)
+    const int           up_vector,
+    const float         amount)
 {
     if (is_supported_procedural_texture(texmap, false) || is_osl_texture(texmap))
     {
@@ -466,7 +467,8 @@ void connect_normal_map(
 
         shader_group.add_shader("shader", "as_max_normal_map", normal_map_layer_name.c_str(),
             asr::ParamArray()
-                .insert("UpVector", fmt_osl_expr(up_vector == 0 ? "Green" : "Blue")));
+                .insert("UpVector", fmt_osl_expr(up_vector == 0 ? "Green" : "Blue"))
+                .insert("Amount", fmt_osl_expr(amount)));
 
         shader_group.add_connection(
             normal_map_layer_name.c_str(), "NormalOut",
@@ -491,7 +493,8 @@ void connect_normal_map(
         auto normal_map_layer_name = asf::format("{0}_normal_map", material_node_name);
         shader_group.add_shader("shader", "as_max_normal_map", normal_map_layer_name.c_str(),
             asr::ParamArray()
-                .insert("UpVector", fmt_osl_expr(up_vector == 0 ? "Green" : "Blue")));
+                .insert("UpVector", fmt_osl_expr(up_vector == 0 ? "Green" : "Blue"))
+                .insert("Amount", fmt_osl_expr(amount)));
 
         shader_group.add_connection(
             uv_transform_layer_name.c_str(), "out_U",

--- a/src/appleseed-max-impl/oslutils.h
+++ b/src/appleseed-max-impl/oslutils.h
@@ -97,7 +97,8 @@ void connect_normal_map(
     const char*             material_normal_input_name,
     const char*             material_tn_input_name,
     Texmap*                 texmap,
-    const int               up_vector);
+    const int               up_vector,
+    const float             amount);
 
 void connect_sub_mtl(
     renderer::Assembly&     assembly,


### PR DESCRIPTION
In this version Amount parameter in appleseed's Bump rollout is enabled in normal map mode and it is connected to normal map shader's Amount parameter.
