### PR TITLE
Disable project exporting options when Use Max Procedural Maps turned on (issue #175)

### DIFF
--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.rc
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.rc
@@ -127,7 +127,7 @@ BEGIN
     CONTROL         "CPU Cores",IDC_TEXT_RENDERINGTHREADS,"CustEdit",WS_TABSTOP,39,5,30,10
     CONTROL         "CPU Cores",IDC_SPINNER_RENDERINGTHREADS,"SpinnerControl",WS_TABSTOP,71,5,6,10
     CONTROL         "Low Priority Mode",IDC_CHECK_LOW_PRIORITY_MODE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,0,58,73,10
-    CONTROL         "Use Max Procedural Maps (non-compatible mode)",IDC_CHECK_USE_MAX_PROCEDURAL_MAPS,
+    CONTROL         "Use Max Procedural Maps (disables scene export)",IDC_CHECK_USE_MAX_PROCEDURAL_MAPS,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,0,48,197,10
     COMBOBOX        IDC_COMBO_LOG,39,20,65,30,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     LTEXT           "Open Log:",IDC_STATIC_LOG,0,23,34,8

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.cpp
@@ -565,10 +565,10 @@ namespace
 
         virtual void init(HWND hwnd) override
         {
+            m_static_project_filepath = GetDlgItem(hwnd, IDC_STATIC_PROJECT_FILEPATH);
             m_radio_render_only = GetDlgItem(hwnd, IDC_RADIO_RENDER);
             m_radio_save_only = GetDlgItem(hwnd, IDC_RADIO_SAVEPROJECT);
             m_radio_save_and_render = GetDlgItem(hwnd, IDC_RADIO_SAVEPROJECT_AND_RENDER);
-            m_static_project_filepath = GetDlgItem(hwnd, IDC_STATIC_PROJECT_FILEPATH);
             m_text_project_filepath = GetICustEdit(GetDlgItem(hwnd, IDC_TEXT_PROJECT_FILEPATH));
             m_text_project_filepath->SetText(m_settings.m_project_file_path);
             m_button_browse = GetICustButton(GetDlgItem(hwnd, IDC_BUTTON_BROWSE));

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.cpp
@@ -530,10 +530,10 @@ namespace
         IRendParams*            m_rend_params;
         RendererSettings&       m_settings;
         HWND                    m_rollup;
-        HWND                    m_static_project_filepath;
         HWND                    m_radio_render_only;
         HWND                    m_radio_save_only;
         HWND                    m_radio_save_and_render;
+        HWND                    m_static_project_filepath;
         ICustEdit*              m_text_project_filepath;
         ICustButton*            m_button_browse;
         ICustEdit*              m_text_scale_multiplier;
@@ -565,10 +565,10 @@ namespace
 
         virtual void init(HWND hwnd) override
         {
-            m_static_project_filepath = GetDlgItem(hwnd, IDC_STATIC_PROJECT_FILEPATH);
             m_radio_render_only = GetDlgItem(hwnd, IDC_RADIO_RENDER);
             m_radio_save_only = GetDlgItem(hwnd, IDC_RADIO_SAVEPROJECT);
             m_radio_save_and_render = GetDlgItem(hwnd, IDC_RADIO_SAVEPROJECT_AND_RENDER);
+            m_static_project_filepath = GetDlgItem(hwnd, IDC_STATIC_PROJECT_FILEPATH);
             m_text_project_filepath = GetICustEdit(GetDlgItem(hwnd, IDC_TEXT_PROJECT_FILEPATH));
             m_text_project_filepath->SetText(m_settings.m_project_file_path);
             m_button_browse = GetICustButton(GetDlgItem(hwnd, IDC_BUTTON_BROWSE));
@@ -592,7 +592,7 @@ namespace
             enable_disable_controls(false);
         }
 
-        void enable_disable_controls(bool use_max_procedural_maps)
+        void enable_disable_controls(const bool use_max_procedural_maps)
         {
             const bool save_project =
                 m_settings.m_output_mode == RendererSettings::OutputMode::SaveProjectOnly ||


### PR DESCRIPTION
Scene export ui elements are disabled when Use Max Procedurals mode is selected.