### PR TITLE
Add motion blur support

### DIFF
--- a/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
@@ -1719,14 +1719,20 @@ asf::auto_release_ptr<asr::Camera> build_camera(
 
             if (phys_camera->GetMotionBlurEnabled(time, FOREVER))
             {
-                const float shutter_duration = phys_camera->GetShutterDurationInFrames(time, FOREVER);
-                const int time_offset = asf::round<int, float>(shutter_duration * GetTicksPerFrame());
                 const asf::Transformd transform =
                     asf::Transformd::from_local_to_parent(
                         asf::Matrix4d::make_scaling(asf::Vector3d(settings.m_scale_multiplier)) *
-                        to_matrix4d(view_node->GetObjTMAfterWSM(time + time_offset)));
+                        to_matrix4d(view_node->GetObjTMAfterWSM(time + GetTicksPerFrame())));
 
                 camera->transform_sequence().set_transform(1.0, transform);
+
+                // Set motion blur parameters.
+                const float opening_time = phys_camera->GetShutterOffsetInFrames(time, FOREVER);
+                const float closing_time = opening_time + phys_camera->GetShutterDurationInFrames(time, FOREVER);
+                params.insert("shutter_open_begin_time", opening_time);
+                params.insert("shutter_open_end_time", opening_time);
+                params.insert("shutter_close_begin_time", closing_time);
+                params.insert("shutter_close_end_time", closing_time);
             }
         }
         else

--- a/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
@@ -819,7 +819,7 @@ namespace
 
                 if (is_animated)
                 {
-                    asf::Transformd animated_transform =
+                   asf::Transformd animated_transform =
                         asf::Transformd::from_local_to_parent(
                             to_matrix4d(node->GetObjTMAfterWSM(time + GetTicksPerFrame())));
 
@@ -1718,12 +1718,13 @@ asf::auto_release_ptr<asr::Camera> build_camera(
                 camera->transform_sequence().set_transform(1.0, transform);
 
                 // Set motion blur parameters.
+                asr::ParamArray& camera_params = camera->get_parameters();
                 const float opening_time = phys_camera->GetShutterOffsetInFrames(time, FOREVER);
                 const float closing_time = opening_time + phys_camera->GetShutterDurationInFrames(time, FOREVER);
-                params.insert("shutter_open_begin_time", opening_time);
-                params.insert("shutter_open_end_time", opening_time);
-                params.insert("shutter_close_begin_time", closing_time);
-                params.insert("shutter_close_end_time", closing_time);
+                camera_params.insert("shutter_open_begin_time", opening_time);
+                camera_params.insert("shutter_open_end_time", opening_time);
+                camera_params.insert("shutter_close_begin_time", closing_time);
+                camera_params.insert("shutter_close_end_time", closing_time);
             }
         }
         else

--- a/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
@@ -819,21 +819,12 @@ namespace
 
                 if (is_animated)
                 {
-                    float shutter_duration = 0.5f;
-                    if (view_node != nullptr)
-                    {
-                        MaxSDK::IPhysicalCamera* phys_camera = dynamic_cast<MaxSDK::IPhysicalCamera*>(view_node->EvalWorldState(time).obj);
-                        if (phys_camera != nullptr)
-                            shutter_duration = phys_camera->GetShutterDurationInFrames(time, FOREVER);
-                    }
-
-                    const int time_offset = asf::round<int>(shutter_duration * GetTicksPerFrame());
-                    asf::Transformd transform =
+                    asf::Transformd animated_transform =
                         asf::Transformd::from_local_to_parent(
-                            to_matrix4d(node->GetObjTMAfterWSM(time + time_offset)));
+                            to_matrix4d(node->GetObjTMAfterWSM(time + GetTicksPerFrame())));
 
                     object_assembly_instance->transform_sequence()
-                        .set_transform(1.0, transform);
+                        .set_transform(1.0, animated_transform);
                 }
             }
 

--- a/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
@@ -807,23 +807,16 @@ namespace
             object_assembly_instance->transform_sequence()
                 .set_transform(0.0, transform);
 
-            if (node->GetMotBlurOnOff(time) && node->MotBlur() == 1)
+            const int ObjectMotionBlur = 1;
+            if (node->GetMotBlurOnOff(time) && node->MotBlur() == ObjectMotionBlur)
             {
-                bool is_animated = false;
-                Control* tm_controller;
-                Control* controller;
-                tm_controller = node->GetTMController();
-                auto class_id = tm_controller->ClassID();
+                Control* tm_controller = node->GetTMController();
 
-                controller = tm_controller->GetPositionController();
-                is_animated = controller->IsAnimated() > 0;
+                const bool is_animated =
+                    tm_controller->GetPositionController()->IsAnimated() > 0 ||
+                    tm_controller->GetRotationController()->IsAnimated() > 0 ||
+                    tm_controller->GetScaleController()->IsAnimated() > 0;
 
-                controller = tm_controller->GetRotationController();
-                is_animated = is_animated || controller->IsAnimated() > 0;
-
-                controller = tm_controller->GetScaleController();
-                is_animated = is_animated || controller->IsAnimated() > 0;
-                
                 if (is_animated)
                 {
                     float shutter_duration = 0.5f;
@@ -834,7 +827,7 @@ namespace
                             shutter_duration = phys_camera->GetShutterDurationInFrames(time, FOREVER);
                     }
 
-                    int time_offset = asf::round<int, float>(shutter_duration * GetTicksPerFrame());
+                    const int time_offset = asf::round<int>(shutter_duration * GetTicksPerFrame());
                     asf::Transformd transform =
                         asf::Transformd::from_local_to_parent(
                             to_matrix4d(node->GetObjTMAfterWSM(time + time_offset)));
@@ -1726,17 +1719,15 @@ asf::auto_release_ptr<asr::Camera> build_camera(
 
             if (phys_camera->GetMotionBlurEnabled(time, FOREVER))
             {
-                float shutter_duration = phys_camera->GetShutterDurationInFrames(time, FOREVER);
-                int time_offset = asf::round<int, float>(shutter_duration * GetTicksPerFrame());
-                asf::Transformd transform =
+                const float shutter_duration = phys_camera->GetShutterDurationInFrames(time, FOREVER);
+                const int time_offset = asf::round<int, float>(shutter_duration * GetTicksPerFrame());
+                const asf::Transformd transform =
                     asf::Transformd::from_local_to_parent(
                         asf::Matrix4d::make_scaling(asf::Vector3d(settings.m_scale_multiplier)) *
                         to_matrix4d(view_node->GetObjTMAfterWSM(time + time_offset)));
 
-                camera->transform_sequence()
-                    .set_transform(1.0, transform);
+                camera->transform_sequence().set_transform(1.0, transform);
             }
-
         }
         else
         {


### PR DESCRIPTION
Hello!

This is quick attempt to add motion blur support. Both object and camera motion blur are supported.
 * To enable object motion blur `appleseed object properties` modifier needs to be added and `optimize instances` should be turned on. Plus Object motion blur should be enabled in standard object properties.
 * Camera motion blur turned on by using Physical camera and by turning on Enable Motion Blur checkbox.
In both cases physical camera's shutter speed is used to determine time offset.
