### PR TITLE
Implement renderer UI with ParamBlock

### DIFF
--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
@@ -161,9 +161,9 @@ void AppleseedRendererPBlockAccessor::Get(
         v.f = settings.m_scale_multiplier;
         break;
         
-    //
-    // Image Sampling.
-    //
+      //
+      // Image Sampling.
+      //
 
       case ParamIdPixelSamples:
         v.i = settings.m_pixel_samples;
@@ -177,9 +177,9 @@ void AppleseedRendererPBlockAccessor::Get(
         v.i = settings.m_passes;
         break;
 
-    //
-    // Pixel Filtering.
-    //
+      //
+      // Pixel Filtering.
+      //
 
       case ParamIdFilterType:
         v.i = settings.m_pixel_filter;
@@ -189,9 +189,9 @@ void AppleseedRendererPBlockAccessor::Get(
         v.f = settings.m_pixel_filter_size;
         break;
 
-    //
-    // Lighting.
-    //
+      //
+      // Lighting.
+      //
 
       case ParamIdEnableGI:
         v.i = static_cast<int>(settings.m_gi);
@@ -225,9 +225,9 @@ void AppleseedRendererPBlockAccessor::Get(
         v.f = settings.m_background_alpha;
         break;
 
-    //
-    // System.
-    //
+      //
+      // System.
+      //
 
       case ParamIdCPUCores:
         v.i = settings.m_rendering_threads;
@@ -651,7 +651,7 @@ void AppleseedRenderer::SetReference(int i, RefTargetHandle rtarg)
     switch (i)
     {
       case 0:
-        m_param_block = dynamic_cast<IParamBlock2*>(rtarg);
+        m_param_block = static_cast<IParamBlock2*>(rtarg);
         break;
       default:
         DbgAssert(false);
@@ -1314,10 +1314,7 @@ const MCHAR* AppleseedRendererClassDesc::InternalName()
 const MCHAR* AppleseedRendererClassDesc::GetRsrcString(INT_PTR id)
 {
     const asf::KeyValuePair<int, const wchar_t*>* dialog_string_pair =
-        lookup_kvpair_array(
-            g_dialog_strings,
-            11,
-            id);
+        LOOKUP_KVPAIR_ARRAY(g_dialog_strings, id);
 
     return dialog_string_pair->m_value;
 }

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
@@ -400,7 +400,11 @@ ParamBlockDesc2 g_param_block_desc(
     L"appleseed render parameters",             // internal parameter block's name
     0,                                          // ID of the localized name string
     &g_appleseed_renderer_classdesc,            // class descriptor
-    P_AUTO_CONSTRUCT + P_AUTO_UI + P_MULTIMAP + P_VERSION,  // block flags
+    P_AUTO_CONSTRUCT + 
+    P_AUTO_UI + 
+    P_MULTIMAP + 
+    P_VERSION + 
+    P_CALLSETS_ON_LOAD,                         // block flags
 
     1,                                          // --- P_VERSION arguments ---
 
@@ -442,17 +446,17 @@ ParamBlockDesc2 g_param_block_desc(
 
     // --- Parameters specifications for Output rollup ---
 
-    ParamIdOuputMode, L"output_mode", TYPE_INT, 0, 0,
+    ParamIdOuputMode, L"output_mode", TYPE_INT, P_TRANSIENT, 0,
         p_ui, ParamMapIdOutput, TYPE_RADIO, 3, IDC_RADIO_RENDER, IDC_RADIO_SAVEPROJECT, IDC_RADIO_SAVEPROJECT_AND_RENDER,
         p_accessor, &g_pblock_accessor,
     p_end,
 
-    ParamIdProjectPath, L"project_path", TYPE_STRING, 0, 0,
+    ParamIdProjectPath, L"project_path", TYPE_STRING, P_TRANSIENT, 0,
         p_ui, ParamMapIdOutput, TYPE_EDITBOX, IDC_TEXT_PROJECT_FILEPATH,
     p_accessor, &g_pblock_accessor,
     p_end,
 
-    ParamIdScaleMultiplier, L"scale_multiplier", TYPE_FLOAT, 0, 0,
+    ParamIdScaleMultiplier, L"scale_multiplier", TYPE_FLOAT, P_TRANSIENT, 0,
         p_ui, ParamMapIdOutput, TYPE_SPINNER, EDITTYPE_FLOAT, IDC_TEXT_SCALE_MULTIPLIER, IDC_SPINNER_SCALE_MULTIPLIER, SPIN_AUTOSCALE,
         p_default, 1.0f,
         p_range, 1.0e-6f, 1.0e6f,
@@ -461,35 +465,35 @@ ParamBlockDesc2 g_param_block_desc(
 
     // --- Parameters specifications for Image Sampling rollup ---
 
-    ParamIdPixelSamples, L"pixel_samples", TYPE_INT, 0, 0,
+    ParamIdPixelSamples, L"pixel_samples", TYPE_INT, P_TRANSIENT, 0,
         p_ui, ParamMapIdImageSampling, TYPE_SPINNER, EDITTYPE_INT, IDC_TEXT_PIXEL_SAMPLES, IDC_SPINNER_PIXEL_SAMPLES, SPIN_AUTOSCALE,
         p_default, 16,
         p_range, 1, 1000000,
         p_accessor, &g_pblock_accessor,
     p_end,
 
-    ParamIdTileSize, L"tile_size", TYPE_INT, 0, 0,
+    ParamIdTileSize, L"tile_size", TYPE_INT, P_TRANSIENT, 0,
         p_ui, ParamMapIdImageSampling, TYPE_SPINNER, EDITTYPE_INT, IDC_TEXT_TILE_SIZE, IDC_SPINNER_TILE_SIZE, SPIN_AUTOSCALE,
         p_default, 64,
         p_range, 1, 4096,
         p_accessor, &g_pblock_accessor,
     p_end,
 
-    ParamIdPasses, L"passes", TYPE_INT, 0, 0,
+    ParamIdPasses, L"passes", TYPE_INT, P_TRANSIENT, 0,
         p_ui, ParamMapIdImageSampling, TYPE_SPINNER, EDITTYPE_INT, IDC_TEXT_PASSES, IDC_SPINNER_PASSES, SPIN_AUTOSCALE,
         p_default, 1,
         p_range, 1, 1000000,
         p_accessor, &g_pblock_accessor,
     p_end,
 
-    ParamIdFilterSize, L"filter_size", TYPE_FLOAT, 0, 0,
+    ParamIdFilterSize, L"filter_size", TYPE_FLOAT, P_TRANSIENT, 0,
         p_ui, ParamMapIdImageSampling, TYPE_SPINNER, EDITTYPE_FLOAT, IDC_TEXT_FILTER_SIZE, IDC_SPINNER_FILTER_SIZE, SPIN_AUTOSCALE,
         p_default, 1.5f,
         p_range, 1.0f, 20.0f,
         p_accessor, &g_pblock_accessor,
     p_end,
 
-    ParamIdFilterType, L"filter_type", TYPE_INT, 0, 0,
+    ParamIdFilterType, L"filter_type", TYPE_INT, P_TRANSIENT, 0,
         p_ui, ParamMapIdImageSampling, TYPE_INT_COMBOBOX, IDC_COMBO_FILTER,
         8, IDS_RENDERERPARAMS_FILTER_TYPE_1, IDS_RENDERERPARAMS_FILTER_TYPE_2,
         IDS_RENDERERPARAMS_FILTER_TYPE_3, IDS_RENDERERPARAMS_FILTER_TYPE_4,
@@ -501,53 +505,53 @@ ParamBlockDesc2 g_param_block_desc(
 
     // --- Parameters specifications for Lighting rollup ---
 
-    ParamIdEnableGI, L"enable_global_illumination", TYPE_BOOL, 0, 0,
+    ParamIdEnableGI, L"enable_global_illumination", TYPE_BOOL, P_TRANSIENT, 0,
         p_ui, ParamMapIdLighting, TYPE_SINGLECHEKBOX, IDC_CHECK_GI,
         p_default, TRUE,
         p_enable_ctrls, 1, ParamIdGIBounces,
         p_accessor, &g_pblock_accessor,
     p_end,
 
-    ParamIdGIBounces, L"global_illumination_bounces", TYPE_INT, 0, 0,
+    ParamIdGIBounces, L"global_illumination_bounces", TYPE_INT, P_TRANSIENT, 0,
         p_ui, ParamMapIdLighting, TYPE_SPINNER, EDITTYPE_INT, IDC_TEXT_BOUNCES, IDC_SPINNER_BOUNCES, SPIN_AUTOSCALE,
         p_default, 3,
         p_range, 0, 100,
         p_accessor, &g_pblock_accessor,
     p_end,
 
-    ParamIdEnableCaustics, L"enable_caustics", TYPE_BOOL, 0, 0,
+    ParamIdEnableCaustics, L"enable_caustics", TYPE_BOOL, P_TRANSIENT, 0,
         p_ui, ParamMapIdLighting, TYPE_SINGLECHEKBOX, IDC_CHECK_CAUSTICS,
         p_default, FALSE,
         p_accessor, &g_pblock_accessor,
     p_end,
 
-    ParamIdEnableMaxRayIntensity, L"enable_max_ray", TYPE_BOOL, 0, 0,
+    ParamIdEnableMaxRayIntensity, L"enable_max_ray", TYPE_BOOL, P_TRANSIENT, 0,
         p_ui, ParamMapIdLighting, TYPE_SINGLECHEKBOX, IDC_CHECK_MAX_RAY_INTENSITY,
         p_default, FALSE,
         p_enable_ctrls, 1, ParamIdMaxRayIntensity,
         p_accessor, &g_pblock_accessor,
     p_end,
 
-    ParamIdMaxRayIntensity, L"max_ray_value", TYPE_FLOAT, 0, 0,
+    ParamIdMaxRayIntensity, L"max_ray_value", TYPE_FLOAT, P_TRANSIENT, 0,
         p_ui, ParamMapIdLighting, TYPE_SPINNER, EDITTYPE_FLOAT, IDC_TEXT_MAX_RAY_INTENSITY, IDC_SPINNER_MAX_RAY_INTENSITY, SPIN_AUTOSCALE,
         p_default, 1.0f,
         p_range, 0.0f, 1000.0f,
         p_accessor, &g_pblock_accessor,
     p_end,
 
-    ParamIdForceDefaultLightsOff, L"force_default_lights_off", TYPE_BOOL, 0, 0,
+    ParamIdForceDefaultLightsOff, L"force_default_lights_off", TYPE_BOOL, P_TRANSIENT, 0,
         p_ui, ParamMapIdLighting, TYPE_SINGLECHEKBOX, IDC_CHECK_FORCE_OFF_DEFAULT_LIGHT,
         p_default, FALSE,
         p_accessor, &g_pblock_accessor,
     p_end,
 
-    ParamIdEnableBackgroundLight, L"enable_background_light", TYPE_BOOL, 0, 0,
+    ParamIdEnableBackgroundLight, L"enable_background_light", TYPE_BOOL, P_TRANSIENT, 0,
         p_ui, ParamMapIdLighting, TYPE_SINGLECHEKBOX, IDC_CHECK_BACKGROUND_EMITS_LIGHT,
         p_default, TRUE,
         p_accessor, &g_pblock_accessor,
     p_end,
 
-    ParamIdBackgroundAlphaValue, L"background_alpha", TYPE_FLOAT, 0, 0,
+    ParamIdBackgroundAlphaValue, L"background_alpha", TYPE_FLOAT, P_TRANSIENT, 0,
         p_ui, ParamMapIdLighting, TYPE_SPINNER, EDITTYPE_FLOAT, IDC_TEXT_BACKGROUND_ALPHA, IDC_SPINNER_BACKGROUND_ALPHA, SPIN_AUTOSCALE,
         p_default, 0.0f,
         p_range, 0.0f, 1.0f,
@@ -556,14 +560,14 @@ ParamBlockDesc2 g_param_block_desc(
 
     // --- Parameters specifications for System rollup ---
 
-    ParamIdCPUCores, L"cpu_cores", TYPE_INT, 0, 0,
+    ParamIdCPUCores, L"cpu_cores", TYPE_INT, P_TRANSIENT, 0,
         p_ui, ParamMapIdSystem, TYPE_SPINNER, EDITTYPE_INT, IDC_TEXT_RENDERINGTHREADS, IDC_SPINNER_RENDERINGTHREADS, SPIN_AUTOSCALE,
         p_default, 0,
         p_range, -255, 256,
         p_accessor, &g_pblock_accessor,
     p_end,
 
-    ParamIdOpenLogMode, L"log_open_mode", TYPE_INT, 0, 0,
+    ParamIdOpenLogMode, L"log_open_mode", TYPE_INT, P_TRANSIENT, 0,
         p_ui, ParamMapIdSystem, TYPE_INT_COMBOBOX, IDC_COMBO_LOG,
         3, IDS_RENDERERPARAMS_LOG_OPEN_MODE_1, IDS_RENDERERPARAMS_LOG_OPEN_MODE_2,
         IDS_RENDERERPARAMS_LOG_OPEN_MODE_3,
@@ -571,32 +575,32 @@ ParamBlockDesc2 g_param_block_desc(
         p_accessor, &g_pblock_accessor,
     p_end,
 
-    ParamIdLogMaterialRendering, L"log_material_editor_rendering", TYPE_BOOL, 0, 0,
+    ParamIdLogMaterialRendering, L"log_material_editor_rendering", TYPE_BOOL, P_TRANSIENT, 0,
         p_ui, ParamMapIdSystem, TYPE_SINGLECHEKBOX, IDC_CHECK_LOG_MATERIAL_EDITOR,
         p_default, TRUE,
         p_accessor, &g_pblock_accessor,
     p_end,
 
-    ParamIdUseMaxProcedurals, L"use_max_procedural_maps", TYPE_BOOL, 0, 0,
+    ParamIdUseMaxProcedurals, L"use_max_procedural_maps", TYPE_BOOL, P_TRANSIENT, 0,
         p_ui, ParamMapIdSystem, TYPE_SINGLECHEKBOX, IDC_CHECK_USE_MAX_PROCEDURAL_MAPS,
         p_default, FALSE,
         p_accessor, &g_pblock_accessor,
     p_end,
     
-    ParamIdEnableLowPriority, L"low_priority_mode", TYPE_BOOL, 0, 0,
+    ParamIdEnableLowPriority, L"low_priority_mode", TYPE_BOOL, P_TRANSIENT, 0,
         p_ui, ParamMapIdSystem, TYPE_SINGLECHEKBOX, IDC_CHECK_LOW_PRIORITY_MODE,
         p_default, TRUE,
         p_accessor, &g_pblock_accessor,
     p_end,
 
-    ParamIdEnableRenderStamp, L"enable_render_stamp", TYPE_BOOL, 0, 0,
+    ParamIdEnableRenderStamp, L"enable_render_stamp", TYPE_BOOL, P_TRANSIENT, 0,
         p_ui, ParamMapIdSystem, TYPE_SINGLECHEKBOX, IDC_CHECK_RENDER_STAMP,
         p_default, FALSE,
         p_enable_ctrls, 1, ParamIdRenderStampFormat,
         p_accessor, &g_pblock_accessor,
     p_end,
 
-    ParamIdRenderStampFormat, L"render_stamp_format", TYPE_STRING, 0, 0,
+    ParamIdRenderStampFormat, L"render_stamp_format", TYPE_STRING, P_TRANSIENT, 0,
         p_ui, ParamMapIdSystem, TYPE_EDITBOX, IDC_TEXT_RENDER_STAMP,
         p_default, L"appleseed {lib-version} | Time: {render-time}",
         p_accessor, &g_pblock_accessor,

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
@@ -54,6 +54,7 @@
 #include "foundation/platform/thread.h"
 #include "foundation/platform/types.h"
 #include "foundation/utility/autoreleaseptr.h"
+#include "foundation/utility/kvpair.h"
 
 // 3ds Max headers.
 #include <assert1.h>
@@ -1160,7 +1161,6 @@ RendParamDlg* AppleseedRenderer::CreateParamDialog(
         new AppleseedRendererParamDlg(
             rend_params,
             in_progress,
-            m_settings,
             this);
 }
 
@@ -1317,8 +1317,7 @@ const MCHAR* AppleseedRendererClassDesc::InternalName()
 
 const MCHAR* AppleseedRendererClassDesc::GetRsrcString(INT_PTR id)
 {
-    const asf::KeyValuePair<int, const wchar_t*>* dialog_string_pair =
-        LOOKUP_KVPAIR_ARRAY(g_dialog_strings, id);
+    const auto* dialog_string_pair = LOOKUP_KVPAIR_ARRAY(g_dialog_strings, id);
 
     return dialog_string_pair->m_value;
 }

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
@@ -115,15 +115,21 @@ namespace
         ParamIdEnableRenderStamp        = 21,
         ParamIdRenderStampFormat        = 22,
     };
-
-    MCHAR* GetString(int id)
+    
+    const asf::KeyValuePair<int, const wchar_t*> g_dialog_strings[] =
     {
-        static wchar_t buf[256];
-
-        if (g_module)
-            return LoadString(g_module, id, buf, _countof(buf)) ? buf : nullptr;
-        return nullptr;
-    }
+        { IDS_RENDERERPARAMS_FILTER_TYPE_1,     L"Blackman-Harris" },
+        { IDS_RENDERERPARAMS_FILTER_TYPE_2,     L"Box" },
+        { IDS_RENDERERPARAMS_FILTER_TYPE_3,     L"Catmull-Rom Spline" },
+        { IDS_RENDERERPARAMS_FILTER_TYPE_4,     L"Cubic B-spline" },
+        { IDS_RENDERERPARAMS_FILTER_TYPE_5,     L"Gaussian" },
+        { IDS_RENDERERPARAMS_FILTER_TYPE_6,     L"Lanczos" },
+        { IDS_RENDERERPARAMS_FILTER_TYPE_7,     L"Mitchell-Netravali" },
+        { IDS_RENDERERPARAMS_FILTER_TYPE_8,     L"Triangle" },
+        { IDS_RENDERERPARAMS_LOG_OPEN_MODE_1,   L"Always" },
+        { IDS_RENDERERPARAMS_LOG_OPEN_MODE_2,   L"Never" },
+        { IDS_RENDERERPARAMS_LOG_OPEN_MODE_3,   L"On Error" }
+    };
 }
 
 //
@@ -1307,5 +1313,11 @@ const MCHAR* AppleseedRendererClassDesc::InternalName()
 
 const MCHAR* AppleseedRendererClassDesc::GetRsrcString(INT_PTR id)
 {
-    return GetString(static_cast<int>(id));
+    const asf::KeyValuePair<int, const wchar_t*>* dialog_string_pair =
+        lookup_kvpair_array(
+            g_dialog_strings,
+            11,
+            id);
+
+    return dialog_string_pair->m_value;
 }

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
@@ -100,9 +100,9 @@ namespace
         
         ParamIdEnableGI                 = 8,
         ParamIdGIBounces                = 9,
-        ParamIdEnagleCaustics           = 10,
-        ParamIdEnableMaxRay             = 11,
-        ParamIdMaxRayValue              = 12,
+        ParamIdEnableCaustics           = 10,
+        ParamIdEnableMaxRayIntensity    = 11,
+        ParamIdMaxRayIntensity          = 12,
         ParamIdForceDefaultLightsOff    = 13,
         ParamIdEnableBackgroundLight    = 14,
         ParamIdBackgroundAlphaValue     = 15,
@@ -121,8 +121,8 @@ namespace
         static wchar_t buf[256];
 
         if (g_module)
-            return LoadString(g_module, id, buf, _countof(buf)) ? buf : NULL;
-        return NULL;
+            return LoadString(g_module, id, buf, _countof(buf)) ? buf : nullptr;
+        return nullptr;
     }
 }
 
@@ -138,7 +138,7 @@ void AppleseedRendererPBlockAccessor::Get(
     TimeValue       t,
     Interval        &valid)
 {
-    AppleseedRenderer* const renderer = dynamic_cast<AppleseedRenderer*>(owner);
+    AppleseedRenderer* const renderer = static_cast<AppleseedRenderer*>(owner);
     RendererSettings& settings = renderer->m_settings;
 
     switch (id)
@@ -191,11 +191,11 @@ void AppleseedRendererPBlockAccessor::Get(
         v.i = static_cast<int>(settings.m_gi);
         break;
             
-      case ParamIdEnagleCaustics:
+      case ParamIdEnableCaustics:
         v.i = static_cast<int>(settings.m_caustics);
         break;
             
-      case ParamIdEnableMaxRay:
+      case ParamIdEnableMaxRayIntensity:
         v.i = static_cast<int>(settings.m_max_ray_intensity_set);
         break;
 
@@ -211,7 +211,7 @@ void AppleseedRendererPBlockAccessor::Get(
         v.i = settings.m_bounces;
         break;
 
-      case ParamIdMaxRayValue:
+      case ParamIdMaxRayIntensity:
         v.f = settings.m_max_ray_intensity;
         break;
 
@@ -316,11 +316,11 @@ void AppleseedRendererPBlockAccessor::Set(
         settings.m_gi = v.i > 0;
         break;
             
-      case ParamIdEnagleCaustics:
+      case ParamIdEnableCaustics:
         settings.m_caustics = v.i > 0;
         break;
             
-      case ParamIdEnableMaxRay:
+      case ParamIdEnableMaxRayIntensity:
         settings.m_max_ray_intensity_set = v.i > 0;
         break;
 
@@ -336,7 +336,7 @@ void AppleseedRendererPBlockAccessor::Set(
         settings.m_bounces = v.i;
         break;
 
-      case ParamIdMaxRayValue:
+      case ParamIdMaxRayIntensity:
         settings.m_max_ray_intensity = v.f;
         break;
 
@@ -509,20 +509,20 @@ ParamBlockDesc2 g_param_block_desc(
         p_accessor, &g_pblock_accessor,
     p_end,
 
-    ParamIdEnagleCaustics, L"enable_caustics", TYPE_BOOL, 0, 0,
+    ParamIdEnableCaustics, L"enable_caustics", TYPE_BOOL, 0, 0,
         p_ui, ParamMapIdLighting, TYPE_SINGLECHEKBOX, IDC_CHECK_CAUSTICS,
         p_default, FALSE,
         p_accessor, &g_pblock_accessor,
     p_end,
 
-    ParamIdEnableMaxRay, L"enable_max_ray", TYPE_BOOL, 0, 0,
+    ParamIdEnableMaxRayIntensity, L"enable_max_ray", TYPE_BOOL, 0, 0,
         p_ui, ParamMapIdLighting, TYPE_SINGLECHEKBOX, IDC_CHECK_MAX_RAY_INTENSITY,
         p_default, FALSE,
-        p_enable_ctrls, 1, ParamIdMaxRayValue,
+        p_enable_ctrls, 1, ParamIdMaxRayIntensity,
         p_accessor, &g_pblock_accessor,
     p_end,
 
-    ParamIdMaxRayValue, L"max_ray_value", TYPE_FLOAT, 0, 0,
+    ParamIdMaxRayIntensity, L"max_ray_value", TYPE_FLOAT, 0, 0,
         p_ui, ParamMapIdLighting, TYPE_SPINNER, EDITTYPE_FLOAT, IDC_TEXT_MAX_RAY_INTENSITY, IDC_SPINNER_MAX_RAY_INTENSITY, SPIN_AUTOSCALE,
         p_default, 1.0f,
         p_range, 0.0f, 1000.0f,

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.h
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.h
@@ -74,7 +74,7 @@ class AppleseedRendererPBlockAccessor
 class AppleseedRenderer
   : public Renderer
   , public ITabDialogObject
-{    
+{
   public:
     static Class_ID get_class_id();
 

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.h
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.h
@@ -51,10 +51,32 @@
 // Forward declarations.
 class AppleseedInteractiveRender;
 
+class AppleseedRendererPBlockAccessor
+  : public PBAccessor
+{
+  public:
+    void Get(
+        PB2Value&       v,
+        ReferenceMaker* owner,
+        ParamID         id,
+        int             tab_index,
+        TimeValue       t,
+        Interval        &valid) override;
+
+    void Set(
+        PB2Value&       v,
+        ReferenceMaker* owner,
+        ParamID         id,
+        int             tab_index,
+        TimeValue       t) override;
+};
+
 class AppleseedRenderer
   : public Renderer
   , public ITabDialogObject
 {
+    friend AppleseedRendererPBlockAccessor;
+    
   public:
     static Class_ID get_class_id();
 
@@ -62,11 +84,18 @@ class AppleseedRenderer
 
     const RendererSettings& get_renderer_settings();
 
+    // ReferenceMaker methods.
+    int NumRefs() override;
+    RefTargetHandle	GetReference(int i) override;
+    void SetReference(int i, RefTargetHandle rtarg) override;
     Class_ID ClassID() override;
 
     void GetClassName(MSTR& s) override;
 
     void DeleteThis() override;
+    int NumParamBlocks() override;
+    IParamBlock2* GetParamBlock(int i) override;
+    IParamBlock2* GetParamBlockByID(BlockID id) override;
 
     // Animatable.
     void* GetInterface(ULONG id) override;
@@ -153,6 +182,7 @@ class AppleseedRenderer
     std::vector<DefaultLight>   m_default_lights;
     TimeValue                   m_time;
     MaxSceneEntities            m_entities;
+    IParamBlock2*               m_param_block;
 
     void clear();
 };
@@ -173,6 +203,8 @@ class AppleseedRendererClassDesc
     Class_ID ClassID() override;
     const MCHAR* Category() override;
     const MCHAR* InternalName() override;
+    const MCHAR* GetRsrcString(INT_PTR id) override;
+
 };
 
 extern AppleseedRendererClassDesc g_appleseed_renderer_classdesc;

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.h
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.h
@@ -74,9 +74,7 @@ class AppleseedRendererPBlockAccessor
 class AppleseedRenderer
   : public Renderer
   , public ITabDialogObject
-{
-    friend AppleseedRendererPBlockAccessor;
-    
+{    
   public:
     static Class_ID get_class_id();
 
@@ -86,7 +84,7 @@ class AppleseedRenderer
 
     // ReferenceMaker methods.
     int NumRefs() override;
-    RefTargetHandle	GetReference(int i) override;
+    RefTargetHandle GetReference(int i) override;
     void SetReference(int i, RefTargetHandle rtarg) override;
     Class_ID ClassID() override;
 
@@ -173,6 +171,8 @@ class AppleseedRenderer
     void create_log_window();
 
   private:
+    friend AppleseedRendererPBlockAccessor;
+
     AppleseedInteractiveRender* m_interactive_renderer;
     RendererSettings            m_settings;
     INode*                      m_scene;
@@ -204,7 +204,6 @@ class AppleseedRendererClassDesc
     const MCHAR* Category() override;
     const MCHAR* InternalName() override;
     const MCHAR* GetRsrcString(INT_PTR id) override;
-
 };
 
 extern AppleseedRendererClassDesc g_appleseed_renderer_classdesc;

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.rc
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.rc
@@ -238,20 +238,6 @@ END
 // String Table
 //
 
-STRINGTABLE
-BEGIN
-    IDS_RENDERERPARAMS_FILTER_TYPE_1 "Blackman-Harris"
-    IDS_RENDERERPARAMS_FILTER_TYPE_2 "Box"
-    IDS_RENDERERPARAMS_FILTER_TYPE_3 "Catmull-Rom Spline"
-    IDS_RENDERERPARAMS_FILTER_TYPE_4 "Cubic B-spline"
-    IDS_RENDERERPARAMS_FILTER_TYPE_5 "Gaussian"
-    IDS_RENDERERPARAMS_FILTER_TYPE_6 "Lanczos"
-    IDS_RENDERERPARAMS_FILTER_TYPE_7 "Mitchell-Netravali"
-    IDS_RENDERERPARAMS_FILTER_TYPE_8 "Triangle"
-    IDS_RENDERERPARAMS_LOG_OPEN_MODE_1 "Always"
-    IDS_RENDERERPARAMS_LOG_OPEN_MODE_2 "Never"
-    IDS_RENDERERPARAMS_LOG_OPEN_MODE_3 "On Error"
-END
 
 #endif    // English (United States) resources
 /////////////////////////////////////////////////////////////////////////////

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.rc
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.rc
@@ -232,6 +232,27 @@ BEGIN
     0
 END
 
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// String Table
+//
+
+STRINGTABLE
+BEGIN
+    IDS_RENDERERPARAMS_FILTER_TYPE_1 "Blackman-Harris"
+    IDS_RENDERERPARAMS_FILTER_TYPE_2 "Box"
+    IDS_RENDERERPARAMS_FILTER_TYPE_3 "Catmull-Rom Spline"
+    IDS_RENDERERPARAMS_FILTER_TYPE_4 "Cubic B-spline"
+    IDS_RENDERERPARAMS_FILTER_TYPE_5 "Gaussian"
+    IDS_RENDERERPARAMS_FILTER_TYPE_6 "Lanczos"
+    IDS_RENDERERPARAMS_FILTER_TYPE_7 "Mitchell-Netravali"
+    IDS_RENDERERPARAMS_FILTER_TYPE_8 "Triangle"
+    IDS_RENDERERPARAMS_LOG_OPEN_MODE_1 "Always"
+    IDS_RENDERERPARAMS_LOG_OPEN_MODE_2 "Never"
+    IDS_RENDERERPARAMS_LOG_OPEN_MODE_3 "On Error"
+END
+
 #endif    // English (United States) resources
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.cpp
@@ -326,7 +326,7 @@ namespace
                   case IDC_RADIO_SAVEPROJECT_AND_RENDER:
                     enable_disable_controls();
                     return TRUE;
-                  
+ 
                   default:
                     return FALSE;
                 }
@@ -354,7 +354,7 @@ namespace
             int output_mode;
             m_pblock->GetValueByName(L"use_max_procedural_maps", 0, temp_use_max_procedural_maps, FOREVER);
             m_pblock->GetValueByName(L"output_mode", 0, output_mode, FOREVER);
-            bool use_max_procedural_maps = temp_use_max_procedural_maps > 0;
+            const bool use_max_procedural_maps = temp_use_max_procedural_maps > 0;
             const bool save_project =
                 output_mode == static_cast<int>(RendererSettings::OutputMode::SaveProjectOnly) ||
                 output_mode == static_cast<int>(RendererSettings::OutputMode::SaveProjectAndRender);

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.cpp
@@ -459,7 +459,6 @@ AppleseedRendererParamDlg::AppleseedRendererParamDlg(
     RendererSettings&       settings,
     AppleseedRenderer*      renderer)
   : impl(new Impl(rend_params, in_progress, settings, renderer))
-  , m_renderer(renderer)
   , m_pmap_output(nullptr)
   , m_pmap_image_sampling(nullptr)
   , m_pmap_lighting(nullptr)
@@ -511,22 +510,22 @@ AppleseedRendererParamDlg::~AppleseedRendererParamDlg()
 
 void AppleseedRendererParamDlg::DeleteThis()
 {
-    if (m_pmap_output != nullptr)
-        DestroyRParamMap2(m_pmap_output);
-
-    if (m_pmap_image_sampling != nullptr)
-        DestroyRParamMap2(m_pmap_image_sampling);
-    
-    if (m_pmap_lighting != nullptr)
-        DestroyRParamMap2(m_pmap_lighting);
-    
     if (m_pmap_system != nullptr)
         DestroyRParamMap2(m_pmap_system);
 
-    m_pmap_output = nullptr;
-    m_pmap_image_sampling = nullptr;
-    m_pmap_lighting = nullptr;
+    if (m_pmap_lighting != nullptr)
+        DestroyRParamMap2(m_pmap_lighting);
+    
+    if (m_pmap_image_sampling != nullptr)
+        DestroyRParamMap2(m_pmap_image_sampling);
+    
+    if (m_pmap_output != nullptr)
+        DestroyRParamMap2(m_pmap_output);
+
     m_pmap_system = nullptr;
+    m_pmap_lighting = nullptr;
+    m_pmap_image_sampling = nullptr;
+    m_pmap_output = nullptr;
 
     delete this;
 }

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.h
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.h
@@ -45,7 +45,6 @@ class AppleseedRendererParamDlg
     AppleseedRendererParamDlg(
         IRendParams*        rend_params,
         BOOL                in_progress,
-        RendererSettings&   settings,
         AppleseedRenderer*  renderer);
 
     ~AppleseedRendererParamDlg() override;
@@ -57,9 +56,4 @@ class AppleseedRendererParamDlg
   private:
     struct Impl;
     Impl* impl;
-
-    IParamMap2*         m_pmap_output;
-    IParamMap2*         m_pmap_image_sampling;
-    IParamMap2*         m_pmap_lighting;
-    IParamMap2*         m_pmap_system;
 };

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.h
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.h
@@ -58,7 +58,6 @@ class AppleseedRendererParamDlg
     struct Impl;
     Impl* impl;
 
-    AppleseedRenderer*  m_renderer;
     IParamMap2*         m_pmap_output;
     IParamMap2*         m_pmap_image_sampling;
     IParamMap2*         m_pmap_lighting;

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.h
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.h
@@ -57,4 +57,10 @@ class AppleseedRendererParamDlg
   private:
     struct Impl;
     Impl* impl;
+
+    AppleseedRenderer*  m_renderer;
+    IParamMap2*         m_pmap_output;
+    IParamMap2*         m_pmap_image_sampling;
+    IParamMap2*         m_pmap_lighting;
+    IParamMap2*         m_pmap_system;
 };

--- a/src/appleseed-max-impl/appleseedrenderer/resource.h
+++ b/src/appleseed-max-impl/appleseedrenderer/resource.h
@@ -18,6 +18,14 @@
 #define IDC_COMBO_FILTER                            207
 #define IDC_TEXT_FILTER_SIZE                        208
 #define IDC_SPINNER_FILTER_SIZE                     209
+#define IDS_RENDERERPARAMS_FILTER_TYPE_1            210
+#define IDS_RENDERERPARAMS_FILTER_TYPE_2            211
+#define IDS_RENDERERPARAMS_FILTER_TYPE_3            212
+#define IDS_RENDERERPARAMS_FILTER_TYPE_4            213
+#define IDS_RENDERERPARAMS_FILTER_TYPE_5            214
+#define IDS_RENDERERPARAMS_FILTER_TYPE_6            215
+#define IDS_RENDERERPARAMS_FILTER_TYPE_7            216
+#define IDS_RENDERERPARAMS_FILTER_TYPE_8            217
 
 #define IDD_FORMVIEW_RENDERERPARAMS_LIGHTING        300
 #define IDC_CHECK_GI                                301
@@ -59,14 +67,17 @@
 #define IDC_EDIT_LOG                                604
 #define IDC_CHECK_RENDER_STAMP                      605
 #define IDC_TEXT_RENDER_STAMP                       606
+#define IDS_RENDERERPARAMS_LOG_OPEN_MODE_1          607
+#define IDS_RENDERERPARAMS_LOG_OPEN_MODE_2          608
+#define IDS_RENDERERPARAMS_LOG_OPEN_MODE_3          609
 
 // Next default values for new objects
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        110
-#define _APS_NEXT_CONTROL_VALUE         1026
 #define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         1026
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif


### PR DESCRIPTION
@dictoon 
Please take a look on this implementation of renderer's UI. There's a paramblock that describes all the ui elements and each element have an accessor which save and loads things into RendererSettings class. Right now it's fully compatible with scenes saved with original plugin.
I simplified appleseedrendererparameterdlg.cpp file. I'm not sure if we need Impl class in this case.
Save and Load function have not been changed, so everything is saved and loaded with RendererSettings class.
I'll try to add new parameters like override material and see if it works properly with old scenes.
Thanks,
Sergo.