### PR TITLE
Bugfix, realworld UV, Analytical light shapes

### DIFF
--- a/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
@@ -1030,6 +1030,9 @@ namespace
 
         // Retrieve the light's parameters.
         GenLight* light_object = dynamic_cast<GenLight*>(object_state.obj);
+        if (light_object == nullptr)
+            return;
+
         const asf::Color3f color = to_color3f(light_object->GetRGBColor(time));
         const float intensity = light_object->GetIntensity(time);
         const float decay_start = light_object->GetDecayRadius(time);

--- a/src/appleseed-max-impl/oslutils.cpp
+++ b/src/appleseed-max-impl/oslutils.cpp
@@ -73,12 +73,15 @@ asr::ParamArray get_uv_params(Texmap* texmap, const TimeValue time)
     DbgAssert(texmap->MapSlotType(texmap->GetMapChannel()) == MAPSLOT_TEXTURE);
     DbgAssert(static_cast<StdUVGen*>(uv_gen)->GetUVWSource() == UVWSRC_EXPLICIT);
 
-    float u_tiling = std_uv->GetUScl(time);
-    float v_tiling = std_uv->GetVScl(time);
-    float u_offset = std_uv->GetUOffs(time);
-    float v_offset = std_uv->GetVOffs(time);
-    float w_rotation = std_uv->GetWAng(time);
-    int tiling = std_uv->GetTextureTiling();
+    const float u_tiling = std_uv->GetUScl(time);
+    const float v_tiling = std_uv->GetVScl(time);
+    const float u_offset = std_uv->GetUOffs(time);
+    const float v_offset = std_uv->GetVOffs(time);
+    const float w_rotation = std_uv->GetWAng(time);
+    const int tiling = std_uv->GetTextureTiling();
+    const int real_world_scale = std_uv->GetUseRealWorldScale();
+
+    uv_params.insert("in_real_world_mode", fmt_osl_expr(real_world_scale));
 
     if (tiling & U_WRAP)
         uv_params.insert("in_wrapU", fmt_osl_expr(1));


### PR DESCRIPTION
Hi,
I included three tickets into one PR but commits are separate so it should be easy to review it one by one. First two are actually trivial.
Analytical lights work fine except rectangular light is never visible. Sphere, point, disc and rectangle shapes are supported. Other thing is that I had to rotate transform for the disc and rectangular light to align them according to max's shape.
For point light I took sphere with radius 1, not sure about that.
Visibility of the light shapes is controlled via appleseed obj. properties modifier. Diffuse visibility is ignored anyway, according to appleseed test scenes.
@dictoon I'm not sure if this also fixes #261 ? It will support max's photometric lights but not in the right sense I guess.. It should probably accept proper intensity values and things like that..

Rectangular light is on the back side. It's not visible for some reason. There's is some hint of it in the floor reflection but it's very dim compared to intensity:
![image](https://user-images.githubusercontent.com/1850877/57901847-aac23e80-7834-11e9-9654-611eb93d16b7.png)

Thanks.