### PR TITLE
Revert "Fix random black tiles bug"

### DIFF
--- a/src/appleseed-max-impl/appleseedinteractive/interactivesession.cpp
+++ b/src/appleseed-max-impl/appleseedinteractive/interactivesession.cpp
@@ -60,8 +60,8 @@ void InteractiveSession::render_thread()
     // Create the renderer controller.
     m_renderer_controller.reset(new InteractiveRendererController());
 
-    // Create the tile callback factory.
-    InteractiveTileCallbackFactory m_tile_callback_factory(
+    // Create the tile callback.
+    InteractiveTileCallback m_tile_callback(
         m_bitmap,
         m_iirender_mgr,
         m_renderer_controller.get());
@@ -74,7 +74,7 @@ void InteractiveSession::render_thread()
             m_project->configurations().get_by_name("interactive")->get_inherited_parameters(),
             search_paths,   // don't pass a temporary because MasterRenderer only holds a const reference to the search paths
             m_renderer_controller.get(),
-            &m_tile_callback_factory));
+            &m_tile_callback));
 
     // Render the frame.
     renderer->render();

--- a/src/appleseed-max-impl/appleseedinteractive/interactivetilecallback.cpp
+++ b/src/appleseed-max-impl/appleseedinteractive/interactivetilecallback.cpp
@@ -84,28 +84,3 @@ void InteractiveTileCallback::update_caller(UINT_PTR param_ptr)
 
     tile_callback->m_ui_promise.set_value();
 }
-
-
-//
-// InteractiveTileCallbackFactory class implementation.
-//
-
-InteractiveTileCallbackFactory::InteractiveTileCallbackFactory(
-    Bitmap*                     bitmap,
-    IIRenderMgr*                iimanager,
-    asr::IRendererController*   renderer_controller)
-  : m_bitmap(bitmap)
-  , m_iimanager(iimanager)
-  , m_renderer_controller(renderer_controller)
-{
-}
-
-void InteractiveTileCallbackFactory::release()
-{
-    delete this;
-}
-
-asr::ITileCallback* InteractiveTileCallbackFactory::create()
-{
-    return new InteractiveTileCallback(m_bitmap, m_iimanager, m_renderer_controller);
-}

--- a/src/appleseed-max-impl/appleseedinteractive/interactivetilecallback.h
+++ b/src/appleseed-max-impl/appleseedinteractive/interactivetilecallback.h
@@ -63,22 +63,3 @@ class InteractiveTileCallback
 
     static void update_caller(UINT_PTR param_ptr);
 };
-
-class InteractiveTileCallbackFactory
-  : public renderer::ITileCallbackFactory
-{
-  public:
-    InteractiveTileCallbackFactory(
-        Bitmap*                         bitmap,
-        IIRenderMgr*                    iimanager,
-        renderer::IRendererController*  renderer_controller);
-
-    void release() override;
-
-    renderer::ITileCallback* create() override;
-
-  private:
-    Bitmap*                             m_bitmap;
-    IIRenderMgr*                        m_iimanager;
-    renderer::IRendererController*      m_renderer_controller;
-};

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
@@ -2115,8 +2115,8 @@ namespace
             &rendered_tile_count,
             total_tile_count);
 
-        // Create the tile callback factory.
-        TileCallbackFactory tile_callback_factory(bitmap, &rendered_tile_count);
+        // Create the tile callback.
+        TileCallback tile_callback(bitmap, &rendered_tile_count);
 
         // Create the master renderer.
         asf::SearchPaths search_paths;
@@ -2126,7 +2126,7 @@ namespace
                 project.configurations().get_by_name("final")->get_inherited_parameters(),
                 search_paths,   // don't pass a temporary because MasterRenderer only holds a const reference to the search paths
                 &renderer_controller,
-                &tile_callback_factory));
+                &tile_callback));
 
         // Render the frame.
         renderer->render();

--- a/src/appleseed-max-impl/appleseedrenderer/tilecallback.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/tilecallback.cpp
@@ -167,6 +167,7 @@ void TileCallback::on_tile_begin(
         &BracketColor);
 
     // Partially refresh the display window.
+    // Note that Bitmap::RefreshWindow() must be called from the UI thread.
     RECT rect = make_rect(x, y, tile.get_width(), tile.get_height());
     m_bitmap->RefreshWindow(&rect);
 }
@@ -191,6 +192,7 @@ void TileCallback::on_tile_end(
     blit_tile(*frame, tile_x, tile_y);
 
     // Partially refresh the display window.
+    // Note that Bitmap::RefreshWindow() must be called from the UI thread.
     RECT rect = make_rect(x, y, tile.get_width(), tile.get_height());
     m_bitmap->RefreshWindow(&rect);
 
@@ -215,6 +217,7 @@ void TileCallback::on_progressive_frame_update(
     }
 
     // Refresh the entire display window.
+    // Note that Bitmap::RefreshWindow() must be called from the UI thread.
     m_bitmap->RefreshWindow();
 }
 
@@ -268,27 +271,4 @@ void TileCallback::blit_tile(
                 reinterpret_cast<BMM_Color_fl*>(&color));
         }
     }
-}
-
-
-//
-// TileCallbackFactory class implementation.
-//
-
-TileCallbackFactory::TileCallbackFactory(
-    Bitmap*                 bitmap,
-    volatile asf::uint32*   rendered_tile_count)
-  : m_bitmap(bitmap)
-  , m_rendered_tile_count(rendered_tile_count)
-{
-}
-
-void TileCallbackFactory::release()
-{
-    delete this;
-}
-
-asr::ITileCallback* TileCallbackFactory::create()
-{
-    return new TileCallback(m_bitmap, m_rendered_tile_count);
 }

--- a/src/appleseed-max-impl/appleseedrenderer/tilecallback.h
+++ b/src/appleseed-max-impl/appleseedrenderer/tilecallback.h
@@ -41,7 +41,6 @@
 
 // Forward declarations.
 namespace renderer  { class Frame; }
-namespace renderer  { class ITileCallback; }
 class Bitmap;
 
 class TileCallback
@@ -76,21 +75,4 @@ class TileCallback
         const renderer::Frame&          frame,
         const size_t                    tile_x,
         const size_t                    tile_y);
-};
-
-class TileCallbackFactory
-  : public renderer::ITileCallbackFactory
-{
-  public:
-    TileCallbackFactory(
-        Bitmap*                         bitmap,
-        volatile foundation::uint32*    rendered_tile_count);
-
-    void release() override;
-
-    renderer::ITileCallback* create() override;
-
-  private:
-    Bitmap*                             m_bitmap;
-    volatile foundation::uint32*        m_rendered_tile_count;
 };


### PR DESCRIPTION
Revert ab4667267b6d38ff8ac5c5066d452ee9649f9167 ("Fix random black tiles bug") as it broke render cancellation (issue #266).

A better fix has been implemented in appleseed core in https://github.com/appleseedhq/appleseed/pull/2405.