### PR TITLE
Update animated parameters by getting current time from renderer

### DIFF
--- a/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.cpp
+++ b/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.cpp
@@ -597,8 +597,8 @@ asf::auto_release_ptr<asr::Material> AppleseedBlendMtl::create_osl_material(
 
     connect_sub_mtl(assembly, shader_group.ref(), name, "BaseMtl", mat);
 
-    const TimeValue time = GetCOREInterface()->GetTime();
     
+    const TimeValue time = get_current_time();
     asr::ParamArray shader_params;
     int layer_index = 1;
 

--- a/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.cpp
+++ b/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.cpp
@@ -570,19 +570,21 @@ bool AppleseedBlendMtl::can_emit_light() const
 }
 
 asf::auto_release_ptr<asr::Material> AppleseedBlendMtl::create_material(
-    asr::Assembly&  assembly,
-    const char*     name,
-    const bool      use_max_procedural_maps)
+    asr::Assembly&      assembly,
+    const char*         name,
+    const bool          use_max_procedural_maps,
+    const TimeValue     time)
 {
     return
         use_max_procedural_maps
-            ? create_builtin_material(assembly, name)
-            : create_osl_material(assembly, name);
+            ? create_builtin_material(assembly, name, time)
+            : create_osl_material(assembly, name, time);
 }
 
 asf::auto_release_ptr<asr::Material> AppleseedBlendMtl::create_osl_material(
-    asr::Assembly&  assembly,
-    const char*     name)
+    asr::Assembly&      assembly,
+    const char*         name,
+    const TimeValue     time)
 {
     auto blend_material = asr::OSLMaterialFactory().create(name, asr::ParamArray());
 
@@ -595,10 +597,8 @@ asf::auto_release_ptr<asr::Material> AppleseedBlendMtl::create_osl_material(
     auto shader_group_name = make_unique_name(assembly.shader_groups(), std::string(name) + "_shader_group");
     auto shader_group = asr::ShaderGroupFactory::create(shader_group_name.c_str());
 
-    connect_sub_mtl(assembly, shader_group.ref(), name, "BaseMtl", mat);
+    connect_sub_mtl(assembly, shader_group.ref(), name, "BaseMtl", mat, time);
 
-    
-    const TimeValue time = get_current_time();
     asr::ParamArray shader_params;
     int layer_index = 1;
 
@@ -609,7 +609,7 @@ asf::auto_release_ptr<asr::Material> AppleseedBlendMtl::create_osl_material(
         if (mat == nullptr)
             continue;
 
-        connect_sub_mtl(assembly, shader_group.ref(), name, asf::format("LayerMtl_{0}", layer_index).c_str(), mat);
+        connect_sub_mtl(assembly, shader_group.ref(), name, asf::format("LayerMtl_{0}", layer_index).c_str(), mat, time);
 
         Texmap* tex = nullptr;
         m_pblock->GetValue(ParamIdMaskTex, time, tex, FOREVER, i);
@@ -621,7 +621,8 @@ asf::auto_release_ptr<asr::Material> AppleseedBlendMtl::create_osl_material(
                 name,
                 asf::format("MaskColor_{0}", layer_index).c_str(),
                 tex,
-                mask_amount);
+                mask_amount,
+                time);
         }
 
         shader_params.insert(
@@ -653,8 +654,9 @@ asf::auto_release_ptr<asr::Material> AppleseedBlendMtl::create_osl_material(
 }
 
 asf::auto_release_ptr<asr::Material> AppleseedBlendMtl::create_builtin_material(
-    asr::Assembly&  assembly,
-    const char*     name)
+    asr::Assembly&      assembly,
+    const char*         name,
+    const TimeValue     time)
 {
     return asr::GenericMaterialFactory().create(name, asr::ParamArray());
 }

--- a/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.h
+++ b/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.h
@@ -139,7 +139,8 @@ class AppleseedBlendMtl
     foundation::auto_release_ptr<renderer::Material> create_material(
         renderer::Assembly& assembly,
         const char*         name,
-        const bool          use_max_procedural_maps) override;
+        const bool          use_max_procedural_maps,
+        const TimeValue     time) override;
 
   private:
     IParamBlock2*   m_pblock;
@@ -147,11 +148,13 @@ class AppleseedBlendMtl
 
     foundation::auto_release_ptr<renderer::Material> create_osl_material(
         renderer::Assembly& assembly,
-        const char*         name);
+        const char*         name,
+        const TimeValue     time);
 
     foundation::auto_release_ptr<renderer::Material> create_builtin_material(
         renderer::Assembly& assembly,
-        const char*         name);
+        const char*         name,
+        const TimeValue     time);
 };
 
 

--- a/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.h
+++ b/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.h
@@ -133,7 +133,8 @@ class AppleseedDisneyMtl
     foundation::auto_release_ptr<renderer::Material> create_material(
         renderer::Assembly& assembly,
         const char*         name,
-        const bool          use_max_procedural_maps) override;
+        const bool          use_max_procedural_maps,
+        const TimeValue     time) override;
 
   private:
     IParamBlock2*   m_pblock;
@@ -167,11 +168,13 @@ class AppleseedDisneyMtl
 
     foundation::auto_release_ptr<renderer::Material> create_osl_material(
         renderer::Assembly& assembly,
-        const char*         name);
+        const char*         name,
+        const TimeValue     time);
 
     foundation::auto_release_ptr<renderer::Material> create_builtin_material(
         renderer::Assembly& assembly,
-        const char*         name);
+        const char*         name,
+        const TimeValue     time);
 };
 
 

--- a/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.cpp
+++ b/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.cpp
@@ -550,11 +550,10 @@ Point3 AppleseedEnvMap::EvalNormalPerturb(ShadeContext& /*sc*/)
     return Point3(0.0f, 0.0f, 0.0f);
 }
 
-asf::auto_release_ptr<asr::EnvironmentEDF> AppleseedEnvMap::create_envmap(const char* name)
+asf::auto_release_ptr<asr::EnvironmentEDF> AppleseedEnvMap::create_envmap(const char* name, const TimeValue time)
 {
     float sun_theta_deg = m_sun_theta;
     float sun_phi_deg = m_sun_phi;
-    const TimeValue time = get_current_time();
 
     if (m_sun_node != nullptr && m_sun_node_on)
     {

--- a/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.cpp
+++ b/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.cpp
@@ -554,10 +554,11 @@ asf::auto_release_ptr<asr::EnvironmentEDF> AppleseedEnvMap::create_envmap(const 
 {
     float sun_theta_deg = m_sun_theta;
     float sun_phi_deg = m_sun_phi;
+    const TimeValue time = get_current_time();
 
     if (m_sun_node != nullptr && m_sun_node_on)
     {
-        Matrix3 sun_transform = m_sun_node->GetObjTMAfterWSM(GetCOREInterface()->GetTime());
+        Matrix3 sun_transform = m_sun_node->GetObjTMAfterWSM(time);
         sun_transform.NoTrans();
 
         const Point3 sun_dir = (Point3::ZAxis * sun_transform).Normalize();

--- a/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.h
+++ b/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.h
@@ -100,7 +100,7 @@ class AppleseedEnvMap
     RGBA EvalColor(ShadeContext& sc) override;
     Point3 EvalNormalPerturb(ShadeContext& sc) override;
 
-    virtual foundation::auto_release_ptr<renderer::EnvironmentEDF> create_envmap(const char* name);
+    virtual foundation::auto_release_ptr<renderer::EnvironmentEDF> create_envmap(const char* name, const TimeValue time);
 
   protected:
     void SetReference(int i, RefTargetHandle rtarg) override;

--- a/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.h
+++ b/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.h
@@ -133,13 +133,16 @@ class AppleseedGlassMtl
     foundation::auto_release_ptr<renderer::Material> create_material(
         renderer::Assembly& assembly,
         const char*         name,
-        const bool          use_max_procedural_maps) override;
+        const bool          use_max_procedural_maps,
+        const TimeValue     time) override;
     foundation::auto_release_ptr<renderer::Material> create_builtin_material(
         renderer::Assembly& assembly,
-        const char*         name);
+        const char*         name,
+        const TimeValue     time);
     foundation::auto_release_ptr<renderer::Material> create_osl_material(
         renderer::Assembly& assembly,
-        const char*         name);
+        const char*         name,
+        const TimeValue     time);
 
   private:
     IParamBlock2*   m_pblock;

--- a/src/appleseed-max-impl/appleseedinteractive/appleseedinteractive.cpp
+++ b/src/appleseed-max-impl/appleseedinteractive/appleseedinteractive.cpp
@@ -387,8 +387,6 @@ void AppleseedInteractiveRender::update_camera_object(INode* camera)
 
 void AppleseedInteractiveRender::update_render_view()
 {
-    auto time = GetCOREInterface()->GetTime();
-
     ViewExp& view_exp = GetCOREInterface()->GetActiveViewExp();
 
     if (!view_exp.IsAlive())

--- a/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.cpp
+++ b/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.cpp
@@ -487,19 +487,21 @@ bool AppleseedLightMtl::can_emit_light() const
 }
 
 asf::auto_release_ptr<asr::Material> AppleseedLightMtl::create_material(
-    asr::Assembly&  assembly,
-    const char*     name,
-    const bool      use_max_procedural_maps)
+    asr::Assembly&      assembly,
+    const char*         name,
+    const bool          use_max_procedural_maps,
+    const TimeValue     time)
 {
     return
         use_max_procedural_maps
-            ? create_builtin_material(assembly, name)
-            : create_osl_material(assembly, name);
+            ? create_builtin_material(assembly, name, time)
+            : create_osl_material(assembly, name, time);
 }
 
 asf::auto_release_ptr<asr::Material> AppleseedLightMtl::create_osl_material(
-    asr::Assembly&  assembly,
-    const char*     name)
+    asr::Assembly&      assembly,
+    const char*         name,
+    const TimeValue     time)
 {
     //
     // Shader group.
@@ -507,7 +509,7 @@ asf::auto_release_ptr<asr::Material> AppleseedLightMtl::create_osl_material(
     auto shader_group_name = make_unique_name(assembly.shader_groups(), std::string(name) + "_shader_group");
     auto shader_group = asr::ShaderGroupFactory::create(shader_group_name.c_str());
 
-    connect_color_texture(shader_group.ref(), name, "Color", m_light_color_texmap, m_light_color);
+    connect_color_texture(shader_group.ref(), name, "Color", m_light_color_texmap, m_light_color, time);
     
     shader_group->add_shader("surface", "as_max_light_material", name, 
         asr::ParamArray()
@@ -536,8 +538,9 @@ asf::auto_release_ptr<asr::Material> AppleseedLightMtl::create_osl_material(
 }
 
 asf::auto_release_ptr<asr::Material> AppleseedLightMtl::create_builtin_material(
-    asr::Assembly&  assembly,
-    const char*     name)
+    asr::Assembly&      assembly,
+    const char*         name,
+    const TimeValue     time)
 {
     asr::ParamArray material_params;
     const bool use_max_procedural_maps = true;
@@ -549,7 +552,7 @@ asf::auto_release_ptr<asr::Material> AppleseedLightMtl::create_builtin_material(
     asr::ParamArray edf_params;
 
     // Radiance.
-    std::string instance_name = insert_texture_and_instance(assembly, m_light_color_texmap, use_max_procedural_maps);
+    std::string instance_name = insert_texture_and_instance(assembly, m_light_color_texmap, use_max_procedural_maps, time);
     if (!instance_name.empty())
         edf_params.insert("radiance", instance_name);
     else

--- a/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.h
+++ b/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.h
@@ -133,13 +133,16 @@ class AppleseedLightMtl
     foundation::auto_release_ptr<renderer::Material> create_material(
         renderer::Assembly& assembly,
         const char*         name,
-        const bool          use_max_procedural_maps) override;
+        const bool          use_max_procedural_maps,
+        const TimeValue     time) override;
     foundation::auto_release_ptr<renderer::Material> create_builtin_material(
         renderer::Assembly& assembly,
-        const char*         name);
+        const char*         name,
+        const TimeValue     time);
     foundation::auto_release_ptr<renderer::Material> create_osl_material(
         renderer::Assembly& assembly,
-        const char*         name);
+        const char*         name,
+        const TimeValue     time);
 
   private:
     IParamBlock2*   m_pblock;

--- a/src/appleseed-max-impl/appleseedmetalmtl/appleseedmetalmtl.h
+++ b/src/appleseed-max-impl/appleseedmetalmtl/appleseedmetalmtl.h
@@ -132,7 +132,8 @@ class AppleseedMetalMtl
     foundation::auto_release_ptr<renderer::Material> create_material(
         renderer::Assembly& assembly,
         const char*         name,
-        const bool          use_max_procedural_maps) override;
+        const bool          use_max_procedural_maps,
+        const TimeValue     time) override;
 
   private:
     IParamBlock2*   m_pblock;
@@ -156,11 +157,13 @@ class AppleseedMetalMtl
 
     foundation::auto_release_ptr<renderer::Material> create_osl_material(
         renderer::Assembly& assembly,
-        const char*         name);
+        const char*         name,
+        const TimeValue     time);
 
     foundation::auto_release_ptr<renderer::Material> create_builtin_material(
         renderer::Assembly& assembly,
-        const char*         name);
+        const char*         name,
+        const TimeValue     time);
 };
 
 

--- a/src/appleseed-max-impl/appleseedoslplugin/oslmaterial.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslmaterial.h
@@ -126,7 +126,8 @@ class OSLMaterial
     foundation::auto_release_ptr<renderer::Material> create_material(
         renderer::Assembly& assembly,
         const char*         name,
-        const bool          use_max_procedural_maps) override;
+        const bool          use_max_procedural_maps,
+        const TimeValue     time) override;
 
   protected:
     void SetReference(int i, RefTargetHandle rtarg) override;
@@ -145,11 +146,13 @@ class OSLMaterial
 
     foundation::auto_release_ptr<renderer::Material> create_osl_material(
         renderer::Assembly& assembly,
-        const char*         name);
+        const char*         name,
+        const TimeValue     time);
 
     foundation::auto_release_ptr<renderer::Material> create_builtin_material(
         renderer::Assembly& assembly,
-        const char*         name);
+        const char*         name,
+        const TimeValue     time);
 
     Color get_viewport_diffuse_color() const;
     Color get_viewport_specular_color() const;

--- a/src/appleseed-max-impl/appleseedoslplugin/osltexture.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/osltexture.cpp
@@ -295,7 +295,7 @@ void OSLTexture::Update(TimeValue t, Interval& valid)
         {
             Texmap* tex_map = nullptr;
             m_pblock->GetValue(tex_param.first, t, tex_map, m_params_validity);
-            if (tex_map)
+            if (tex_map != nullptr)
                 tex_map->Update(t, valid);
         }
     }
@@ -418,16 +418,15 @@ void OSLTexture::create_osl_texture(
     asr::ShaderGroup&   shader_group,
     const char*         material_node_name,
     const char*         material_input_name,
-    const int           output_slot_index)
+    const int           output_slot_index,
+    const TimeValue     time)
 {
-    const TimeValue time = get_current_time();
-
     auto layer_name = asf::format("{0}_{1}", material_node_name, material_input_name);
 
     if (m_has_uv_coords)
     {
         auto uv_transform_layer_name = asf::format("{0}_{1}_uv_transform", material_node_name, material_input_name);
-        shader_group.add_shader("shader", "as_max_uv_transform", uv_transform_layer_name.c_str(), get_uv_params(this));
+        shader_group.add_shader("shader", "as_max_uv_transform", uv_transform_layer_name.c_str(), get_uv_params(this, time));
 
         auto* uv_coord_input = m_shader_info->find_maya_attribute("uvCoord");
         auto* uv_filter_input = m_shader_info->find_maya_attribute("uvFilterSize");
@@ -446,7 +445,8 @@ void OSLTexture::create_osl_texture(
         shader_group,
         layer_name.c_str(),
         m_pblock,
-        m_shader_info);
+        m_shader_info,
+        time);
 
     shader_group.add_connection(
         layer_name.c_str(),
@@ -458,16 +458,16 @@ void OSLTexture::create_osl_texture(
 void OSLTexture::create_osl_texture(
     asr::ShaderGroup&   shader_group,
     const char*         material_node_name,
-    const char*         material_input_name)
+    const char*         material_input_name,
+    const TimeValue     time)
 {
-    const TimeValue time = get_current_time();
-
     const int output_slot_index = GetParamBlock(0)->GetInt(m_shader_info->m_output_param.m_max_param_id, time, FOREVER);
     create_osl_texture(
         shader_group,
         material_node_name,
         material_input_name,
-        output_slot_index);
+        output_slot_index,
+        time);
 }
 
 std::vector<std::string> OSLTexture::get_output_names() const

--- a/src/appleseed-max-impl/appleseedoslplugin/osltexture.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/osltexture.h
@@ -110,12 +110,14 @@ class OSLTexture
         renderer::ShaderGroup&  shader_group,
         const char*             material_node_name,
         const char*             material_input_name,
-        const int               output_slot_index);
+        const int               output_slot_index,
+        const TimeValue         time);
 
     void create_osl_texture(
         renderer::ShaderGroup&  shader_group,
         const char*             material_node_name,
-        const char*             material_input_name);
+        const char*             material_input_name,
+        const TimeValue         time);
 
     std::vector<std::string> get_output_names() const;
 

--- a/src/appleseed-max-impl/appleseedplasticmtl/appleseedplasticmtl.h
+++ b/src/appleseed-max-impl/appleseedplasticmtl/appleseedplasticmtl.h
@@ -133,7 +133,8 @@ class AppleseedPlasticMtl
     foundation::auto_release_ptr<renderer::Material> create_material(
         renderer::Assembly& assembly,
         const char*         name,
-        const bool          use_max_procedural_maps) override;
+        const bool          use_max_procedural_maps,
+        const TimeValue     time) override;
 
   private:
     IParamBlock2*   m_pblock;
@@ -158,11 +159,13 @@ class AppleseedPlasticMtl
 
     foundation::auto_release_ptr<renderer::Material> create_osl_material(
         renderer::Assembly& assembly,
-        const char*         name);
+        const char*         name,
+        const TimeValue     time);
 
     foundation::auto_release_ptr<renderer::Material> create_builtin_material(
         renderer::Assembly& assembly,
-        const char*         name);
+        const char*         name,
+        const TimeValue     time);
 };
 
 

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
@@ -1939,6 +1939,11 @@ void AppleseedRenderer::create_log_window()
     g_dialog_log_target.reset(new DialogLogTarget(m_settings.m_log_open_mode));
 }
 
+TimeValue AppleseedRenderer::get_time()
+{
+    return m_time;
+}
+
 void AppleseedRenderer::clear()
 {
     m_scene = nullptr;

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
@@ -1939,11 +1939,6 @@ void AppleseedRenderer::create_log_window()
     g_dialog_log_target.reset(new DialogLogTarget(m_settings.m_log_open_mode));
 }
 
-TimeValue AppleseedRenderer::get_time()
-{
-    return m_time;
-}
-
 void AppleseedRenderer::clear()
 {
     m_scene = nullptr;
@@ -1952,7 +1947,6 @@ void AppleseedRenderer::clear()
     m_time = 0;
     m_entities.clear();
 }
-
 
 //
 // AppleseedRendererClassDesc class implementation.

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
@@ -254,6 +254,7 @@ namespace
     };
 }
 
+
 //
 // AppleseedRendererPBlockAccessor class implementation.
 //
@@ -1947,6 +1948,7 @@ void AppleseedRenderer::clear()
     m_time = 0;
     m_entities.clear();
 }
+
 
 //
 // AppleseedRendererClassDesc class implementation.

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.h
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.h
@@ -172,7 +172,6 @@ class AppleseedRenderer
 
     void show_last_session_log();
     void create_log_window();
-    TimeValue get_time();
 
   private:
     friend AppleseedRendererPBlockAccessor;

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.h
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.h
@@ -172,6 +172,7 @@ class AppleseedRenderer
 
     void show_last_session_log();
     void create_log_window();
+    TimeValue get_time();
 
   private:
     friend AppleseedRendererPBlockAccessor;

--- a/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
@@ -394,7 +394,8 @@ namespace
         const std::string&      instance_name,
         Mtl*                    mtl,
         MaterialMap&            material_map,
-        const bool              use_max_procedural_maps)
+        const bool              use_max_procedural_maps,
+        const TimeValue         time)
     {
         MaterialInfo material_info;
 
@@ -410,7 +411,11 @@ namespace
                 material_info.m_name =
                     make_unique_name(assembly.materials(), wide_to_utf8(mtl->GetName()) + "_mat");
                 assembly.materials().insert(
-                    appleseed_mtl->create_material(assembly, material_info.m_name.c_str(), use_max_procedural_maps));
+                    appleseed_mtl->create_material(
+                        assembly,
+                        material_info.m_name.c_str(),
+                        use_max_procedural_maps,
+                        time));
                 material_map.insert(std::make_pair(mtl, material_info.m_name));
             }
             else
@@ -556,7 +561,8 @@ namespace
                                 instance_name,
                                 submtl,
                                 material_map,
-                                use_max_proc_maps);
+                                use_max_proc_maps,
+                                time);
 
                         const auto entry = object_info.m_mtlid_to_slot.find(i);
                         if (entry != object_info.m_mtlid_to_slot.end())
@@ -583,7 +589,8 @@ namespace
                         instance_name,
                         mtl,
                         material_map,
-                        use_max_proc_maps);
+                        use_max_proc_maps,
+                        time);
 
                 // Assign it to all material slots.
                 for (const auto& entry : object_info.m_mtlid_to_slot)
@@ -1192,7 +1199,7 @@ namespace
         if (rend_params.envMap->IsSubClassOf(AppleseedEnvMap::get_class_id()))
         {
             auto appleseed_envmap = static_cast<AppleseedEnvMap*>(rend_params.envMap);
-            auto env_map = appleseed_envmap->create_envmap("environment_edf");
+            auto env_map = appleseed_envmap->create_envmap("environment_edf", time);
             scene.environment_edfs().insert(env_map);
         }
         else
@@ -1203,7 +1210,8 @@ namespace
                 env_tex_instance_name =
                     insert_procedural_texture_and_instance(
                         scene,
-                        rend_params.envMap);
+                        rend_params.envMap,
+                        time);
             }
             else if (is_bitmap_texture(rend_params.envMap))
             {

--- a/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.h
+++ b/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.h
@@ -133,13 +133,16 @@ class AppleseedSSSMtl
     foundation::auto_release_ptr<renderer::Material> create_material(
         renderer::Assembly& assembly,
         const char*         name,
-        const bool          use_max_procedural_maps) override;
+        const bool          use_max_procedural_maps,
+        const TimeValue     time) override;
     foundation::auto_release_ptr<renderer::Material> create_builtin_material(
         renderer::Assembly& assembly,
-        const char*         name);
+        const char*         name,
+        const TimeValue     time);
     foundation::auto_release_ptr<renderer::Material> create_osl_material(
         renderer::Assembly& assembly,
-        const char*         name);
+        const char*         name,
+        const TimeValue     time);
 
 private:
     IParamBlock2*   m_pblock;

--- a/src/appleseed-max-impl/appleseedvolumemtl/appleseedvolumemtl.cpp
+++ b/src/appleseed-max-impl/appleseedvolumemtl/appleseedvolumemtl.cpp
@@ -450,7 +450,7 @@ asf::auto_release_ptr<asr::Material> AppleseedVolumeMtl::create_material(
     const bool      use_max_procedural_maps)
 {
     asr::ParamArray material_params;
-    auto time = GetCOREInterface()->GetTime();
+    const TimeValue time = get_current_time();
 
     //
     // Volume.

--- a/src/appleseed-max-impl/appleseedvolumemtl/appleseedvolumemtl.cpp
+++ b/src/appleseed-max-impl/appleseedvolumemtl/appleseedvolumemtl.cpp
@@ -445,12 +445,12 @@ bool AppleseedVolumeMtl::can_emit_light() const
 }
 
 asf::auto_release_ptr<asr::Material> AppleseedVolumeMtl::create_material(
-    asr::Assembly&  assembly,
-    const char*     name,
-    const bool      use_max_procedural_maps)
+    asr::Assembly&      assembly,
+    const char*         name,
+    const bool          use_max_procedural_maps,
+    const TimeValue     time)
 {
     asr::ParamArray material_params;
-    const TimeValue time = get_current_time();
 
     //
     // Volume.

--- a/src/appleseed-max-impl/appleseedvolumemtl/appleseedvolumemtl.h
+++ b/src/appleseed-max-impl/appleseedvolumemtl/appleseedvolumemtl.h
@@ -133,7 +133,8 @@ class AppleseedVolumeMtl
     foundation::auto_release_ptr<renderer::Material> create_material(
         renderer::Assembly& assembly,
         const char*         name,
-        const bool          use_max_procedural_maps) override;
+        const bool          use_max_procedural_maps,
+        const TimeValue     time) override;
 
   private:
     IParamBlock2*   m_pblock;

--- a/src/appleseed-max-impl/builtinmapsupport.cpp
+++ b/src/appleseed-max-impl/builtinmapsupport.cpp
@@ -50,17 +50,17 @@ void connect_output_selector(
     const char*         material_input_name,
     Texmap*             texmap)
 {
-    const auto t = GetCOREInterface()->GetTime();
+    TimeValue time = get_current_time();
 
     Texmap* input_map = nullptr;
-    texmap->GetParamBlock(0)->GetValueByName(L"source_map", t, input_map, FOREVER);
+    texmap->GetParamBlock(0)->GetValueByName(L"source_map", time, input_map, FOREVER);
     if (input_map != nullptr && is_osl_texture(input_map))
     {
         OSLTexture* osl_texture = static_cast<OSLTexture*>(input_map);
         auto output_names = osl_texture->get_output_names();
 
         int output_index = 0;
-        texmap->GetParamBlock(0)->GetValueByName(L"output_index", t, output_index, FOREVER);
+        texmap->GetParamBlock(0)->GetValueByName(L"output_index", time, output_index, FOREVER);
         DbgAssert(output_index >= 1);
         output_index -= 1;
         if (output_index < output_names.size())
@@ -81,11 +81,12 @@ void connect_output_map(
     Texmap*             texmap,
     const Color         const_value)
 {
-    const auto t = GetCOREInterface()->GetTime();
+    TimeValue time = get_current_time();
+
     auto color_balance_layer_name = foundation::format("{0}_{1}_color_balance", material_node_name, material_input_name);
 
     Texmap* input_map = nullptr;
-    texmap->GetParamBlock(0)->GetValueByName(L"map1", t, input_map, FOREVER);
+    texmap->GetParamBlock(0)->GetValueByName(L"map1", time, input_map, FOREVER);
 
     connect_color_texture(shader_group, color_balance_layer_name.c_str(), "in_defaultColor", input_map, Color(1.0, 1.0, 1.0));
 
@@ -106,11 +107,11 @@ void connect_output_map(
     Texmap*             texmap,
     const float         const_value)
 {
-    const auto t = GetCOREInterface()->GetTime();
+    const auto time = get_current_time();
     auto color_balance_layer_name = foundation::format("{0}_{1}_color_balance", material_node_name, material_input_name);
 
     Texmap* input_map = nullptr;
-    texmap->GetParamBlock(0)->GetValueByName(L"map1", t, input_map, FOREVER);
+    texmap->GetParamBlock(0)->GetValueByName(L"map1", time, input_map, FOREVER);
 
     connect_float_texture(shader_group, color_balance_layer_name.c_str(), "in_defaultFloat", input_map, 1.0f);
 

--- a/src/appleseed-max-impl/builtinmapsupport.cpp
+++ b/src/appleseed-max-impl/builtinmapsupport.cpp
@@ -48,10 +48,9 @@ void connect_output_selector(
     asr::ShaderGroup&   shader_group,
     const char*         material_node_name,
     const char*         material_input_name,
-    Texmap*             texmap)
+    Texmap*             texmap,
+    const TimeValue     time)
 {
-    TimeValue time = get_current_time();
-
     Texmap* input_map = nullptr;
     texmap->GetParamBlock(0)->GetValueByName(L"source_map", time, input_map, FOREVER);
     if (input_map != nullptr && is_osl_texture(input_map))
@@ -79,18 +78,23 @@ void connect_output_map(
     const char*         material_node_name,
     const char*         material_input_name,
     Texmap*             texmap,
-    const Color         const_value)
+    const Color         const_value,
+    const TimeValue     time)
 {
-    TimeValue time = get_current_time();
-
     auto color_balance_layer_name = foundation::format("{0}_{1}_color_balance", material_node_name, material_input_name);
 
     Texmap* input_map = nullptr;
     texmap->GetParamBlock(0)->GetValueByName(L"map1", time, input_map, FOREVER);
 
-    connect_color_texture(shader_group, color_balance_layer_name.c_str(), "in_defaultColor", input_map, Color(1.0, 1.0, 1.0));
+    connect_color_texture(
+        shader_group,
+        color_balance_layer_name.c_str(),
+        "in_defaultColor",
+        input_map,
+        Color(1.0, 1.0, 1.0),
+        time);
 
-    renderer::ParamArray output_params = get_output_params(texmap)
+    renderer::ParamArray output_params = get_output_params(texmap, time)
         .insert("in_constantColor", fmt_osl_expr(to_color3f(const_value)));
 
     shader_group.add_shader("shader", "as_max_color_balance", color_balance_layer_name.c_str(), output_params);
@@ -105,17 +109,23 @@ void connect_output_map(
     const char*         material_node_name,
     const char*         material_input_name,
     Texmap*             texmap,
-    const float         const_value)
+    const float         const_value,
+    const TimeValue     time)
 {
-    const auto time = get_current_time();
     auto color_balance_layer_name = foundation::format("{0}_{1}_color_balance", material_node_name, material_input_name);
 
     Texmap* input_map = nullptr;
     texmap->GetParamBlock(0)->GetValueByName(L"map1", time, input_map, FOREVER);
 
-    connect_float_texture(shader_group, color_balance_layer_name.c_str(), "in_defaultFloat", input_map, 1.0f);
+    connect_float_texture(
+        shader_group,
+        color_balance_layer_name.c_str(),
+        "in_defaultFloat",
+        input_map,
+        1.0f,
+        time);
 
-    renderer::ParamArray output_params = get_output_params(texmap)
+    renderer::ParamArray output_params = get_output_params(texmap, time)
         .insert("in_constantFloat", fmt_osl_expr(const_value));
 
     shader_group.add_shader("shader", "as_max_color_balance", color_balance_layer_name.c_str(), output_params);

--- a/src/appleseed-max-impl/builtinmapsupport.h
+++ b/src/appleseed-max-impl/builtinmapsupport.h
@@ -51,20 +51,23 @@ void connect_output_map(
     const char*             material_node_name,
     const char*             material_input_name,
     Texmap*                 texmap,
-    const Color             const_value);
+    const Color             const_value,
+    const TimeValue         time);
 
 void connect_output_map(
     renderer::ShaderGroup&  shader_group,
     const char*             material_node_name,
     const char*             material_input_name,
     Texmap*                 texmap,
-    const float             const_value);
+    const float             const_value,
+    const TimeValue         time);
 
 void connect_output_selector(
     renderer::ShaderGroup&  shader_group,
     const char*             material_node_name,
     const char*             material_input_name,
-    Texmap*                 texmap);
+    Texmap*                 texmap,
+    const TimeValue         time);
 
 template <typename T>
 void create_supported_texture(
@@ -72,7 +75,8 @@ void create_supported_texture(
     const char*             material_node_name,
     const char*             material_input_name,
     Texmap*                 texmap,
-    const T                 const_value)
+    const T                 const_value,
+    const TimeValue         time)
 {
     auto part_a = texmap->ClassID().PartA();
     auto part_b = texmap->ClassID().PartB();
@@ -83,7 +87,8 @@ void create_supported_texture(
             shader_group,
             material_node_name,
             material_input_name,
-            texmap);
+            texmap,
+            time);
         return;
     }
 
@@ -95,7 +100,8 @@ void create_supported_texture(
             material_node_name,
             material_input_name,
             texmap,
-            const_value);
+            const_value,
+            time);
 
       default:
         break;

--- a/src/appleseed-max-impl/iappleseedmtl.h
+++ b/src/appleseed-max-impl/iappleseedmtl.h
@@ -59,5 +59,6 @@ class IAppleseedMtl
     virtual foundation::auto_release_ptr<renderer::Material> create_material(
         renderer::Assembly& assembly,
         const char*         name,
-        const bool          use_max_procedural_maps) = 0;
+        const bool          use_max_procedural_maps,
+        const TimeValue     time) = 0;
 };

--- a/src/appleseed-max-impl/osloutputselectormap/osloutputselector.cpp
+++ b/src/appleseed-max-impl/osloutputselectormap/osloutputselector.cpp
@@ -444,7 +444,7 @@ void OSLOutputSelector::Update(TimeValue t, Interval& valid)
         Texmap* source_map;
         m_pblock->GetValue(ParamIdSourceMap, t, source_map, m_params_validity);
 
-        if (source_map)
+        if (source_map != nullptr)
             source_map->Update(t, m_params_validity);
     }
     valid = m_params_validity;

--- a/src/appleseed-max-impl/osloutputselectormap/osloutputselector.cpp
+++ b/src/appleseed-max-impl/osloutputselectormap/osloutputselector.cpp
@@ -260,7 +260,7 @@ OSLOutputSelector::OSLOutputSelector()
   : m_pblock(nullptr)
 {
     g_appleseed_outputselector_classdesc.MakeAutoParamBlocks(this);
-    Reset();
+    m_params_validity.SetEmpty();
 }
 
 void OSLOutputSelector::DeleteThis()
@@ -438,22 +438,21 @@ void OSLOutputSelector::Update(TimeValue t, Interval& valid)
 {
     if (!m_params_validity.InInterval(t))
     {
+        m_params_validity.SetInstant(t);
         NotifyDependents(FOREVER, PART_ALL, REFMSG_CHANGE);
+
+        Texmap* source_map;
+        m_pblock->GetValue(ParamIdSourceMap, t, source_map, m_params_validity);
+
+        if (source_map)
+            source_map->Update(t, m_params_validity);
     }
-    m_params_validity.SetInfinite();
-
-    Texmap* source_map;
-    m_pblock->GetValue(ParamIdSourceMap, t, source_map, m_params_validity);
-
-    if (source_map)
-        source_map->Update(t, m_params_validity);
-
     valid = m_params_validity;
 }
 
 void OSLOutputSelector::Reset()
 {
-    m_params_validity.SetEmpty();
+    g_appleseed_outputselector_classdesc.Reset(this);
 }
 
 Interval OSLOutputSelector::Validity(TimeValue t)

--- a/src/appleseed-max-impl/oslutils.cpp
+++ b/src/appleseed-max-impl/oslutils.cpp
@@ -54,7 +54,7 @@
 namespace asf = foundation;
 namespace asr = renderer;
 
-asr::ParamArray get_uv_params(Texmap* texmap)
+asr::ParamArray get_uv_params(Texmap* texmap, const TimeValue time)
 {
     asr::ParamArray uv_params;
 
@@ -66,7 +66,6 @@ asr::ParamArray get_uv_params(Texmap* texmap)
         return uv_params;
 
     StdUVGen* std_uv = static_cast<StdUVGen*>(uv_gen);
-    const TimeValue time = get_current_time();
 
     DbgAssert(texmap->MapSlotType(texmap->GetMapChannel()) == MAPSLOT_TEXTURE);
     DbgAssert(static_cast<StdUVGen*>(uv_gen)->GetUVWSource() == UVWSRC_EXPLICIT);
@@ -148,7 +147,7 @@ asr::ParamArray get_uv_params(Texmap* texmap)
 }
 
 
-asr::ParamArray get_output_params(Texmap* texmap)
+asr::ParamArray get_output_params(Texmap* texmap, const TimeValue time)
 {
     asr::ParamArray output_params;
     output_params.insert("in_multiplier", fmt_osl_expr(1.0f));
@@ -176,8 +175,6 @@ asr::ParamArray get_output_params(Texmap* texmap)
     }
     if (std_tex_output == nullptr)
         return output_params;
-
-    const TimeValue time = get_current_time();
 
     output_params.insert("in_multiplier", fmt_osl_expr(std_tex_output->GetOutAmt(time)));
     output_params.insert("in_clamp_output", fmt_osl_expr(std_tex_output->GetClamp()));
@@ -241,32 +238,39 @@ void connect_float_texture(
     const char*         material_node_name,
     const char*         material_input_name,
     Texmap*             texmap,
-    const float         const_value)
+    const float         const_value,
+    const TimeValue     time)
 {
     if (is_supported_procedural_texture(texmap, false))
     {
-        create_supported_texture(shader_group, material_node_name, material_input_name, texmap, const_value);
+        create_supported_texture(
+            shader_group,
+            material_node_name,
+            material_input_name,
+            texmap,
+            const_value,
+            time);
         return;
     }
 
     if (is_osl_texture(texmap))
     {
         OSLTexture* osl_tex = static_cast<OSLTexture*>(texmap);
-        osl_tex->create_osl_texture(shader_group, material_node_name, material_input_name);
+        osl_tex->create_osl_texture(shader_group, material_node_name, material_input_name, time);
         return;
     }
 
     if (is_bitmap_texture(texmap))
     {
         const auto uv_transform_layer_name = asf::format("{0}_{1}_uv_transform", material_node_name, material_input_name);
-        shader_group.add_shader("shader", "as_max_uv_transform", uv_transform_layer_name.c_str(), get_uv_params(texmap));
+        shader_group.add_shader("shader", "as_max_uv_transform", uv_transform_layer_name.c_str(), get_uv_params(texmap, time));
 
         const auto layer_name = asf::format("{0}_{1}_texture", material_node_name, material_input_name);
         shader_group.add_shader("shader", "as_max_float_texture", layer_name.c_str(),
             asr::ParamArray()
                 .insert("Filename", fmt_osl_expr(texmap)));
 
-        asr::ParamArray color_balance_params = get_output_params(texmap)
+        asr::ParamArray color_balance_params = get_output_params(texmap, time)
             .insert("in_constantFloat", fmt_osl_expr(const_value));
 
         const auto color_balance_layer_name = asf::format("{0}_{1}_color_balance", material_node_name, material_input_name);
@@ -295,25 +299,32 @@ void connect_color_texture(
     const char*         material_node_name,
     const char*         material_input_name,
     Texmap*             texmap,
-    const Color         const_color)
+    const Color         const_color,
+    const TimeValue     time)
 {
     if (is_supported_procedural_texture(texmap, false))
     {
-        create_supported_texture(shader_group, material_node_name, material_input_name, texmap, const_color);
+        create_supported_texture(
+            shader_group,
+            material_node_name,
+            material_input_name,
+            texmap,
+            const_color,
+            time);
         return;
     }
 
     if (is_osl_texture(texmap))
     {
         OSLTexture* osl_tex = static_cast<OSLTexture*>(texmap);
-        osl_tex->create_osl_texture(shader_group, material_node_name, material_input_name);
+        osl_tex->create_osl_texture(shader_group, material_node_name, material_input_name, time);
         return;
     }
     
     if (is_bitmap_texture(texmap))
     {
         const auto uv_transform_layer_name = asf::format("{0}_{1}_uv_transform", material_node_name, material_input_name);
-        shader_group.add_shader("shader", "as_max_uv_transform", uv_transform_layer_name.c_str(), get_uv_params(texmap));
+        shader_group.add_shader("shader", "as_max_uv_transform", uv_transform_layer_name.c_str(), get_uv_params(texmap, time));
         if (!is_linear_texture(static_cast<BitmapTex*>(texmap)))
         {
             const auto texture_layer_name = asf::format("{0}_{1}_texture", material_node_name, material_input_name);
@@ -325,7 +336,7 @@ void connect_color_texture(
             shader_group.add_shader("shader", "as_max_srgb_to_linear_rgb", srgb_to_linear_layer_name.c_str(),
                 asr::ParamArray());
 
-            asr::ParamArray color_balance_params = get_output_params(texmap)
+            asr::ParamArray color_balance_params = get_output_params(texmap, time)
                 .insert("in_constantColor", fmt_osl_expr(to_color3f(const_color)));
 
             const auto color_balance_layer_name = asf::format("{0}_{1}_color_balance", material_node_name, material_input_name);
@@ -358,7 +369,7 @@ void connect_color_texture(
                 asr::ParamArray()
                     .insert("Filename", fmt_osl_expr(texmap)));
 
-            asr::ParamArray color_balance_params = get_output_params(texmap)
+            asr::ParamArray color_balance_params = get_output_params(texmap, time)
                 .insert("in_constantColor", fmt_osl_expr(to_color3f(const_color)));
 
             const auto color_balance_layer_name = asf::format("{0}_{1}_color_balance", material_node_name, material_input_name);
@@ -389,7 +400,8 @@ void connect_bump_map(
     const char*         material_normal_input_name,
     const char*         material_tn_input_name,
     Texmap*             texmap,
-    const float         amount)
+    const float         amount,
+    const TimeValue     time)
 {
     if (is_supported_procedural_texture(texmap, false) || is_osl_texture(texmap))
     {
@@ -400,7 +412,8 @@ void connect_bump_map(
             bump_map_layer_name.c_str(),
             "Height",
             texmap,
-            1.0f);
+            1.0f,
+            time);
 
         shader_group.add_shader("shader", "as_max_bump_map", bump_map_layer_name.c_str(),
             asr::ParamArray()
@@ -416,7 +429,7 @@ void connect_bump_map(
     if (is_bitmap_texture(texmap))
     {
         auto uv_transform_layer_name = asf::format("{0}_bump_uv_transform", material_node_name);
-        shader_group.add_shader("shader", "as_max_uv_transform", uv_transform_layer_name.c_str(), get_uv_params(texmap));
+        shader_group.add_shader("shader", "as_max_uv_transform", uv_transform_layer_name.c_str(), get_uv_params(texmap, time));
 
         auto texture_layer_name = asf::format("{0}_bump_map_texture", material_node_name);
         shader_group.add_shader("shader", "as_max_float_texture", texture_layer_name.c_str(),
@@ -452,7 +465,8 @@ void connect_normal_map(
     const char*         material_tn_input_name,
     Texmap*             texmap,
     const int           up_vector,
-    const float         amount)
+    const float         amount,
+    const TimeValue     time)
 {
     if (is_supported_procedural_texture(texmap, false) || is_osl_texture(texmap))
     {
@@ -463,7 +477,8 @@ void connect_normal_map(
             normal_map_layer_name.c_str(),
             "Color",
             texmap,
-            Color(1.0f, 1.0f, 1.0f));
+            Color(1.0f, 1.0f, 1.0f),
+            time);
 
         shader_group.add_shader("shader", "as_max_normal_map", normal_map_layer_name.c_str(),
             asr::ParamArray()
@@ -483,7 +498,7 @@ void connect_normal_map(
     if (is_bitmap_texture(texmap))
     {
         auto uv_transform_layer_name = asf::format("{0}_bump_uv_transform", material_node_name);
-        shader_group.add_shader("shader", "as_max_uv_transform", uv_transform_layer_name.c_str(), get_uv_params(texmap));
+        shader_group.add_shader("shader", "as_max_uv_transform", uv_transform_layer_name.c_str(), get_uv_params(texmap, time));
 
         auto texture_layer_name = asf::format("{0}_normal_map_texture", material_node_name);
         shader_group.add_shader("shader", "as_max_color_texture", texture_layer_name.c_str(),
@@ -521,7 +536,8 @@ void connect_sub_mtl(
     asr::ShaderGroup&       shader_group,
     const char*             shader_name,
     const char*             shader_input,
-    Mtl*                    mat)
+    Mtl*                    mat,
+    const TimeValue         time)
 {
     auto appleseed_mtl = static_cast<IAppleseedMtl*>(mat->GetInterface(IAppleseedMtl::interface_id()));
     if (!appleseed_mtl)
@@ -529,7 +545,11 @@ void connect_sub_mtl(
 
     std::string layer_name =
         make_unique_name(assembly.materials(), asf::format("{0}_{1}_sub_mat", shader_name, mat->GetName()));
-    assembly.materials().insert(appleseed_mtl->create_material(assembly, layer_name.c_str(), false));
+    assembly.materials().insert(appleseed_mtl->create_material(
+        assembly,
+        layer_name.c_str(),
+        false,
+        time));
 
     asr::Material* layer_material = assembly.materials().get_by_name(layer_name.c_str());
     if (!layer_material->get_parameters().exist_path("osl_surface"))
@@ -558,10 +578,10 @@ void create_osl_shader(
     asr::ShaderGroup&       shader_group,
     const char*             layer_name,
     IParamBlock2*           param_block,
-    const OSLShaderInfo*    shader_info)
+    const OSLShaderInfo*    shader_info,
+    const TimeValue         time)
 {
     asr::ParamArray params;
-    const TimeValue time = get_current_time();
 
     for (const auto& param_info : shader_info->m_params)
     {
@@ -586,7 +606,8 @@ void create_osl_shader(
                             layer_name,
                             max_param.m_osl_param_name.c_str(),
                             texmap,
-                            constant_value);
+                            constant_value,
+                            time);
                     }
                     break;
                   case MaxParam::Color:
@@ -598,7 +619,8 @@ void create_osl_shader(
                             layer_name,
                             max_param.m_osl_param_name.c_str(),
                             texmap,
-                            constant_color);
+                            constant_color,
+                            time);
                     }
                     break;
 
@@ -609,7 +631,11 @@ void create_osl_shader(
                         if (is_osl_texture(texmap))
                         {
                             OSLTexture* osl_tex = static_cast<OSLTexture*>(texmap);
-                            osl_tex->create_osl_texture(shader_group, layer_name, max_param.m_osl_param_name.c_str());
+                            osl_tex->create_osl_texture(
+                                shader_group,
+                                layer_name,
+                                max_param.m_osl_param_name.c_str(),
+                                time);
                         }
                     }
                     break;
@@ -623,7 +649,13 @@ void create_osl_shader(
             param_block->GetValue(max_param.m_max_param_id, time, material, FOREVER);
             if (material != nullptr && assembly != nullptr)
             {
-                connect_sub_mtl(*assembly, shader_group, layer_name, max_param.m_osl_param_name.c_str(), material);
+                connect_sub_mtl(
+                    *assembly,
+                    shader_group,
+                    layer_name,
+                    max_param.m_osl_param_name.c_str(),
+                    material,
+                    time);
             }
         }
 

--- a/src/appleseed-max-impl/oslutils.h
+++ b/src/appleseed-max-impl/oslutils.h
@@ -49,9 +49,9 @@ class Mtl;
 class OSLShaderInfo;
 class Texmap;
 
-renderer::ParamArray get_uv_params(Texmap* texmap);
+renderer::ParamArray get_uv_params(Texmap* texmap, const TimeValue time);
 
-renderer::ParamArray get_output_params(Texmap* texmap);
+renderer::ParamArray get_output_params(Texmap* texmap, const TimeValue time);
 
 std::string fmt_osl_expr(const std::string& s);
 
@@ -74,14 +74,16 @@ void connect_float_texture(
     const char*             material_node_name,
     const char*             material_input_name,
     Texmap*                 texmap,
-    const float             const_value);
+    const float             const_value,
+    const TimeValue         time);
 
 void connect_color_texture(
     renderer::ShaderGroup&  shader_group,
     const char*             material_node_name,
     const char*             material_input_name,
     Texmap*                 texmap,
-    const Color             const_color);
+    const Color             const_color,
+    const TimeValue         time);
 
 void connect_bump_map(
     renderer::ShaderGroup&  shader_group,
@@ -89,7 +91,8 @@ void connect_bump_map(
     const char*             material_normal_input_name,
     const char*             material_tn_input_name,
     Texmap*                 texmap,
-    const float             amount);
+    const float             amount,
+    const TimeValue         time);
 
 void connect_normal_map(
     renderer::ShaderGroup&  shader_group,
@@ -98,18 +101,21 @@ void connect_normal_map(
     const char*             material_tn_input_name,
     Texmap*                 texmap,
     const int               up_vector,
-    const float             amount);
+    const float             amount,
+    const TimeValue         time);
 
 void connect_sub_mtl(
     renderer::Assembly&     assembly,
     renderer::ShaderGroup&  shader_group,
     const char*             shader_name,
     const char*             shader_input,
-    Mtl*                    mat);
+    Mtl*                    mat,
+    const TimeValue         time);
 
 void create_osl_shader(
     renderer::Assembly*     assembly,
     renderer::ShaderGroup&  shader_group,
     const char*             layer_name,
     IParamBlock2*           param_block,
-    const OSLShaderInfo*    shader_info);
+    const OSLShaderInfo*    shader_info,
+    const TimeValue         time);

--- a/src/appleseed-max-impl/utilities.cpp
+++ b/src/appleseed-max-impl/utilities.cpp
@@ -31,7 +31,6 @@
 
 // appleseed-max headers.
 #include "appleseedoslplugin/osltexture.h"
-#include "appleseedrenderer/appleseedrenderer.h"
 #include "osloutputselectormap/osloutputselector.h"
 #include "main.h"
 
@@ -307,6 +306,7 @@ std::string insert_texture_and_instance(
     asr::BaseGroup& base_group,
     Texmap*         texmap,
     const bool      use_max_procedural_maps,
+    const TimeValue time,
     asr::ParamArray texture_params,
     asr::ParamArray texture_instance_params)
 {
@@ -316,6 +316,7 @@ std::string insert_texture_and_instance(
             insert_procedural_texture_and_instance(
                 base_group,
                 texmap,
+                time,
                 texture_params,
                 texture_instance_params);
     }
@@ -372,22 +373,14 @@ std::string insert_bitmap_texture_and_instance(
     return texture_instance_name;
 }
 
-TimeValue get_current_time()
-{
-    TimeValue time(0);
-    AppleseedRenderer* appleseed_renderer = static_cast<AppleseedRenderer*>(GetCOREInterface()->GetCurrentRenderer(false));
-    if (appleseed_renderer != nullptr)
-        time = appleseed_renderer->get_time();
-    return time;
-}
-
 namespace
 {
     class MaxShadeContext
       : public ShadeContext
     {
       public:
-        explicit MaxShadeContext(const asr::SourceInputs& source_inputs)
+        explicit MaxShadeContext(const asr::SourceInputs& source_inputs, TimeValue time)
+            : m_cur_time(time)
         {
             doMaps = TRUE;
             filterMaps = FALSE;
@@ -397,7 +390,6 @@ namespace
             xshadeID = 0;
             // todo: initialize `out`?
 
-            m_cur_time = get_current_time();
             m_uv.x = source_inputs.m_uv_x;
             m_uv.y = source_inputs.m_uv_y;
         }
@@ -567,9 +559,10 @@ namespace
       : public asr::Source
     {
       public:
-        explicit MaxProceduralTextureSource(Texmap* texmap)
+        explicit MaxProceduralTextureSource(Texmap* texmap, TimeValue time)
           : asr::Source(false)
           , m_texmap(texmap)
+          , m_time(time)
         {
         }
 
@@ -651,18 +644,19 @@ namespace
         }
 
       private:
-        Texmap* m_texmap;
+        Texmap*     m_texmap;
+        TimeValue   m_time;
 
         float evaluate_float(const asr::SourceInputs& source_inputs) const
         {
-            MaxShadeContext maxsc(source_inputs);
+            MaxShadeContext maxsc(source_inputs, m_time);
 
             return m_texmap->EvalMono(maxsc);
         }
 
         void evaluate_color(const asr::SourceInputs& source_inputs, float& r, float& g, float& b) const
         {
-            MaxShadeContext maxsc(source_inputs);
+            MaxShadeContext maxsc(source_inputs, m_time);
             
             const AColor tex_color = m_texmap->EvalColor(maxsc);
 
@@ -673,7 +667,7 @@ namespace
 
         void evaluate_color(const asr::SourceInputs& source_inputs, float& r, float& g, float& b, asr::Alpha& alpha) const
         {
-            MaxShadeContext maxsc(source_inputs);
+            MaxShadeContext maxsc(source_inputs, m_time);
             
             const AColor tex_color = m_texmap->EvalColor(maxsc);
 
@@ -689,9 +683,10 @@ namespace
       : public asr::Texture
     {
       public:
-        MaxProceduralTexture(const char* name, Texmap* texmap)
+        MaxProceduralTexture(const char* name, Texmap* texmap, TimeValue time)
           : asr::Texture(name, asr::ParamArray())
           , m_texmap(texmap)
+          , m_time(time)
         {
             // Dummy values.
             m_properties =
@@ -725,7 +720,7 @@ namespace
             const asf::UniqueID         assembly_uid,
             const asr::TextureInstance& texture_instance) override
         {
-            return new MaxProceduralTextureSource(m_texmap);
+            return new MaxProceduralTextureSource(m_texmap, m_time);
         }
 
         asf::Tile* load_tile(
@@ -745,6 +740,7 @@ namespace
       private:
         asf::CanvasProperties   m_properties;
         Texmap*                 m_texmap;
+        TimeValue               m_time;
     };
 
     void load_map_files_recursively(MtlBase* mat_base, TimeValue time)
@@ -767,10 +763,10 @@ namespace
 std::string insert_procedural_texture_and_instance(
     asr::BaseGroup& base_group,
     Texmap*         texmap,
+    const TimeValue time,
     asr::ParamArray texture_params,
     asr::ParamArray texture_instance_params)
 {
-    const TimeValue time = get_current_time();
     texmap->Update(time, FOREVER);
     load_map_files_recursively(texmap, time);
 
@@ -786,7 +782,9 @@ std::string insert_procedural_texture_and_instance(
         base_group.textures().insert(
             asf::auto_release_ptr<asr::Texture>(
                 new MaxProceduralTexture(
-                    texture_name.c_str(), texmap)));
+                    texture_name.c_str(),
+                    texmap,
+                    time)));
     }
 
     const std::string texture_instance_name = texture_name + "_inst";

--- a/src/appleseed-max-impl/utilities.cpp
+++ b/src/appleseed-max-impl/utilities.cpp
@@ -379,7 +379,7 @@ namespace
       : public ShadeContext
     {
       public:
-        explicit MaxShadeContext(const asr::SourceInputs& source_inputs, TimeValue time)
+        MaxShadeContext(const asr::SourceInputs& source_inputs, const TimeValue time)
             : m_cur_time(time)
         {
             doMaps = TRUE;
@@ -559,7 +559,7 @@ namespace
       : public asr::Source
     {
       public:
-        explicit MaxProceduralTextureSource(Texmap* texmap, TimeValue time)
+        MaxProceduralTextureSource(Texmap* texmap, const TimeValue time)
           : asr::Source(false)
           , m_texmap(texmap)
           , m_time(time)
@@ -644,8 +644,8 @@ namespace
         }
 
       private:
-        Texmap*     m_texmap;
-        TimeValue   m_time;
+        Texmap*         m_texmap;
+        const TimeValue m_time;
 
         float evaluate_float(const asr::SourceInputs& source_inputs) const
         {
@@ -683,7 +683,7 @@ namespace
       : public asr::Texture
     {
       public:
-        MaxProceduralTexture(const char* name, Texmap* texmap, TimeValue time)
+        MaxProceduralTexture(const char* name, Texmap* texmap, const TimeValue time)
           : asr::Texture(name, asr::ParamArray())
           , m_texmap(texmap)
           , m_time(time)

--- a/src/appleseed-max-impl/utilities.cpp
+++ b/src/appleseed-max-impl/utilities.cpp
@@ -31,6 +31,7 @@
 
 // appleseed-max headers.
 #include "appleseedoslplugin/osltexture.h"
+#include "appleseedrenderer/appleseedrenderer.h"
 #include "osloutputselectormap/osloutputselector.h"
 #include "main.h"
 
@@ -371,6 +372,15 @@ std::string insert_bitmap_texture_and_instance(
     return texture_instance_name;
 }
 
+TimeValue get_current_time()
+{
+    TimeValue time(0);
+    AppleseedRenderer* appleseed_renderer = static_cast<AppleseedRenderer*>(GetCOREInterface()->GetCurrentRenderer(false));
+    if (appleseed_renderer != nullptr)
+        time = appleseed_renderer->get_time();
+    return time;
+}
+
 namespace
 {
     class MaxShadeContext
@@ -387,7 +397,7 @@ namespace
             xshadeID = 0;
             // todo: initialize `out`?
 
-            m_cur_time = GetCOREInterface()->GetTime();
+            m_cur_time = get_current_time();
             m_uv.x = source_inputs.m_uv_x;
             m_uv.y = source_inputs.m_uv_y;
         }
@@ -760,7 +770,7 @@ std::string insert_procedural_texture_and_instance(
     asr::ParamArray texture_params,
     asr::ParamArray texture_instance_params)
 {
-    const TimeValue time = GetCOREInterface()->GetTime();
+    const TimeValue time = get_current_time();
     texmap->Update(time, FOREVER);
     load_map_files_recursively(texmap, time);
 

--- a/src/appleseed-max-impl/utilities.h
+++ b/src/appleseed-max-impl/utilities.h
@@ -172,6 +172,7 @@ std::string insert_texture_and_instance(
     renderer::BaseGroup&    base_group,
     Texmap*                 texmap,
     const bool              use_max_procedural_maps,
+    const TimeValue         time,
     renderer::ParamArray    texture_params = renderer::ParamArray(),
     renderer::ParamArray    texture_instance_params = renderer::ParamArray());
 
@@ -184,6 +185,7 @@ std::string insert_bitmap_texture_and_instance(
 std::string insert_procedural_texture_and_instance(
     renderer::BaseGroup&    base_group,
     Texmap*                 texmap,
+    const TimeValue         time,
     renderer::ParamArray    texture_params = renderer::ParamArray(),
     renderer::ParamArray    texture_instance_params = renderer::ParamArray());
 
@@ -203,13 +205,6 @@ const T load_ini_setting(const wchar_t* category, const wchar_t* key_name, const
 
 template <typename T>
 const T load_system_setting(const wchar_t* key_name, const T& default_value);
-
-
-//
-// Renderer access functions.
-//
-
-TimeValue get_current_time();
 
 
 //

--- a/src/appleseed-max-impl/utilities.h
+++ b/src/appleseed-max-impl/utilities.h
@@ -206,6 +206,13 @@ const T load_system_setting(const wchar_t* key_name, const T& default_value);
 
 
 //
+// Renderer access functions.
+//
+
+TimeValue get_current_time();
+
+
+//
 // Implementation.
 //
 


### PR DESCRIPTION
Hi,
This PR fixes bug #212. OSL materials and textures were not updated during animation rendering. Now they are working. What I did is instead of getting current with the call `GetCOREInterface()->GetTime()` I added a function to renderer to get currently rendered frame from the it.

Thanks for review!
Sergo.