### PR TITLE
Fix built-in Plastic material in OSL mode

### DIFF
--- a/src/appleseed-max-impl/appleseedplasticmtl/appleseedplasticmtl.cpp
+++ b/src/appleseed-max-impl/appleseedplasticmtl/appleseedplasticmtl.cpp
@@ -683,11 +683,11 @@ asf::auto_release_ptr<asr::Material> AppleseedPlasticMtl::create_osl_material(
 
     shader_group->add_shader("surface", "as_max_plastic_material", name, 
         asr::ParamArray()
-            .insert("DiffuseColor", fmt_osl_expr(to_color3f(m_diffuse)))
             .insert("SpecularColor", fmt_osl_expr(to_color3f(m_specular)))
-            .insert("Roughness", fmt_osl_expr(m_roughness / 100.0f))
             .insert("SpecularWeight", fmt_osl_expr(m_specular_weight / 100.0f))
+            .insert("DiffuseColor", fmt_osl_expr(to_color3f(m_diffuse)))
             .insert("DiffuseWeight", fmt_osl_expr(m_diffuse_weight / 100.0f))
+            .insert("Roughness", fmt_osl_expr(m_roughness / 100.0f))
             .insert("Spread", fmt_osl_expr(m_highlight_falloff / 100.0f))
             .insert("Scattering", fmt_osl_expr(m_scattering / 100.0f))
             .insert("IOR", fmt_osl_expr(m_ior)));

--- a/src/appleseed-max-impl/appleseedplasticmtl/appleseedplasticmtl.cpp
+++ b/src/appleseed-max-impl/appleseedplasticmtl/appleseedplasticmtl.cpp
@@ -683,6 +683,9 @@ asf::auto_release_ptr<asr::Material> AppleseedPlasticMtl::create_osl_material(
 
     shader_group->add_shader("surface", "as_max_plastic_material", name, 
         asr::ParamArray()
+            .insert("DiffuseColor", fmt_osl_expr(to_color3f(m_diffuse)))
+            .insert("SpecularColor", fmt_osl_expr(to_color3f(m_specular)))
+            .insert("Roughness", fmt_osl_expr(m_roughness / 100.0f))
             .insert("SpecularWeight", fmt_osl_expr(m_specular_weight / 100.0f))
             .insert("DiffuseWeight", fmt_osl_expr(m_diffuse_weight / 100.0f))
             .insert("Spread", fmt_osl_expr(m_highlight_falloff / 100.0f))


### PR DESCRIPTION
There's unreported bug in Plastic material. When rendering in normal mode Diffuse and Specular colors and Roughness parameter do not affect the material.