### PR TITLE
Fix max2018 2019

### DIFF
--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
@@ -207,10 +207,6 @@ void AppleseedRendererPBlockAccessor::Get(
         v.i = static_cast<int>(settings.m_output_mode);
         break;
 
-      case ParamIdProjectPath:
-        v.s = settings.m_project_file_path;
-        break;
-
       case ParamIdScaleMultiplier:
         v.f = settings.m_scale_multiplier;
         break;
@@ -297,10 +293,6 @@ void AppleseedRendererPBlockAccessor::Get(
             
       case ParamIdEnableRenderStamp:
         v.i = static_cast<int>(settings.m_enable_render_stamp);
-        break;
-
-      case ParamIdRenderStampFormat:
-        v.s = settings.m_render_stamp_format;
         break;
 
       case ParamIdLogMaterialRendering:

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
@@ -1377,5 +1377,8 @@ const MCHAR* AppleseedRendererClassDesc::GetRsrcString(INT_PTR id)
 {
     const auto* dialog_string_pair = LOOKUP_KVPAIR_ARRAY(g_dialog_strings, id);
 
-    return dialog_string_pair->m_value;
+    if (dialog_string_pair != nullptr)
+        return dialog_string_pair->m_value;
+    else
+        return nullptr;
 }

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.cpp
@@ -410,6 +410,7 @@ namespace
                 {
                   case IDC_BUTTON_LOG:
                     m_renderer->show_last_session_log();
+                    break;
 
                   case IDC_CHECK_USE_MAX_PROCEDURAL_MAPS:
                     {

--- a/src/appleseed-max-impl/appleseedrenderer/renderersettings.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/renderersettings.cpp
@@ -126,7 +126,7 @@ void RendererSettings::apply_settings_to_final_config(asr::Project& project) con
     asr::ParamArray& params = project.configurations().get_by_name("final")->get_parameters();
 
     params.insert_path("generic_frame_renderer.tile_ordering", "spiral");
-    params.insert_path("generic_frame_renderer.passes", m_passes);
+    params.insert_path("passes", m_passes);
     params.insert_path("shading_result_framebuffer", m_passes == 1 ? "ephemeral" : "permanent");
 
     params.insert_path("uniform_pixel_renderer.samples", m_pixel_samples);


### PR DESCRIPTION
1. Quick fix of the crash that happens when accessing string parameters in 3ds max 2018, 2019
2. Fix maxscript access of the renderer parameters
3. Fix crash when opening log window after rendering