### PR TITLE
Adapt VC project files to recent changes of the VS platform identifier

### DIFF
--- a/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj
@@ -18,7 +18,7 @@
     <ProjectGuid>{62C41566-DBCB-49D3-943A-4DD53222269E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>appleseedmax</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
@@ -86,7 +86,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\v140\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc140;$(SolutionDir)..\..\boost_1_69_0\stage\lib</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc140;$(SolutionDir)..\..\boost_1_69_0\stage\lib</AdditionalLibraryDirectories>
       <AdditionalDependencies>Paramblk2.lib;ShLwApi.Lib;appleseed.lib;bmm.lib;core.lib;geom.lib;maxutil.lib;mesh.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <DelayLoadDLLs>
@@ -102,11 +102,11 @@ copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2017\Current\"
 if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
 if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2017\Current\"
 
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2017\Current\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2017\Current\"
 
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2017\Current\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2017\Current\"
 
 rmdir /S /Q "$(SolutionDir)..\sandbox\max2017\$(Configuration)\shaders" 2&gt;nul
 rmdir /S /Q "$(SolutionDir)..\sandbox\max2017\Current\shaders" 2&gt;nul
@@ -150,7 +150,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\v140\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc140;$(SolutionDir)..\..\boost_1_69_0\stage\lib</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc140;$(SolutionDir)..\..\boost_1_69_0\stage\lib</AdditionalLibraryDirectories>
       <AdditionalDependencies>Paramblk2.lib;ShLwApi.Lib;appleseed.lib;bmm.lib;core.lib;geom.lib;maxutil.lib;mesh.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>
       </DelayLoadDLLs>
@@ -165,11 +165,11 @@ copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2017\Current\"
 if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
 if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2017\Current\"
 
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2017\Current\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2017\Current\"
 
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2017\Current\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2017\Current\"
 
 rmdir /S /Q "$(SolutionDir)..\sandbox\max2017\$(Configuration)\shaders" 2&gt;nul
 rmdir /S /Q "$(SolutionDir)..\sandbox\max2017\Current\shaders" 2&gt;nul
@@ -212,7 +212,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\v140\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc140;$(SolutionDir)..\..\boost_1_69_0\stage\lib</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc140;$(SolutionDir)..\..\boost_1_69_0\stage\lib</AdditionalLibraryDirectories>
       <AdditionalDependencies>Paramblk2.lib;ShLwApi.Lib;appleseed.lib;bmm.lib;core.lib;geom.lib;maxutil.lib;mesh.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>
       </DelayLoadDLLs>
@@ -227,11 +227,11 @@ copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2017\Current\"
 if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
 if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2017\Current\"
 
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2017\Current\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2017\Current\"
 
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2017\Current\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2017\Current\"
 
 rmdir /S /Q "$(SolutionDir)..\sandbox\max2017\$(Configuration)\shaders" 2&gt;nul
 rmdir /S /Q "$(SolutionDir)..\sandbox\max2017\Current\shaders" 2&gt;nul

--- a/src/appleseed-max-impl/appleseed-max2018-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2018-impl.vcxproj
@@ -18,7 +18,7 @@
     <ProjectGuid>{62C41566-DBCB-49D3-943A-4DD53222269E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>appleseedmax</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
@@ -86,7 +86,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\v140\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc140;$(SolutionDir)..\..\boost_1_69_0\stage\lib</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc140;$(SolutionDir)..\..\boost_1_69_0\stage\lib</AdditionalLibraryDirectories>
       <AdditionalDependencies>Paramblk2.lib;ShLwApi.Lib;appleseed.lib;bmm.lib;core.lib;geom.lib;maxutil.lib;mesh.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <DelayLoadDLLs>
@@ -102,11 +102,11 @@ copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\Current\"
 if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
 if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\Current\"
 
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2018\Current\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2018\Current\"
 
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2018\Current\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2018\Current\"
 
 rmdir /S /Q "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders" 2&gt;nul
 rmdir /S /Q "$(SolutionDir)..\sandbox\max2018\Current\shaders" 2&gt;nul
@@ -150,7 +150,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\v140\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc140;$(SolutionDir)..\..\boost_1_69_0\stage\lib</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc140;$(SolutionDir)..\..\boost_1_69_0\stage\lib</AdditionalLibraryDirectories>
       <AdditionalDependencies>Paramblk2.lib;ShLwApi.Lib;appleseed.lib;bmm.lib;core.lib;geom.lib;maxutil.lib;mesh.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>
       </DelayLoadDLLs>
@@ -165,11 +165,11 @@ copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\Current\"
 if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
 if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\Current\"
 
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2018\Current\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2018\Current\"
 
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2018\Current\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2018\Current\"
 
 rmdir /S /Q "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders" 2&gt;nul
 rmdir /S /Q "$(SolutionDir)..\sandbox\max2018\Current\shaders" 2&gt;nul
@@ -212,7 +212,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\v140\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc140;$(SolutionDir)..\..\boost_1_69_0\stage\lib</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc140;$(SolutionDir)..\..\boost_1_69_0\stage\lib</AdditionalLibraryDirectories>
       <AdditionalDependencies>Paramblk2.lib;ShLwApi.Lib;appleseed.lib;bmm.lib;core.lib;geom.lib;maxutil.lib;mesh.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>
       </DelayLoadDLLs>
@@ -227,11 +227,11 @@ copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\Current\"
 if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
 if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\Current\"
 
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2018\Current\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2018\Current\"
 
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2018\Current\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2018\Current\"
 
 rmdir /S /Q "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders" 2&gt;nul
 rmdir /S /Q "$(SolutionDir)..\sandbox\max2018\Current\shaders" 2&gt;nul

--- a/src/appleseed-max-impl/appleseed-max2019-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2019-impl.vcxproj
@@ -18,7 +18,7 @@
     <ProjectGuid>{62C41566-DBCB-49D3-943A-4DD53222269E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>appleseedmax</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
@@ -86,7 +86,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\v140\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc140;$(SolutionDir)..\..\boost_1_69_0\stage\lib</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc140;$(SolutionDir)..\..\boost_1_69_0\stage\lib</AdditionalLibraryDirectories>
       <AdditionalDependencies>Paramblk2.lib;ShLwApi.Lib;appleseed.lib;bmm.lib;core.lib;geom.lib;maxutil.lib;mesh.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <DelayLoadDLLs>
@@ -102,11 +102,11 @@ copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2019\Current\"
 if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
 if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2019\Current\"
 
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2019\Current\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2019\Current\"
 
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2019\Current\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2019\Current\"
 
 rmdir /S /Q "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders" 2&gt;nul
 rmdir /S /Q "$(SolutionDir)..\sandbox\max2019\Current\shaders" 2&gt;nul
@@ -150,7 +150,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\v140\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc140;$(SolutionDir)..\..\boost_1_69_0\stage\lib</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc140;$(SolutionDir)..\..\boost_1_69_0\stage\lib</AdditionalLibraryDirectories>
       <AdditionalDependencies>Paramblk2.lib;ShLwApi.Lib;appleseed.lib;bmm.lib;core.lib;geom.lib;maxutil.lib;mesh.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>
       </DelayLoadDLLs>
@@ -165,11 +165,11 @@ copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2019\Current\"
 if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
 if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2019\Current\"
 
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2019\Current\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2019\Current\"
 
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2019\Current\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2019\Current\"
 
 rmdir /S /Q "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders" 2&gt;nul
 rmdir /S /Q "$(SolutionDir)..\sandbox\max2019\Current\shaders" 2&gt;nul
@@ -212,7 +212,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\v140\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc140;$(SolutionDir)..\..\boost_1_69_0\stage\lib</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc140;$(SolutionDir)..\..\boost_1_69_0\stage\lib</AdditionalLibraryDirectories>
       <AdditionalDependencies>Paramblk2.lib;ShLwApi.Lib;appleseed.lib;bmm.lib;core.lib;geom.lib;maxutil.lib;mesh.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>
       </DelayLoadDLLs>
@@ -227,11 +227,11 @@ copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2019\Current\"
 if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
 if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2019\Current\"
 
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2019\Current\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2019\Current\"
 
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2019\Current\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2019\Current\"
 
 rmdir /S /Q "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders" 2&gt;nul
 rmdir /S /Q "$(SolutionDir)..\sandbox\max2019\Current\shaders" 2&gt;nul

--- a/src/appleseed-max-impl/appleseed-max2020-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2020-impl.vcxproj
@@ -86,7 +86,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\v141\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc141;$(SolutionDir)..\..\boost_1_69_0\stage\lib</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc141\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc141;$(SolutionDir)..\..\boost_1_69_0\stage\lib</AdditionalLibraryDirectories>
       <AdditionalDependencies>Paramblk2.lib;ShLwApi.Lib;appleseed.lib;bmm.lib;core.lib;geom.lib;maxutil.lib;mesh.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <DelayLoadDLLs>
@@ -102,11 +102,11 @@ copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2020\Current\"
 if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
 if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2020\Current\"
 
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2020\Current\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2020\Current\"
 
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2020\Current\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2020\Current\"
 
 rmdir /S /Q "$(SolutionDir)..\sandbox\max2020\$(Configuration)\shaders" 2&gt;nul
 rmdir /S /Q "$(SolutionDir)..\sandbox\max2020\Current\shaders" 2&gt;nul
@@ -150,7 +150,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\v141\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc141;$(SolutionDir)..\..\boost_1_69_0\stage\lib</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc141\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc141;$(SolutionDir)..\..\boost_1_69_0\stage\lib</AdditionalLibraryDirectories>
       <AdditionalDependencies>Paramblk2.lib;ShLwApi.Lib;appleseed.lib;bmm.lib;core.lib;geom.lib;maxutil.lib;mesh.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>
       </DelayLoadDLLs>
@@ -165,11 +165,11 @@ copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2020\Current\"
 if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
 if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2020\Current\"
 
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2020\Current\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2020\Current\"
 
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2020\Current\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2020\Current\"
 
 rmdir /S /Q "$(SolutionDir)..\sandbox\max2020\$(Configuration)\shaders" 2&gt;nul
 rmdir /S /Q "$(SolutionDir)..\sandbox\max2020\Current\shaders" 2&gt;nul
@@ -212,7 +212,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\v141\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc141;C:\Barbo\3d\appleseed_addons\boost_1_69_0\stage\lib</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc141\$(ConfigurationName);$(SolutionDir)..\..\appleseed-deps\stage\vc141;C:\Barbo\3d\appleseed_addons\boost_1_69_0\stage\lib</AdditionalLibraryDirectories>
       <AdditionalDependencies>Paramblk2.lib;ShLwApi.Lib;appleseed.lib;bmm.lib;core.lib;geom.lib;maxutil.lib;mesh.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>
       </DelayLoadDLLs>
@@ -227,11 +227,11 @@ copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2020\Current\"
 if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
 if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2020\Current\"
 
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2020\Current\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
+copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2020\Current\"
 
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\$(PlatformToolset)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2020\Current\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
+if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2020\Current\"
 
 rmdir /S /Q "$(SolutionDir)..\sandbox\max2020\$(Configuration)\shaders" 2&gt;nul
 rmdir /S /Q "$(SolutionDir)..\sandbox\max2020\Current\shaders" 2&gt;nul

--- a/src/appleseed-max/appleseed-max2017.vcxproj
+++ b/src/appleseed-max/appleseed-max2017.vcxproj
@@ -25,7 +25,7 @@
     <ProjectGuid>{F43B3C0E-2A72-4B30-9016-DEC6B022D135}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>appleseedmax</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/appleseed-max/appleseed-max2018.vcxproj
+++ b/src/appleseed-max/appleseed-max2018.vcxproj
@@ -25,7 +25,7 @@
     <ProjectGuid>{F43B3C0E-2A72-4B30-9016-DEC6B022D135}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>appleseedmax</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/appleseed-max/appleseed-max2019.vcxproj
+++ b/src/appleseed-max/appleseed-max2019.vcxproj
@@ -25,7 +25,7 @@
     <ProjectGuid>{F43B3C0E-2A72-4B30-9016-DEC6B022D135}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>appleseedmax</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">


### PR DESCRIPTION
- Fixes the platform identifier to be consistent with recent changes in the naming convention [(Update VS 2015 platform identifier (vc14 -> vc140)) ](https://github.com/appleseedhq/appleseed-deps/commit/caffa2e626bb175c1e7518c441545116cc05de65)