### PR TITLE
Implement Nested Medium Priority object control

### DIFF
--- a/src/appleseed-max-impl/appleseedobjpropsmod/appleseedobjpropsmod.cpp
+++ b/src/appleseed-max-impl/appleseedobjpropsmod/appleseedobjpropsmod.cpp
@@ -76,7 +76,7 @@ namespace
         ParamIdVisibilitySSS            = 8,
         ParamIdSSSSet                   = 9,
         ParamIdOptimizeForInstancing    = 10,
-        paramIdNestedmediumPriority     = 11
+        ParamIdMediumPriority           = 11
     };
 
     ParamBlockDesc2 g_block_desc(
@@ -146,10 +146,11 @@ namespace
         ParamIdSSSSet, L"sss_set", TYPE_STRING, 0, IDS_SSS_SET,
             p_ui, ParamMapIdVisibility, TYPE_EDITBOX, IDC_SSS_SET,
         p_end,
-        paramIdNestedmediumPriority, L"nested_medium_priority", TYPE_INT, P_TRANSIENT, 0,
-            p_ui, ParamMapIdVisibility, TYPE_SPINNER, EDITTYPE_INT, IDS_TEXT_Nested_Medium_Priority, IDS_SPINNER_Nested_Medium_Priority, SPIN_AUTOSCALE,
+        ParamIdMediumPriority, L"medium_priority", TYPE_INT, P_TRANSIENT, 0,
+            p_ui, ParamMapIdVisibility, TYPE_SPINNER, EDITTYPE_INT, IDS_TEXT_MEDIUM_PRIORITY, IDS_SPINNER_MEDIUM_PRIORITY, SPIN_AUTOSCALE,
             p_default, 0, p_range, -128, 127,
         p_end,
+
         // --- The end ---
         p_end);
 }
@@ -358,11 +359,8 @@ std::string AppleseedObjPropsMod::get_sss_set(const TimeValue t) const
 
 int AppleseedObjPropsMod::get_medium_priority(const TimeValue t) const
 {
-   int int_value = 0;
-   int_value = m_pblock->GetInt(paramIdNestedmediumPriority, t, FOREVER);
-   return int_value;
+   return m_pblock->GetInt(ParamIdMediumPriority, t, FOREVER);
 }
-
 
 
 //

--- a/src/appleseed-max-impl/appleseedobjpropsmod/appleseedobjpropsmod.cpp
+++ b/src/appleseed-max-impl/appleseedobjpropsmod/appleseedobjpropsmod.cpp
@@ -75,7 +75,8 @@ namespace
         ParamIdVisibilitySpecular       = 7,
         ParamIdVisibilitySSS            = 8,
         ParamIdSSSSet                   = 9,
-        ParamIdOptimizeForInstancing    = 10
+        ParamIdOptimizeForInstancing    = 10,
+        paramIdNestedmediumPriority     = 11
     };
 
     ParamBlockDesc2 g_block_desc(
@@ -145,7 +146,10 @@ namespace
         ParamIdSSSSet, L"sss_set", TYPE_STRING, 0, IDS_SSS_SET,
             p_ui, ParamMapIdVisibility, TYPE_EDITBOX, IDC_SSS_SET,
         p_end,
-
+        paramIdNestedmediumPriority, L"nested_medium_priority", TYPE_INT, P_TRANSIENT, 0,
+            p_ui, ParamMapIdVisibility, TYPE_SPINNER, EDITTYPE_INT, IDS_TEXT_Nested_Medium_Priority, IDS_SPINNER_Nested_Medium_Priority, SPIN_AUTOSCALE,
+            p_default, 0, p_range, 0, 100,
+        p_end,
         // --- The end ---
         p_end);
 }
@@ -351,6 +355,14 @@ std::string AppleseedObjPropsMod::get_sss_set(const TimeValue t) const
     m_pblock->GetValue(ParamIdSSSSet, t, str_value, FOREVER);
     return str_value != nullptr ? wide_to_utf8(str_value) : std::string();
 }
+
+int AppleseedObjPropsMod::get_medium_priority(const TimeValue t) const
+{
+   int int_value = 0;
+   int_value = m_pblock->GetInt(paramIdNestedmediumPriority, t, FOREVER);
+   return int_value;
+}
+
 
 
 //

--- a/src/appleseed-max-impl/appleseedobjpropsmod/appleseedobjpropsmod.cpp
+++ b/src/appleseed-max-impl/appleseedobjpropsmod/appleseedobjpropsmod.cpp
@@ -148,7 +148,7 @@ namespace
         p_end,
         paramIdNestedmediumPriority, L"nested_medium_priority", TYPE_INT, P_TRANSIENT, 0,
             p_ui, ParamMapIdVisibility, TYPE_SPINNER, EDITTYPE_INT, IDS_TEXT_Nested_Medium_Priority, IDS_SPINNER_Nested_Medium_Priority, SPIN_AUTOSCALE,
-            p_default, 0, p_range, 0, 100,
+            p_default, 0, p_range, -128, 127,
         p_end,
         // --- The end ---
         p_end);

--- a/src/appleseed-max-impl/appleseedobjpropsmod/appleseedobjpropsmod.h
+++ b/src/appleseed-max-impl/appleseedobjpropsmod/appleseedobjpropsmod.h
@@ -94,6 +94,7 @@ class AppleseedObjPropsMod
 
     renderer::VisibilityFlags::Type get_visibility_flags(const TimeValue t) const;
     std::string get_sss_set(const TimeValue t) const;
+    int get_medium_priority(const TimeValue t) const;
 
   private:
     IParamBlock2*   m_pblock;

--- a/src/appleseed-max-impl/appleseedobjpropsmod/appleseedobjpropsmod.rc
+++ b/src/appleseed-max-impl/appleseedobjpropsmod/appleseedobjpropsmod.rc
@@ -50,7 +50,7 @@ END
 // Dialog
 //
 
-IDD_FORMVIEW_PARAMS DIALOGEX 0, 0, 108, 133
+IDD_FORMVIEW_PARAMS DIALOGEX 0, 0, 108, 147
 STYLE DS_SETFONT | WS_CHILD | WS_VISIBLE
 FONT 8, "MS Sans Serif", 0, 0, 0x1
 BEGIN
@@ -63,9 +63,15 @@ BEGIN
     CONTROL         "Glossy",IDC_BUTTON_VISIBILITY_GLOSSY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,5,71,94,10
     CONTROL         "Specular",IDC_BUTTON_VISIBILITY_SPECULAR,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,5,82,94,10
     CONTROL         "SSS",IDC_BUTTON_VISIBILITY_SSS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,5,93,94,10
-    CONTROL         "SSS Set",IDC_SSS_SET,"CustEdit",WS_TABSTOP,43,116,58,10
-    LTEXT           "SSS Set Id:",IDC_SSS_SET_LABEL,5,116,38,8
-    CONTROL         "Optimize for Instancing",IDC_BUTTON_OPTIMIZE_FOR_INSTANCING,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,5,104,94,10
+    CONTROL         "SSS Set",IDC_SSS_SET,"CustEdit",WS_TABSTOP,43,130,54,10
+    LTEXT           "SSS Set Id:",IDC_SSS_SET_LABEL,5,131,38,8
+    CONTROL         "Optimize for Instancing",IDC_BUTTON_OPTIMIZE_FOR_INSTANCING,
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,5,104,94,10
+    LTEXT           "Medium Priority:",IDS_STATIC_Nested_Medium_Priority,5,117,50,8
+    CONTROL         "Nested Medium Priority",IDS_TEXT_Nested_Medium_Priority,
+                    "CustEdit",WS_TABSTOP,57,117,29,10
+    CONTROL         "Nested Medium Priority",IDS_SPINNER_Nested_Medium_Priority,
+                    "SpinnerControl",WS_TABSTOP,89,117,6,10
 END
 
 
@@ -79,7 +85,7 @@ GUIDELINES DESIGNINFO
 BEGIN
     IDD_FORMVIEW_PARAMS, DIALOG
     BEGIN
-        BOTTOMMARGIN, 126
+        BOTTOMMARGIN, 140
     END
 END
 #endif    // APSTUDIO_INVOKED
@@ -108,8 +114,8 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_VISIBILITY_SSS          "SSS"
-    IDS_SSS_SET                 "SSSSet"
+    IDS_VISIBILITY_SSS      "SSS"
+    IDS_SSS_SET             "SSSSet"
     IDS_OPTIMIZE_FOR_INSTANCING "Optimize for Instansing"
 END
 

--- a/src/appleseed-max-impl/appleseedobjpropsmod/appleseedobjpropsmod.rc
+++ b/src/appleseed-max-impl/appleseedobjpropsmod/appleseedobjpropsmod.rc
@@ -67,10 +67,10 @@ BEGIN
     LTEXT           "SSS Set Id:",IDC_SSS_SET_LABEL,5,131,38,8
     CONTROL         "Optimize for Instancing",IDC_BUTTON_OPTIMIZE_FOR_INSTANCING,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,5,104,94,10
-    LTEXT           "Medium Priority:",IDS_STATIC_Nested_Medium_Priority,5,117,50,8
-    CONTROL         "Nested Medium Priority",IDS_TEXT_Nested_Medium_Priority,
+    LTEXT           "Medium Priority:",IDS_STATIC_MEDIUM_PRIORITY,5,117,50,8
+    CONTROL         "Medium Priority",IDS_TEXT_MEDIUM_PRIORITY,
                     "CustEdit",WS_TABSTOP,57,117,29,10
-    CONTROL         "Nested Medium Priority",IDS_SPINNER_Nested_Medium_Priority,
+    CONTROL         "Medium Priority",IDS_SPINNER_MEDIUM_PRIORITY,
                     "SpinnerControl",WS_TABSTOP,89,117,6,10
 END
 

--- a/src/appleseed-max-impl/appleseedobjpropsmod/resource.h
+++ b/src/appleseed-max-impl/appleseedobjpropsmod/resource.h
@@ -2,49 +2,43 @@
 // Microsoft Visual C++ generated include file.
 // Used by appleseedobjpropsmod.rc
 //
+#define IDC_SPINNER_DL_SAMPLES              329
 #define IDD_FORMVIEW_PARAMS                 7000
 #define IDS_FORMVIEW_PARAMS_TITLE           7001
-
 #define IDC_BUTTON_VISIBILITY_CAMERA        7010
 #define IDS_VISIBILITY_CAMERA               7011
-
 #define IDC_BUTTON_VISIBILITY_LIGHT         7020
 #define IDS_VISIBILITY_LIGHT                7021
-
 #define IDC_BUTTON_VISIBILITY_SHADOW        7030
 #define IDS_VISIBILITY_SHADOW               7031
-
 #define IDC_BUTTON_VISIBILITY_TRANSPARENCY  7040
 #define IDS_VISIBILITY_TRANSPARENCY         7041
-
 #define IDC_BUTTON_VISIBILITY_PROBE         7050
 #define IDS_VISIBILITY_PROBE                7051
-
 #define IDC_BUTTON_VISIBILITY_DIFFUSE       7060
 #define IDS_VISIBILITY_DIFFUSE              7061
-
 #define IDC_BUTTON_VISIBILITY_GLOSSY        7070
 #define IDS_VISIBILITY_GLOSSY               7071
-
 #define IDC_BUTTON_VISIBILITY_SPECULAR      7080
 #define IDS_VISIBILITY_SPECULAR             7081
-
 #define IDC_BUTTON_VISIBILITY_SSS           7090
 #define IDS_VISIBILITY_SSS                  7091
 #define IDC_SSS_SET                         7092
 #define IDS_SSS_SET                         7093
 #define IDC_SSS_SET_LABEL                   7094
-
 #define IDC_BUTTON_OPTIMIZE_FOR_INSTANCING  7101
 #define IDS_OPTIMIZE_FOR_INSTANCING         7102
+#define IDS_STATIC_Nested_Medium_Priority   7200
+#define IDS_TEXT_Nested_Medium_Priority     7201
+#define IDS_SPINNER_Nested_Medium_Priority  7202
 
 // Next default values for new objects
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        104
-#define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1005
-#define _APS_NEXT_SYMED_VALUE           101
+#define _APS_NEXT_RESOURCE_VALUE            104
+#define _APS_NEXT_COMMAND_VALUE             40001
+#define _APS_NEXT_CONTROL_VALUE             1005
+#define _APS_NEXT_SYMED_VALUE               101
 #endif
 #endif

--- a/src/appleseed-max-impl/appleseedobjpropsmod/resource.h
+++ b/src/appleseed-max-impl/appleseedobjpropsmod/resource.h
@@ -28,9 +28,9 @@
 #define IDC_SSS_SET_LABEL                   7094
 #define IDC_BUTTON_OPTIMIZE_FOR_INSTANCING  7101
 #define IDS_OPTIMIZE_FOR_INSTANCING         7102
-#define IDS_STATIC_Nested_Medium_Priority   7200
-#define IDS_TEXT_Nested_Medium_Priority     7201
-#define IDS_SPINNER_Nested_Medium_Priority  7202
+#define IDS_STATIC_MEDIUM_PRIORITY          7200
+#define IDS_TEXT_MEDIUM_PRIORITY            7201
+#define IDS_SPINNER_MEDIUM_PRIORITY         7202
 
 // Next default values for new objects
 // 

--- a/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
@@ -470,6 +470,25 @@ namespace
         return std::string();
     }
 
+    int get_medium_priority(Object* object, const TimeValue time)
+    {
+        if (object->SuperClassID() == GEN_DERIVOB_CLASS_ID)
+        {
+            IDerivedObject* derived_object = static_cast<IDerivedObject*>(object);
+            for (int i = 0, e = derived_object->NumModifiers(); i < e; ++i)
+            {
+                Modifier* modifier = derived_object->GetModifier(i);
+                if (modifier->ClassID() == AppleseedObjPropsMod::get_class_id())
+                {
+                    const auto obj_props_mod = static_cast<const AppleseedObjPropsMod*>(modifier);
+                    return obj_props_mod->get_medium_priority(time);
+                }
+            }
+        }
+
+        return 0;
+    }
+
     bool should_optimize_for_instancing(Object* object, const TimeValue time)
     {
         if (object->SuperClassID() == GEN_DERIVOB_CLASS_ID)
@@ -610,7 +629,10 @@ namespace
                     get_visibility_flags(instance_node->GetObjectRef(), time)))
             .insert(
                 "sss_set_id",
-                get_sss_set(instance_node->GetObjectRef(), time));
+                get_sss_set(instance_node->GetObjectRef(), time))
+            .insert(
+                "medium_priority",
+                get_medium_priority(instance_node->GetObjectRef(), time));
         if (type == RenderType::MaterialPreview)
             params.insert_path("visibility.shadow", false);
 


### PR DESCRIPTION
Medium Priority of the box object in Max is set to 2:
![max](https://user-images.githubusercontent.com/22252558/45012814-70579f00-b021-11e8-8ee8-3e9463e9f74e.PNG)

and the exported scene is correctly imported with the setting in appleseed studio:
![studio](https://user-images.githubusercontent.com/22252558/45012825-87968c80-b021-11e8-804e-32a12c5825be.PNG)

