### PR TITLE
Small Fixes

### DIFF
--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
@@ -5,7 +5,7 @@
 //
 // This software is released under the MIT license.
 //
-// Copyright (c) 2015-2018 Francois Beaune, The appleseedhq Organization
+// Copyright (c) 2015-2019 Francois Beaune, The appleseedhq Organization
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -1213,7 +1213,7 @@ ParamBlockDesc2 g_param_block_desc(
 
     ParamIdUniformPixelSamples, L"pixel_samples", TYPE_INT, P_TRANSIENT, 0,
         p_ui, ParamMapIdImageSampling, TYPE_SPINNER, EDITTYPE_INT, IDC_TEXT_PIXEL_SAMPLES, IDC_SPINNER_PIXEL_SAMPLES, SPIN_AUTOSCALE,
-        p_default, 16,
+        p_default, 64,
         p_range, 1, 1000000,
         p_accessor, &g_pblock_accessor,
     p_end,
@@ -1265,7 +1265,7 @@ ParamBlockDesc2 g_param_block_desc(
 
     ParamIdAdaptiveTileMinSamples, L"minimum_samples", TYPE_INT, P_TRANSIENT, 0,
         p_ui, ParamMapIdImageSampling, TYPE_SPINNER, EDITTYPE_INT, IDC_TEXT_MIN_ADAPTIVE_SAMPLES, IDC_SPINNER_MIN_ADAPTIVE_SAMPLES, SPIN_AUTOSCALE,
-        p_default, 0,
+        p_default, 16,
         p_range, 0, 1000000,
         p_accessor, &g_pblock_accessor,
     p_end,
@@ -1279,7 +1279,7 @@ ParamBlockDesc2 g_param_block_desc(
 
     ParamIdAdaptiveTileNoiseThreshold, L"noise_threshold", TYPE_FLOAT, P_TRANSIENT, 0,
         p_ui, ParamMapIdImageSampling, TYPE_SPINNER, EDITTYPE_FLOAT, IDC_TEXT_ADAPTIVE_NOISE_THRESHOLD, IDC_SPINNER_ADAPTIVE_NOISE_THRESHOLD, SPIN_AUTOSCALE,
-        p_default, 1.0f,
+        p_default, 0.1f,
         p_range, 0.0f, 25.0f,
         p_accessor, &g_pblock_accessor,
     p_end,

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.cpp
@@ -5,7 +5,7 @@
 //
 // This software is released under the MIT license.
 //
-// Copyright (c) 2015-2018 Francois Beaune, The appleseedhq Organization
+// Copyright (c) 2015-2019 Francois Beaune, The appleseedhq Organization
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -82,6 +82,8 @@ namespace
         FilterList filter;
         filter.Append(L"Project Files (*.appleseed)");
         filter.Append(L"*.appleseed");
+        filter.Append(L"Packed Project Files (*.appleseedz)");
+        filter.Append(L"*.appleseedz");
         filter.Append(L"All Files (*.*)");
         filter.Append(L"*.*");
 

--- a/src/appleseed-max-impl/appleseedrenderer/renderersettings.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/renderersettings.cpp
@@ -5,7 +5,7 @@
 //
 // This software is released under the MIT license.
 //
-// Copyright (c) 2015-2018 Francois Beaune, The appleseedhq Organization
+// Copyright (c) 2015-2019 Francois Beaune, The appleseedhq Organization
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -55,12 +55,12 @@ namespace
             m_noise_seed = 0;
             m_enable_noise_seed = true;
 
-            m_uniform_pixel_samples = 16;
+            m_uniform_pixel_samples = 64;
 
             m_adaptive_batch_size = 16;
-            m_adaptive_min_samples = 0;
+            m_adaptive_min_samples = 16;
             m_adaptive_max_samples = 256;
-            m_adaptive_noise_threshold = 1.0f;
+            m_adaptive_noise_threshold = 0.1f;
 
             m_pixel_filter = 0;
             m_pixel_filter_size = 1.5f;


### PR DESCRIPTION
- Added .appleseedz file mask to the export menu. Allows selection of packed project files as an export option (#287)
- Changed defaults for the adaptive tile sampler to match the ones in appleseed.studio.