### PR TITLE
Add build options include

### DIFF
--- a/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj
@@ -77,7 +77,7 @@
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>APPLESEED_ENABLE_IMATH_INTEROP;APPLESEED_USE_SSE;APPLESEED_WITH_DISNEY_MATERIAL;APPLESEED_X86;BOOST_FILESYSTEM_NO_DEPRECATED;BOOST_FILESYSTEM_VERSION=3;BOOST_PYTHON_STATIC_LIB;DEBUG;OIIO_STATIC_BUILD;OSL_STATIC_LIBRARY;WIN32;WIN64;XERCES_STATIC_LIBRARY;_CRT_SECURE_NO_WARNINGS;_DEBUG;_SCL_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>APPLESEED_ENABLE_IMATH_INTEROP;APPLESEED_X86;BOOST_FILESYSTEM_NO_DEPRECATED;BOOST_FILESYSTEM_VERSION=3;BOOST_PYTHON_STATIC_LIB;DEBUG;OIIO_STATIC_BUILD;OSL_STATIC_LIBRARY;WIN32;WIN64;XERCES_STATIC_LIBRARY;_CRT_SECURE_NO_WARNINGS;_DEBUG;_SCL_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir);$(SolutionDir)..\..\appleseed\src\appleseed;$(SolutionDir)..\..\appleseed-deps\stage\vc140\ilmbase-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\openexr-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\oiio-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\osl-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\SeExpr-debug\include;$(SolutionDir)..\..\boost_1_69_0;C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\include</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <StringPooling>true</StringPooling>
@@ -134,7 +134,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
       </PrecompiledHeader>
       <Optimization>Full</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>APPLESEED_ENABLE_IMATH_INTEROP;APPLESEED_USE_SSE;APPLESEED_WITH_DISNEY_MATERIAL;APPLESEED_X86;BOOST_FILESYSTEM_NO_DEPRECATED;BOOST_FILESYSTEM_VERSION=3;BOOST_PYTHON_STATIC_LIB;NDEBUG;OIIO_STATIC_BUILD;OSL_STATIC_LIBRARY;WIN32;WIN64;XERCES_STATIC_LIBRARY;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>APPLESEED_ENABLE_IMATH_INTEROP;APPLESEED_X86;BOOST_FILESYSTEM_NO_DEPRECATED;BOOST_FILESYSTEM_VERSION=3;BOOST_PYTHON_STATIC_LIB;NDEBUG;OIIO_STATIC_BUILD;OSL_STATIC_LIBRARY;WIN32;WIN64;XERCES_STATIC_LIBRARY;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir);$(SolutionDir)..\..\appleseed\src\appleseed;$(SolutionDir)..\..\appleseed-deps\stage\vc140\ilmbase-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\openexr-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\oiio-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\osl-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\SeExpr-release\include;$(SolutionDir)..\..\boost_1_69_0;C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\include</AdditionalIncludeDirectories>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -197,7 +197,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
       </PrecompiledHeader>
       <Optimization>Full</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>APPLESEED_ENABLE_IMATH_INTEROP;APPLESEED_USE_SSE;APPLESEED_WITH_DISNEY_MATERIAL;APPLESEED_X86;BOOST_FILESYSTEM_NO_DEPRECATED;BOOST_FILESYSTEM_VERSION=3;BOOST_PYTHON_STATIC_LIB;NDEBUG;OIIO_STATIC_BUILD;OSL_STATIC_LIBRARY;WIN32;WIN64;XERCES_STATIC_LIBRARY;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>APPLESEED_ENABLE_IMATH_INTEROP;APPLESEED_X86;BOOST_FILESYSTEM_NO_DEPRECATED;BOOST_FILESYSTEM_VERSION=3;BOOST_PYTHON_STATIC_LIB;NDEBUG;OIIO_STATIC_BUILD;OSL_STATIC_LIBRARY;WIN32;WIN64;XERCES_STATIC_LIBRARY;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir);$(SolutionDir)..\..\appleseed\src\appleseed;$(SolutionDir)..\..\appleseed-deps\stage\vc140\ilmbase-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\openexr-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\oiio-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\osl-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\SeExpr-release\include;$(SolutionDir)..\..\boost_1_69_0;C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\include</AdditionalIncludeDirectories>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>

--- a/src/appleseed-max-impl/appleseed-max2018-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2018-impl.vcxproj
@@ -77,7 +77,7 @@
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>APPLESEED_ENABLE_IMATH_INTEROP;APPLESEED_USE_SSE;APPLESEED_WITH_DISNEY_MATERIAL;APPLESEED_X86;BOOST_FILESYSTEM_NO_DEPRECATED;BOOST_FILESYSTEM_VERSION=3;BOOST_PYTHON_STATIC_LIB;DEBUG;OIIO_STATIC_BUILD;OSL_STATIC_LIBRARY;WIN32;WIN64;XERCES_STATIC_LIBRARY;_CRT_SECURE_NO_WARNINGS;_DEBUG;_SCL_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>APPLESEED_ENABLE_IMATH_INTEROP;APPLESEED_X86;BOOST_FILESYSTEM_NO_DEPRECATED;BOOST_FILESYSTEM_VERSION=3;BOOST_PYTHON_STATIC_LIB;DEBUG;OIIO_STATIC_BUILD;OSL_STATIC_LIBRARY;WIN32;WIN64;XERCES_STATIC_LIBRARY;_CRT_SECURE_NO_WARNINGS;_DEBUG;_SCL_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir);$(SolutionDir)..\..\appleseed\src\appleseed;$(SolutionDir)..\..\appleseed-deps\stage\vc140\ilmbase-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\openexr-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\oiio-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\osl-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\SeExpr-debug\include;$(SolutionDir)..\..\boost_1_69_0;C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\include</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <StringPooling>true</StringPooling>
@@ -134,7 +134,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
       </PrecompiledHeader>
       <Optimization>Full</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>APPLESEED_ENABLE_IMATH_INTEROP;APPLESEED_USE_SSE;APPLESEED_WITH_DISNEY_MATERIAL;APPLESEED_X86;BOOST_FILESYSTEM_NO_DEPRECATED;BOOST_FILESYSTEM_VERSION=3;BOOST_PYTHON_STATIC_LIB;NDEBUG;OIIO_STATIC_BUILD;OSL_STATIC_LIBRARY;WIN32;WIN64;XERCES_STATIC_LIBRARY;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>APPLESEED_ENABLE_IMATH_INTEROP;APPLESEED_X86;BOOST_FILESYSTEM_NO_DEPRECATED;BOOST_FILESYSTEM_VERSION=3;BOOST_PYTHON_STATIC_LIB;NDEBUG;OIIO_STATIC_BUILD;OSL_STATIC_LIBRARY;WIN32;WIN64;XERCES_STATIC_LIBRARY;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir);$(SolutionDir)..\..\appleseed\src\appleseed;$(SolutionDir)..\..\appleseed-deps\stage\vc140\ilmbase-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\openexr-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\oiio-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\osl-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\SeExpr-release\include;$(SolutionDir)..\..\boost_1_69_0;C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\include</AdditionalIncludeDirectories>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -197,7 +197,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
       </PrecompiledHeader>
       <Optimization>Full</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>APPLESEED_ENABLE_IMATH_INTEROP;APPLESEED_USE_SSE;APPLESEED_WITH_DISNEY_MATERIAL;APPLESEED_X86;BOOST_FILESYSTEM_NO_DEPRECATED;BOOST_FILESYSTEM_VERSION=3;BOOST_PYTHON_STATIC_LIB;NDEBUG;OIIO_STATIC_BUILD;OSL_STATIC_LIBRARY;WIN32;WIN64;XERCES_STATIC_LIBRARY;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>APPLESEED_ENABLE_IMATH_INTEROP;APPLESEED_X86;BOOST_FILESYSTEM_NO_DEPRECATED;BOOST_FILESYSTEM_VERSION=3;BOOST_PYTHON_STATIC_LIB;NDEBUG;OIIO_STATIC_BUILD;OSL_STATIC_LIBRARY;WIN32;WIN64;XERCES_STATIC_LIBRARY;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir);$(SolutionDir)..\..\appleseed\src\appleseed;$(SolutionDir)..\..\appleseed-deps\stage\vc140\ilmbase-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\openexr-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\oiio-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\osl-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\SeExpr-release\include;$(SolutionDir)..\..\boost_1_69_0;C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\include</AdditionalIncludeDirectories>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>

--- a/src/appleseed-max-impl/appleseed-max2019-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2019-impl.vcxproj
@@ -77,7 +77,7 @@
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>APPLESEED_ENABLE_IMATH_INTEROP;APPLESEED_USE_SSE;APPLESEED_WITH_DISNEY_MATERIAL;APPLESEED_X86;BOOST_FILESYSTEM_NO_DEPRECATED;BOOST_FILESYSTEM_VERSION=3;BOOST_PYTHON_STATIC_LIB;DEBUG;OIIO_STATIC_BUILD;OSL_STATIC_LIBRARY;WIN32;WIN64;XERCES_STATIC_LIBRARY;_CRT_SECURE_NO_WARNINGS;_DEBUG;_SCL_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>APPLESEED_ENABLE_IMATH_INTEROP;APPLESEED_X86;BOOST_FILESYSTEM_NO_DEPRECATED;BOOST_FILESYSTEM_VERSION=3;BOOST_PYTHON_STATIC_LIB;DEBUG;OIIO_STATIC_BUILD;OSL_STATIC_LIBRARY;WIN32;WIN64;XERCES_STATIC_LIBRARY;_CRT_SECURE_NO_WARNINGS;_DEBUG;_SCL_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir);$(SolutionDir)..\..\appleseed\src\appleseed;$(SolutionDir)..\..\appleseed-deps\stage\vc140\ilmbase-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\openexr-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\oiio-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\osl-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\SeExpr-debug\include;$(SolutionDir)..\..\boost_1_69_0;C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\include</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <StringPooling>true</StringPooling>
@@ -134,7 +134,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
       </PrecompiledHeader>
       <Optimization>Full</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>APPLESEED_ENABLE_IMATH_INTEROP;APPLESEED_USE_SSE;APPLESEED_WITH_DISNEY_MATERIAL;APPLESEED_X86;BOOST_FILESYSTEM_NO_DEPRECATED;BOOST_FILESYSTEM_VERSION=3;BOOST_PYTHON_STATIC_LIB;NDEBUG;OIIO_STATIC_BUILD;OSL_STATIC_LIBRARY;WIN32;WIN64;XERCES_STATIC_LIBRARY;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>APPLESEED_ENABLE_IMATH_INTEROP;APPLESEED_X86;BOOST_FILESYSTEM_NO_DEPRECATED;BOOST_FILESYSTEM_VERSION=3;BOOST_PYTHON_STATIC_LIB;NDEBUG;OIIO_STATIC_BUILD;OSL_STATIC_LIBRARY;WIN32;WIN64;XERCES_STATIC_LIBRARY;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir);$(SolutionDir)..\..\appleseed\src\appleseed;$(SolutionDir)..\..\appleseed-deps\stage\vc140\ilmbase-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\openexr-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\oiio-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\osl-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\SeExpr-release\include;$(SolutionDir)..\..\boost_1_69_0;C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\include</AdditionalIncludeDirectories>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -197,7 +197,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
       </PrecompiledHeader>
       <Optimization>Full</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>APPLESEED_ENABLE_IMATH_INTEROP;APPLESEED_USE_SSE;APPLESEED_WITH_DISNEY_MATERIAL;APPLESEED_X86;BOOST_FILESYSTEM_NO_DEPRECATED;BOOST_FILESYSTEM_VERSION=3;BOOST_PYTHON_STATIC_LIB;NDEBUG;OIIO_STATIC_BUILD;OSL_STATIC_LIBRARY;WIN32;WIN64;XERCES_STATIC_LIBRARY;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>APPLESEED_ENABLE_IMATH_INTEROP;APPLESEED_X86;BOOST_FILESYSTEM_NO_DEPRECATED;BOOST_FILESYSTEM_VERSION=3;BOOST_PYTHON_STATIC_LIB;NDEBUG;OIIO_STATIC_BUILD;OSL_STATIC_LIBRARY;WIN32;WIN64;XERCES_STATIC_LIBRARY;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir);$(SolutionDir)..\..\appleseed\src\appleseed;$(SolutionDir)..\..\appleseed-deps\stage\vc140\ilmbase-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\openexr-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\oiio-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\osl-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc140\SeExpr-release\include;$(SolutionDir)..\..\boost_1_69_0;C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\include</AdditionalIncludeDirectories>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>

--- a/src/appleseed-max-impl/appleseed-max2020-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2020-impl.vcxproj
@@ -77,7 +77,7 @@
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>APPLESEED_ENABLE_IMATH_INTEROP;APPLESEED_USE_SSE;APPLESEED_WITH_DISNEY_MATERIAL;APPLESEED_X86;BOOST_FILESYSTEM_NO_DEPRECATED;BOOST_FILESYSTEM_VERSION=3;BOOST_PYTHON_STATIC_LIB;DEBUG;OIIO_STATIC_BUILD;OSL_STATIC_LIBRARY;WIN32;WIN64;XERCES_STATIC_LIBRARY;_CRT_SECURE_NO_WARNINGS;_DEBUG;_SCL_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>APPLESEED_ENABLE_IMATH_INTEROP;APPLESEED_X86;BOOST_FILESYSTEM_NO_DEPRECATED;BOOST_FILESYSTEM_VERSION=3;BOOST_PYTHON_STATIC_LIB;DEBUG;OIIO_STATIC_BUILD;OSL_STATIC_LIBRARY;WIN32;WIN64;XERCES_STATIC_LIBRARY;_CRT_SECURE_NO_WARNINGS;_DEBUG;_SCL_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir);$(SolutionDir)..\..\appleseed\src\appleseed;$(SolutionDir)..\..\appleseed-deps\stage\vc141\ilmbase-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc141\openexr-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc141\oiio-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc141\osl-debug\include;$(SolutionDir)..\..\appleseed-deps\stage\vc141\SeExpr-debug\include;$(SolutionDir)..\..\boost_1_69_0;C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\include</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <StringPooling>true</StringPooling>
@@ -134,7 +134,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
       </PrecompiledHeader>
       <Optimization>Full</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>APPLESEED_ENABLE_IMATH_INTEROP;APPLESEED_USE_SSE;APPLESEED_WITH_DISNEY_MATERIAL;APPLESEED_X86;BOOST_FILESYSTEM_NO_DEPRECATED;BOOST_FILESYSTEM_VERSION=3;BOOST_PYTHON_STATIC_LIB;NDEBUG;OIIO_STATIC_BUILD;OSL_STATIC_LIBRARY;WIN32;WIN64;XERCES_STATIC_LIBRARY;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>APPLESEED_ENABLE_IMATH_INTEROP;APPLESEED_X86;BOOST_FILESYSTEM_NO_DEPRECATED;BOOST_FILESYSTEM_VERSION=3;BOOST_PYTHON_STATIC_LIB;NDEBUG;OIIO_STATIC_BUILD;OSL_STATIC_LIBRARY;WIN32;WIN64;XERCES_STATIC_LIBRARY;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir);$(SolutionDir)..\..\appleseed\src\appleseed;$(SolutionDir)..\..\appleseed-deps\stage\vc141\ilmbase-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc141\openexr-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc141\oiio-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc141\osl-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc141\SeExpr-release\include;$(SolutionDir)..\..\boost_1_69_0;C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\include</AdditionalIncludeDirectories>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -197,7 +197,7 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
       </PrecompiledHeader>
       <Optimization>Full</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>APPLESEED_ENABLE_IMATH_INTEROP;APPLESEED_USE_SSE;APPLESEED_WITH_DISNEY_MATERIAL;APPLESEED_X86;BOOST_FILESYSTEM_NO_DEPRECATED;BOOST_FILESYSTEM_VERSION=3;BOOST_PYTHON_STATIC_LIB;NDEBUG;OIIO_STATIC_BUILD;OSL_STATIC_LIBRARY;WIN32;WIN64;XERCES_STATIC_LIBRARY;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>APPLESEED_ENABLE_IMATH_INTEROP;APPLESEED_X86;BOOST_FILESYSTEM_NO_DEPRECATED;BOOST_FILESYSTEM_VERSION=3;BOOST_PYTHON_STATIC_LIB;NDEBUG;OIIO_STATIC_BUILD;OSL_STATIC_LIBRARY;WIN32;WIN64;XERCES_STATIC_LIBRARY;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir);$(SolutionDir)..\..\appleseed\src\appleseed;$(SolutionDir)..\..\appleseed-deps\stage\vc141\ilmbase-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc141\openexr-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc141\oiio-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc141\osl-release\include;$(SolutionDir)..\..\appleseed-deps\stage\vc141\SeExpr-release\include;$(SolutionDir)..\..\boost_1_69_0;C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\include</AdditionalIncludeDirectories>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>

--- a/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.cpp
+++ b/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.cpp
@@ -44,6 +44,9 @@
 #include "utilities.h"
 #include "version.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/material.h"
 #include "renderer/api/scene.h"

--- a/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.h
+++ b/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.h
@@ -31,6 +31,9 @@
 // appleseed-max headers.
 #include "iappleseedmtl.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 #include "foundation/utility/autoreleaseptr.h"

--- a/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
+++ b/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
@@ -40,6 +40,9 @@
 #include "utilities.h"
 #include "version.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/material.h"
 #include "renderer/api/scene.h"

--- a/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.h
+++ b/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.h
@@ -31,6 +31,9 @@
 // appleseed-max headers.
 #include "iappleseedmtl.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 #include "foundation/utility/autoreleaseptr.h"

--- a/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.h
+++ b/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/environmentedf.h"
 

--- a/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.cpp
+++ b/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.cpp
@@ -40,6 +40,9 @@
 #include "utilities.h"
 #include "version.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/bsdf.h"
 #include "renderer/api/material.h"

--- a/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.h
+++ b/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.h
@@ -31,6 +31,9 @@
 // appleseed-max headers.
 #include "iappleseedmtl.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 #include "foundation/utility/autoreleaseptr.h"

--- a/src/appleseed-max-impl/appleseedinteractive/appleseedinteractive.h
+++ b/src/appleseed-max-impl/appleseedinteractive/appleseedinteractive.h
@@ -31,6 +31,9 @@
 // appleseed-max headers.
 #include "appleseedrenderer/maxsceneentities.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 #include "foundation/utility/autoreleaseptr.h"

--- a/src/appleseed-max-impl/appleseedinteractive/interactiverenderercontroller.h
+++ b/src/appleseed-max-impl/appleseedinteractive/interactiverenderercontroller.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/project.h"
 #include "renderer/api/rendering.h"

--- a/src/appleseed-max-impl/appleseedinteractive/interactivesession.cpp
+++ b/src/appleseed-max-impl/appleseedinteractive/interactivesession.cpp
@@ -32,6 +32,9 @@
 // appleseed-max headers.
 #include "appleseedinteractive/interactivetilecallback.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/project.h"
 #include "renderer/api/rendering.h"

--- a/src/appleseed-max-impl/appleseedinteractive/interactivesession.h
+++ b/src/appleseed-max-impl/appleseedinteractive/interactivesession.h
@@ -32,6 +32,9 @@
 #include "appleseedinteractive/interactiverenderercontroller.h"
 #include "appleseedrenderer/renderersettings.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/utility/autoreleaseptr.h"
 

--- a/src/appleseed-max-impl/appleseedinteractive/interactivetilecallback.h
+++ b/src/appleseed-max-impl/appleseedinteractive/interactivetilecallback.h
@@ -31,6 +31,9 @@
 // appleseed-max headers.
 #include "appleseedrenderer/tilecallback.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/types.h"
 #include "foundation/platform/windows.h"

--- a/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.cpp
+++ b/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.cpp
@@ -38,6 +38,9 @@
 #include "utilities.h"
 #include "version.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/edf.h"
 #include "renderer/api/material.h"

--- a/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.h
+++ b/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.h
@@ -31,6 +31,9 @@
 // appleseed-max headers.
 #include "iappleseedmtl.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 #include "foundation/utility/autoreleaseptr.h"

--- a/src/appleseed-max-impl/appleseedmetalmtl/appleseedmetalmtl.cpp
+++ b/src/appleseed-max-impl/appleseedmetalmtl/appleseedmetalmtl.cpp
@@ -40,6 +40,9 @@
 #include "utilities.h"
 #include "version.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/bsdf.h"
 #include "renderer/api/material.h"

--- a/src/appleseed-max-impl/appleseedmetalmtl/appleseedmetalmtl.h
+++ b/src/appleseed-max-impl/appleseedmetalmtl/appleseedmetalmtl.h
@@ -31,6 +31,9 @@
 // appleseed-max headers.
 #include "iappleseedmtl.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 #include "foundation/utility/autoreleaseptr.h"

--- a/src/appleseed-max-impl/appleseedobjpropsmod/appleseedobjpropsmod.h
+++ b/src/appleseed-max-impl/appleseedobjpropsmod/appleseedobjpropsmod.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/scene.h"
 

--- a/src/appleseed-max-impl/appleseedoslplugin/oslclassdesc.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslclassdesc.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 

--- a/src/appleseed-max-impl/appleseedoslplugin/oslmaterial.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslmaterial.cpp
@@ -38,6 +38,9 @@
 #include "utilities.h"
 #include "version.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/material.h"
 #include "renderer/api/shadergroup.h"

--- a/src/appleseed-max-impl/appleseedoslplugin/oslmaterial.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslmaterial.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 #include "foundation/utility/autoreleaseptr.h"

--- a/src/appleseed-max-impl/appleseedoslplugin/oslparamdlg.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslparamdlg.h
@@ -31,6 +31,9 @@
 // appleseed-max headers.
 #include "appleseedoslplugin/oslclassdesc.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.cpp
@@ -32,6 +32,9 @@
 // appleseed.renderer headers.
 #include "renderer/api/shadergroup.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/utility/autoreleaseptr.h"
 #include "foundation/utility/containers/dictionary.h"

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/core/concepts/noncopyable.h"
 #include "foundation/utility/containers/dictionary.h"

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshaderregistry.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshaderregistry.cpp
@@ -37,6 +37,9 @@
 #include "bump/resource.h"
 #include "utilities.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/shadergroup.h"
 

--- a/src/appleseed-max-impl/appleseedoslplugin/osltexture.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/osltexture.cpp
@@ -38,6 +38,9 @@
 #include "utilities.h"
 #include "version.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/shadergroup.h"
 #include "renderer/api/utility.h"

--- a/src/appleseed-max-impl/appleseedoslplugin/osltexture.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/osltexture.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 #include "foundation/utility/autoreleaseptr.h"

--- a/src/appleseed-max-impl/appleseedplasticmtl/appleseedplasticmtl.cpp
+++ b/src/appleseed-max-impl/appleseedplasticmtl/appleseedplasticmtl.cpp
@@ -40,6 +40,9 @@
 #include "utilities.h"
 #include "version.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/bsdf.h"
 #include "renderer/api/material.h"

--- a/src/appleseed-max-impl/appleseedplasticmtl/appleseedplasticmtl.h
+++ b/src/appleseed-max-impl/appleseedplasticmtl/appleseedplasticmtl.h
@@ -31,6 +31,9 @@
 // appleseed-max headers.
 #include "iappleseedmtl.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 #include "foundation/utility/autoreleaseptr.h"

--- a/src/appleseed-max-impl/appleseedplasticmtl/datachunks.h
+++ b/src/appleseed-max-impl/appleseedplasticmtl/datachunks.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"
 

--- a/src/appleseed-max-impl/appleseedrenderelement/appleseedrenderelement.cpp
+++ b/src/appleseed-max-impl/appleseedrenderelement/appleseedrenderelement.cpp
@@ -36,6 +36,9 @@
 #include "utilities.h"
 #include "version.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/aov.h"
 

--- a/src/appleseed-max-impl/appleseedrenderelement/appleseedrenderelement.h
+++ b/src/appleseed-max-impl/appleseedrenderelement/appleseedrenderelement.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
@@ -43,6 +43,9 @@
 #include "utilities.h"
 #include "version.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/frame.h"
 #include "renderer/api/project.h"

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.h
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.h
@@ -32,6 +32,9 @@
 #include "appleseedrenderer/maxsceneentities.h"
 #include "appleseedrenderer/renderersettings.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.cpp
@@ -37,6 +37,9 @@
 #include "utilities.h"
 #include "version.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/core/appleseed.h"
 

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.h
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 

--- a/src/appleseed-max-impl/appleseedrenderer/datachunks.h
+++ b/src/appleseed-max-impl/appleseedrenderer/datachunks.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"
 

--- a/src/appleseed-max-impl/appleseedrenderer/dialoglogtarget.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/dialoglogtarget.cpp
@@ -34,6 +34,9 @@
 #include "main.h"
 #include "utilities.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 #include "foundation/utility/string.h"

--- a/src/appleseed-max-impl/appleseedrenderer/dialoglogtarget.h
+++ b/src/appleseed-max-impl/appleseedrenderer/dialoglogtarget.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/utility/log.h"
 

--- a/src/appleseed-max-impl/appleseedrenderer/maxsceneentities.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/maxsceneentities.cpp
@@ -29,6 +29,9 @@
 // Interface header.
 #include "maxsceneentities.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 #include "foundation/utility/memory.h"

--- a/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
@@ -40,6 +40,9 @@
 #include "seexprutils.h"
 #include "utilities.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/aov.h"
 #include "renderer/api/camera.h"

--- a/src/appleseed-max-impl/appleseedrenderer/projectbuilder.h
+++ b/src/appleseed-max-impl/appleseedrenderer/projectbuilder.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 #include "foundation/utility/autoreleaseptr.h"

--- a/src/appleseed-max-impl/appleseedrenderer/renderercontroller.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/renderercontroller.cpp
@@ -29,6 +29,9 @@
 // Interface header.
 #include "renderercontroller.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/atomic.h"
 #include "foundation/platform/windows.h"    // include before 3ds Max headers

--- a/src/appleseed-max-impl/appleseedrenderer/renderercontroller.h
+++ b/src/appleseed-max-impl/appleseedrenderer/renderercontroller.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/rendering.h"
 

--- a/src/appleseed-max-impl/appleseedrenderer/renderersettings.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/renderersettings.cpp
@@ -33,6 +33,9 @@
 #include "appleseedrenderer/datachunks.h"
 #include "utilities.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/project.h"
 #include "renderer/api/utility.h"

--- a/src/appleseed-max-impl/appleseedrenderer/renderersettings.h
+++ b/src/appleseed-max-impl/appleseedrenderer/renderersettings.h
@@ -31,6 +31,9 @@
 // appleseed-max headers.
 #include "dialoglogtarget.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 

--- a/src/appleseed-max-impl/appleseedrenderer/tilecallback.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/tilecallback.cpp
@@ -29,6 +29,9 @@
 // Interface header.
 #include "tilecallback.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/frame.h"
 

--- a/src/appleseed-max-impl/appleseedrenderer/tilecallback.h
+++ b/src/appleseed-max-impl/appleseedrenderer/tilecallback.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/rendering.h"
 

--- a/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
+++ b/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
@@ -40,6 +40,9 @@
 #include "utilities.h"
 #include "version.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/bsdf.h"
 #include "renderer/api/bssrdf.h"

--- a/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.h
+++ b/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.h
@@ -31,6 +31,9 @@
 // appleseed-max headers.
 #include "iappleseedmtl.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 #include "foundation/utility/autoreleaseptr.h"

--- a/src/appleseed-max-impl/appleseedsssmtl/datachunks.h
+++ b/src/appleseed-max-impl/appleseedsssmtl/datachunks.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"
 

--- a/src/appleseed-max-impl/appleseedvolumemtl/appleseedvolumemtl.cpp
+++ b/src/appleseed-max-impl/appleseedvolumemtl/appleseedvolumemtl.cpp
@@ -38,6 +38,9 @@
 #include "utilities.h"
 #include "version.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/material.h"
 #include "renderer/api/scene.h"

--- a/src/appleseed-max-impl/appleseedvolumemtl/appleseedvolumemtl.h
+++ b/src/appleseed-max-impl/appleseedvolumemtl/appleseedvolumemtl.h
@@ -31,6 +31,9 @@
 // appleseed-max headers.
 #include "iappleseedmtl.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 #include "foundation/utility/autoreleaseptr.h"

--- a/src/appleseed-max-impl/appleseedvolumemtl/datachunks.h
+++ b/src/appleseed-max-impl/appleseedvolumemtl/datachunks.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"
 

--- a/src/appleseed-max-impl/builtinmapsupport.cpp
+++ b/src/appleseed-max-impl/builtinmapsupport.cpp
@@ -34,6 +34,9 @@
 #include "oslutils.h"
 #include "utilities.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/shadergroup.h"
 #include "renderer/api/utility.h"

--- a/src/appleseed-max-impl/builtinmapsupport.h
+++ b/src/appleseed-max-impl/builtinmapsupport.h
@@ -31,6 +31,9 @@
 // appleseed-max headers.
 #include "osloutputselectormap/osloutputselector.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 #include "foundation/image/color.h"

--- a/src/appleseed-max-impl/iappleseedmtl.h
+++ b/src/appleseed-max-impl/iappleseedmtl.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 #include "foundation/utility/autoreleaseptr.h"

--- a/src/appleseed-max-impl/logtarget.cpp
+++ b/src/appleseed-max-impl/logtarget.cpp
@@ -32,6 +32,9 @@
 // appleseed-max headers.
 #include "utilities.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 #include "foundation/utility/string.h"

--- a/src/appleseed-max-impl/logtarget.h
+++ b/src/appleseed-max-impl/logtarget.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/utility/log.h"
 

--- a/src/appleseed-max-impl/main.h
+++ b/src/appleseed-max-impl/main.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 

--- a/src/appleseed-max-impl/osloutputselectormap/datachunks.h
+++ b/src/appleseed-max-impl/osloutputselectormap/datachunks.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"
 

--- a/src/appleseed-max-impl/osloutputselectormap/osloutputselector.h
+++ b/src/appleseed-max-impl/osloutputselectormap/osloutputselector.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 #include "foundation/utility/autoreleaseptr.h"

--- a/src/appleseed-max-impl/oslutils.cpp
+++ b/src/appleseed-max-impl/oslutils.cpp
@@ -36,6 +36,9 @@
 #include "iappleseedmtl.h"
 #include "utilities.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/shadergroup.h"
 #include "renderer/api/utility.h"

--- a/src/appleseed-max-impl/oslutils.h
+++ b/src/appleseed-max-impl/oslutils.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 #include "foundation/image/color.h"

--- a/src/appleseed-max-impl/plugin.cpp
+++ b/src/appleseed-max-impl/plugin.cpp
@@ -46,6 +46,9 @@
 #include "utilities.h"
 #include "version.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/log.h"
 

--- a/src/appleseed-max-impl/seexprutils.cpp
+++ b/src/appleseed-max-impl/seexprutils.cpp
@@ -32,6 +32,9 @@
 // appleseed-max headers.
 #include "utilities.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/utility/string.h"
 

--- a/src/appleseed-max-impl/seexprutils.h
+++ b/src/appleseed-max-impl/seexprutils.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/image/color.h"
 

--- a/src/appleseed-max-impl/utilities.cpp
+++ b/src/appleseed-max-impl/utilities.cpp
@@ -34,6 +34,9 @@
 #include "osloutputselectormap/osloutputselector.h"
 #include "main.h"
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/color.h"
 #include "renderer/api/source.h"

--- a/src/appleseed-max-impl/utilities.h
+++ b/src/appleseed-max-impl/utilities.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.renderer headers.
 #include "renderer/api/scene.h"
 #include "renderer/api/utility.h"

--- a/src/appleseed-max-impl/version.h
+++ b/src/appleseed-max-impl/version.h
@@ -28,6 +28,9 @@
 
 #pragma once
 
+// Build options header.
+#include "renderer/api/buildoptions.h"
+
 // appleseed.foundation headers.
 #include "foundation/platform/windows.h"
 


### PR DESCRIPTION
Include `buildoptions.h` header to avoid link errors.