### PR TITLE
Rotate environment map by 90 degrees to align with Max viewport preview

### DIFF
--- a/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
@@ -1302,7 +1302,7 @@ namespace
             if (uvgen && uvgen->IsStdUVGen())
             {
                 StdUVGen* std_uvgen = static_cast<StdUVGen*>(uvgen);
-                env_edf_params.insert("horizontal_shift", std_uvgen->GetUOffs(time) * 180.0f);
+                env_edf_params.insert("horizontal_shift", std_uvgen->GetUOffs(time) * 180.0f + 90.0f);
                 env_edf_params.insert("vertical_shift", std_uvgen->GetVOffs(time) * 180.0f);
             }
 


### PR DESCRIPTION
This will align the Max viewport preview of the environment map with the rendered image and partly solve issue #251 
The environment still needs to be reflected along the vertical axis to have it fully fixed (and identical to Corona or V-Ray).
One can do this meanwhile by setting `Tiling_U = -1` in the Max `Bitmap Coordinates` rollout.