### PR TITLE
Custom render context

### DIFF
--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
@@ -133,9 +133,9 @@ namespace
     };
 
     class AppleseedRenderContext
-        : public RenderGlobalContext
+      : public RenderGlobalContext
     {
-    public:
+      public:
         AppleseedRenderContext(
             Renderer*           renderer,
             Bitmap*             bitmap,
@@ -802,7 +802,7 @@ bool AppleseedRenderer::HasRequirement(Requirement requirement)
         return m_settings.m_output_mode == RendererSettings::OutputMode::SaveProjectOnly;
 #if MAX_RELEASE < 19000
       case kRequirement8_Wants32bitFPOutput: return true;
-#elif
+#else
       case kRequirement_Wants32bitFPOutput: return true;
       case kRequirement_SupportsConcurrentRendering: return true;
 #endif

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
@@ -783,9 +783,32 @@ void* AppleseedRenderer::GetInterface(ULONG id)
 
 BaseInterface* AppleseedRenderer::GetInterface(Interface_ID id)
 {
+#if MAX_RELEASE < 19000
+    if (id == IRENDERERREQUIREMENTS_INTERFACE_ID)
+        return static_cast<IRendererRequirements*>(this);
+#endif
     if (id == TAB_DIALOG_OBJECT_INTERFACE_ID)
         return static_cast<ITabDialogObject*>(this);
     else return Renderer::GetInterface(id);
+}
+
+
+bool AppleseedRenderer::HasRequirement(Requirement requirement)
+{
+    switch (requirement)
+    {
+      case kRequirement_NoVFB:
+      case kRequirement_DontSaveRenderOutput:
+        return m_settings.m_output_mode == RendererSettings::OutputMode::SaveProjectOnly;
+#if MAX_RELEASE < 19000
+      case kRequirement8_Wants32bitFPOutput: return true;
+#elif
+      case kRequirement_Wants32bitFPOutput: return true;
+      case kRequirement_SupportsConcurrentRendering: return true;
+#endif
+    }
+
+    return false;
 }
 
 #if MAX_RELEASE > 18000
@@ -810,19 +833,6 @@ void AppleseedRenderer::PauseRendering()
 
 void AppleseedRenderer::ResumeRendering()
 {
-}
-
-bool AppleseedRenderer::HasRequirement(Requirement requirement)
-{
-    // todo: specify kRequirement_NoVFB and kRequirement_DontSaveRenderOutput when saving project instead of rendering.
-
-    switch (requirement)
-    {
-      case kRequirement_Wants32bitFPOutput: return true;
-      case kRequirement_SupportsConcurrentRendering: return true;
-    }
-
-    return false;
 }
 
 bool AppleseedRenderer::CompatibleWithAnyRenderElement() const

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.h
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.h
@@ -74,6 +74,9 @@ class AppleseedRendererPBlockAccessor
 class AppleseedRenderer
   : public Renderer
   , public ITabDialogObject
+#if MAX_RELEASE < 19000
+  , public IRendererRequirements
+#endif
 {
   public:
     static Class_ID get_class_id();
@@ -99,6 +102,8 @@ class AppleseedRenderer
     void* GetInterface(ULONG id) override;
     BaseInterface* GetInterface(Interface_ID id) override;
 
+    bool HasRequirement(Requirement requirement) override;
+
 #if MAX_RELEASE > 18000
 
     bool IsStopSupported() const override;
@@ -107,8 +112,6 @@ class AppleseedRenderer
     PauseSupport IsPauseSupported() const override;
     void PauseRendering() override;
     void ResumeRendering() override;
-
-    bool HasRequirement(Requirement requirement) override;
 
     bool CompatibleWithAnyRenderElement() const override;
     bool CompatibleWithRenderElement(IRenderElement& pIRenderElement) const override;

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.cpp
@@ -506,11 +506,6 @@ struct AppleseedRendererParamDlg::Impl
 
         if (m_pmap_output != nullptr)
             DestroyRParamMap2(m_pmap_output);
-
-        m_pmap_system = nullptr;
-        m_pmap_lighting = nullptr;
-        m_pmap_image_sampling = nullptr;
-        m_pmap_output = nullptr;
     }
 };
 


### PR DESCRIPTION
Hi Franz,
I've made two small changes:
1. Adds more complete RenderGlobalContext to make plugin compatible with extensions such VFB+
2. Implemented HasRequirement interface for max 2016 to make framebuffer 32-bit and to not show frambuffer when only project file is saved.

Thanks,
Sergo.