### PR TITLE
Undefine base_type macro to avoid conflict with boost type

### DIFF
--- a/src/appleseed-max-impl/_beginmaxheaders.h
+++ b/src/appleseed-max-impl/_beginmaxheaders.h
@@ -5,7 +5,7 @@
 //
 // This software is released under the MIT license.
 //
-// Copyright (c) 2016-2018 Francois Beaune, The appleseedhq Organization
+// Copyright (c) 2015-2019 Sergo Pogosyan, The appleseedhq Organization
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -27,26 +27,3 @@
 //
 
 #pragma once
-
-// Build options header.
-#include "renderer/api/buildoptions.h"
-
-// appleseed.foundation headers.
-#include "foundation/utility/log.h"
-
-// Standard headers.
-#include <cstddef>
-
-class LogTarget
-  : public foundation::ILogTarget
-{
-  public:
-    void release() override;
-
-    void write(
-        const foundation::LogMessage::Category  category,
-        const char*                             file,
-        const size_t                            line,
-        const char*                             header,
-        const char*                             message) override;
-};

--- a/src/appleseed-max-impl/_beginmaxheaders.h
+++ b/src/appleseed-max-impl/_beginmaxheaders.h
@@ -5,7 +5,7 @@
 //
 // This software is released under the MIT license.
 //
-// Copyright (c) 2015-2019 Sergo Pogosyan, The appleseedhq Organization
+// Copyright (c) 2019 Sergo Pogosyan, The appleseedhq Organization
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -25,5 +25,3 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 //
-
-#pragma once

--- a/src/appleseed-max-impl/_endmaxheaders.h
+++ b/src/appleseed-max-impl/_endmaxheaders.h
@@ -5,7 +5,7 @@
 //
 // This software is released under the MIT license.
 //
-// Copyright (c) 2016-2018 Francois Beaune, The appleseedhq Organization
+// Copyright (c) 2015-2019 Sergo Pogosyan, The appleseedhq Organization
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -28,25 +28,4 @@
 
 #pragma once
 
-// Build options header.
-#include "renderer/api/buildoptions.h"
-
-// appleseed.foundation headers.
-#include "foundation/utility/log.h"
-
-// Standard headers.
-#include <cstddef>
-
-class LogTarget
-  : public foundation::ILogTarget
-{
-  public:
-    void release() override;
-
-    void write(
-        const foundation::LogMessage::Category  category,
-        const char*                             file,
-        const size_t                            line,
-        const char*                             header,
-        const char*                             message) override;
-};
+#undef base_type

--- a/src/appleseed-max-impl/_endmaxheaders.h
+++ b/src/appleseed-max-impl/_endmaxheaders.h
@@ -5,7 +5,7 @@
 //
 // This software is released under the MIT license.
 //
-// Copyright (c) 2015-2019 Sergo Pogosyan, The appleseedhq Organization
+// Copyright (c) 2019 Sergo Pogosyan, The appleseedhq Organization
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -25,7 +25,5 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 //
-
-#pragma once
 
 #undef base_type

--- a/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj
@@ -361,6 +361,8 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
     <ClInclude Include="seexprutils.h" />
     <ClInclude Include="utilities.h" />
     <ClInclude Include="version.h" />
+    <ClInclude Include="_beginmaxheaders.h" />
+    <ClInclude Include="_endmaxheaders.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="appleseedblendmtl\appleseedblendmtl.rc" />

--- a/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj.filters
+++ b/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj.filters
@@ -285,6 +285,8 @@
     <ClInclude Include="appleseedvolumemtl\resource.h">
       <Filter>appleseedvolumemtl</Filter>
     </ClInclude>    
+    <ClInclude Include="_beginmaxheaders.h" />
+    <ClInclude Include="_endmaxheaders.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="appleseedrenderer\appleseedrenderer.rc">

--- a/src/appleseed-max-impl/appleseed-max2018-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2018-impl.vcxproj
@@ -361,6 +361,8 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
     <ClInclude Include="seexprutils.h" />
     <ClInclude Include="utilities.h" />
     <ClInclude Include="version.h" />
+    <ClInclude Include="_beginmaxheaders.h" />
+    <ClInclude Include="_endmaxheaders.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="appleseedblendmtl\appleseedblendmtl.rc" />

--- a/src/appleseed-max-impl/appleseed-max2018-impl.vcxproj.filters
+++ b/src/appleseed-max-impl/appleseed-max2018-impl.vcxproj.filters
@@ -285,6 +285,8 @@
     <ClInclude Include="appleseedvolumemtl\resource.h">
       <Filter>appleseedvolumemtl</Filter>
     </ClInclude>  
+    <ClInclude Include="_beginmaxheaders.h" />
+    <ClInclude Include="_endmaxheaders.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="appleseedrenderer\appleseedrenderer.rc">

--- a/src/appleseed-max-impl/appleseed-max2019-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2019-impl.vcxproj
@@ -361,6 +361,8 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
     <ClInclude Include="seexprutils.h" />
     <ClInclude Include="utilities.h" />
     <ClInclude Include="version.h" />
+    <ClInclude Include="_beginmaxheaders.h" />
+    <ClInclude Include="_endmaxheaders.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="appleseedblendmtl\appleseedblendmtl.rc" />

--- a/src/appleseed-max-impl/appleseed-max2019-impl.vcxproj.filters
+++ b/src/appleseed-max-impl/appleseed-max2019-impl.vcxproj.filters
@@ -285,6 +285,8 @@
     <ClInclude Include="appleseedvolumemtl\resource.h">
       <Filter>appleseedvolumemtl</Filter>
     </ClInclude>  
+    <ClInclude Include="_beginmaxheaders.h" />
+    <ClInclude Include="_endmaxheaders.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="appleseedrenderer\appleseedrenderer.rc">

--- a/src/appleseed-max-impl/appleseed-max2020-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2020-impl.vcxproj
@@ -361,6 +361,8 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
     <ClInclude Include="seexprutils.h" />
     <ClInclude Include="utilities.h" />
     <ClInclude Include="version.h" />
+    <ClInclude Include="_beginmaxheaders.h" />
+    <ClInclude Include="_endmaxheaders.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="appleseedblendmtl\appleseedblendmtl.rc" />

--- a/src/appleseed-max-impl/appleseed-max2020-impl.vcxproj.filters
+++ b/src/appleseed-max-impl/appleseed-max2020-impl.vcxproj.filters
@@ -285,6 +285,8 @@
     <ClInclude Include="appleseedvolumemtl\resource.h">
       <Filter>appleseedvolumemtl</Filter>
     </ClInclude>  
+    <ClInclude Include="_beginmaxheaders.h" />
+    <ClInclude Include="_endmaxheaders.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="appleseedrenderer\appleseedrenderer.rc">

--- a/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.cpp
+++ b/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.cpp
@@ -57,10 +57,12 @@
 #include "foundation/image/colorspace.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <color.h>
 #include <iparamm2.h>
 #include <stdmat.h>
 #include <strclass.h>
+#include "_endmaxheaders.h"
 
 // Standard headers.
 #include <string>

--- a/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.h
+++ b/src/appleseed-max-impl/appleseedblendmtl/appleseedblendmtl.h
@@ -39,6 +39,7 @@
 #include "foundation/utility/autoreleaseptr.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <color.h>
 #include <IMaterialBrowserEntryInfo.h>
 #include <IMtlRender_Compatibility.h>
@@ -48,7 +49,7 @@
 #include <maxtypes.h>
 #include <ref.h>
 #include <strbasic.h>
-#undef base_type
+#include "_endmaxheaders.h"
 
 // Forward declarations.
 namespace renderer  { class Material; }

--- a/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
+++ b/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.cpp
@@ -53,10 +53,12 @@
 #include "foundation/image/colorspace.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <color.h>
 #include <iparamm2.h>
 #include <stdmat.h>
 #include <strclass.h>
+#include "_endmaxheaders.h"
 
 // Standard headers.
 #include <string>

--- a/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.h
+++ b/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.h
@@ -39,6 +39,7 @@
 #include "foundation/utility/autoreleaseptr.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <color.h>
 #include <IMaterialBrowserEntryInfo.h>
 #include <IMtlRender_Compatibility.h>
@@ -48,7 +49,7 @@
 #include <maxtypes.h>
 #include <ref.h>
 #include <strbasic.h>
-#undef base_type
+#include "_endmaxheaders.h"
 
 // Forward declarations.
 namespace renderer  { class Material; }

--- a/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.h
+++ b/src/appleseed-max-impl/appleseedenvmap/appleseedenvmap.h
@@ -39,6 +39,7 @@
 #include "foundation/utility/autoreleaseptr.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <IMaterialBrowserEntryInfo.h>
 #include <IMtlRender_Compatibility.h>
 #include <imtl.h>
@@ -47,7 +48,7 @@
 #include <istdplug.h>
 #include <maxtypes.h>
 #include <stdmat.h>
-#undef base_type
+#include "_endmaxheaders.h"
 
 class AppleseedEnvMap
   : public Texmap

--- a/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.cpp
+++ b/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.cpp
@@ -55,12 +55,14 @@
 #include "foundation/utility/searchpaths.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <AssetManagement/AssetUser.h>
 #include <color.h>
 #include <hsv.h>
 #include <iparamm2.h>
 #include <stdmat.h>
 #include <strclass.h>
+#include "_endmaxheaders.h"
 
 // Windows headers.
 #include <tchar.h>

--- a/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.h
+++ b/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.h
@@ -39,6 +39,7 @@
 #include "foundation/utility/autoreleaseptr.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <color.h>
 #include <IMaterialBrowserEntryInfo.h>
 #include <IMtlRender_Compatibility.h>
@@ -48,7 +49,7 @@
 #include <maxtypes.h>
 #include <ref.h>
 #include <strbasic.h>
-#undef base_type
+#include "_endmaxheaders.h"
 
 // Forward declarations.
 namespace renderer  { class Material; }

--- a/src/appleseed-max-impl/appleseedinteractive/appleseedinteractive.cpp
+++ b/src/appleseed-max-impl/appleseedinteractive/appleseedinteractive.cpp
@@ -41,8 +41,10 @@
 #include "boost/thread/mutex.hpp"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <assert1.h>
 #include <matrix3.h>
+#include "_endmaxheaders.h"
 
 // Standard headers.
 #include <clocale>

--- a/src/appleseed-max-impl/appleseedinteractive/appleseedinteractive.h
+++ b/src/appleseed-max-impl/appleseedinteractive/appleseedinteractive.h
@@ -39,12 +39,14 @@
 #include "foundation/utility/autoreleaseptr.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <interactiverender.h>
 #include <ISceneEventManager.h>
 #include <maxapi.h>
 #if MAX_RELEASE == MAX_RELEASE_R18
 #include <Rendering/IAbortableRenderer.h>
 #endif
+#include "_endmaxheaders.h"
 
 // Standard headers.
 #include <memory>

--- a/src/appleseed-max-impl/appleseedinteractive/interactiverenderercontroller.cpp
+++ b/src/appleseed-max-impl/appleseedinteractive/interactiverenderercontroller.cpp
@@ -30,7 +30,9 @@
 #include "interactiverenderercontroller.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <interactiverender.h>
+#include "_endmaxheaders.h"
 
 // Standard headers.
 #include <utility>

--- a/src/appleseed-max-impl/appleseedinteractive/interactivetilecallback.cpp
+++ b/src/appleseed-max-impl/appleseedinteractive/interactivetilecallback.cpp
@@ -30,9 +30,11 @@
 #include "interactivetilecallback.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <bitmap.h>
 #include <interactiverender.h>
 #include <maxapi.h>
+#include "_endmaxheaders.h"
 
 namespace asr = renderer;
 

--- a/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.cpp
+++ b/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.cpp
@@ -53,11 +53,13 @@
 #include "foundation/utility/searchpaths.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <AssetManagement/AssetUser.h>
 #include <color.h>
 #include <iparamm2.h>
 #include <stdmat.h>
 #include <strclass.h>
+#include "_endmaxheaders.h"
 
 // Windows headers.
 #include <tchar.h>

--- a/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.h
+++ b/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.h
@@ -39,6 +39,7 @@
 #include "foundation/utility/autoreleaseptr.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <color.h>
 #include <IMaterialBrowserEntryInfo.h>
 #include <IMtlRender_Compatibility.h>
@@ -48,7 +49,7 @@
 #include <maxtypes.h>
 #include <ref.h>
 #include <strbasic.h>
-#undef base_type
+#include "_endmaxheaders.h"
 
 // Forward declarations.
 namespace renderer  { class Material; }

--- a/src/appleseed-max-impl/appleseedmetalmtl/appleseedmetalmtl.cpp
+++ b/src/appleseed-max-impl/appleseedmetalmtl/appleseedmetalmtl.cpp
@@ -54,11 +54,13 @@
 #include "foundation/image/colorspace.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <color.h>
 #include <interval.h>
 #include <iparamm2.h>
 #include <stdmat.h>
 #include <strclass.h>
+#include "_endmaxheaders.h"
 
 // Standard headers.
 #include <string>

--- a/src/appleseed-max-impl/appleseedmetalmtl/appleseedmetalmtl.h
+++ b/src/appleseed-max-impl/appleseedmetalmtl/appleseedmetalmtl.h
@@ -39,6 +39,7 @@
 #include "foundation/utility/autoreleaseptr.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <color.h>
 #include <IMaterialBrowserEntryInfo.h>
 #include <IMtlRender_Compatibility.h>
@@ -47,7 +48,7 @@
 #include <maxtypes.h>
 #include <ref.h>
 #include <strbasic.h>
-#undef base_type
+#include "_endmaxheaders.h"
 
 // Forward declarations.
 namespace renderer  { class Material; }

--- a/src/appleseed-max-impl/appleseedobjpropsmod/appleseedobjpropsmod.cpp
+++ b/src/appleseed-max-impl/appleseedobjpropsmod/appleseedobjpropsmod.cpp
@@ -35,8 +35,10 @@
 #include "utilities.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <modstack.h>
 #include <paramtype.h>
+#include "_endmaxheaders.h"
 
 #if MAX_RELEASE == MAX_RELEASE_R18
 #define TYPE_SINGLECHECKBOX TYPE_SINGLECHEKBOX

--- a/src/appleseed-max-impl/appleseedobjpropsmod/appleseedobjpropsmod.h
+++ b/src/appleseed-max-impl/appleseedobjpropsmod/appleseedobjpropsmod.h
@@ -38,13 +38,14 @@
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <iparamb2.h>
 #include <maxtypes.h>
 #include <object.h>
 #include <ref.h>
 #include <strbasic.h>
 #include <strclass.h>
-#undef base_type
+#include "_endmaxheaders.h"
 
 class AppleseedObjPropsMod
   : public OSModifier

--- a/src/appleseed-max-impl/appleseedoslplugin/oslclassdesc.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslclassdesc.h
@@ -38,9 +38,10 @@
 #include "oslshaderregistry.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <IMaterialBrowserEntryInfo.h>
 #include <IMtlRender_Compatibility.h>
-#undef base_type
+#include "_endmaxheaders.h"
 
 //
 // OSLPlugin material browser info.

--- a/src/appleseed-max-impl/appleseedoslplugin/oslmaterial.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslmaterial.cpp
@@ -47,7 +47,9 @@
 #include "renderer/api/utility.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <iparamm2.h>
+#include "_endmaxheaders.h"
 
 namespace asf = foundation;
 namespace asr = renderer;

--- a/src/appleseed-max-impl/appleseedoslplugin/oslmaterial.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslmaterial.h
@@ -40,10 +40,11 @@
 #include "iappleseedmtl.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <imtl.h>
 #include <iparamb2.h>
 #include <maxtypes.h>
-#undef base_type
+#include "_endmaxheaders.h"
 
 // Forward declarations.
 namespace renderer { class Material; }

--- a/src/appleseed-max-impl/appleseedoslplugin/oslparamdlg.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslparamdlg.cpp
@@ -39,8 +39,10 @@
 #include "utilities.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <iparamm2.h>
 #include <maxtypes.h>
+#include "_endmaxheaders.h"
 
 namespace asf = foundation;
 namespace asr = renderer;

--- a/src/appleseed-max-impl/appleseedoslplugin/oslparamdlg.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslparamdlg.h
@@ -38,7 +38,9 @@
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <imtl.h>
+#include "_endmaxheaders.h"
 
 // Standard headers.
 #include <map>

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.cpp
@@ -46,9 +46,10 @@
 #include "utilities.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <iparamb2.h>
 #include <maxtypes.h>
-#undef base_type
+#include "_endmaxheaders.h"
 
 // Standard headers.
 #include <iostream>

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.cpp
@@ -48,6 +48,7 @@
 // 3ds Max headers.
 #include <iparamb2.h>
 #include <maxtypes.h>
+#undef base_type
 
 // Standard headers.
 #include <iostream>

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.h
@@ -36,8 +36,10 @@
 #include "foundation/utility/containers/dictionary.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <maxapi.h>
 #include <maxtypes.h>
+#include "_endmaxheaders.h"
 
 // Standard headers.
 #include <vector>

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshaderregistry.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshaderregistry.cpp
@@ -50,10 +50,11 @@
 #include "foundation/utility/string.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <iparamb2.h>
 #include <iparamm2.h>
 #include <maxtypes.h>
-#undef base_type
+#include "_endmaxheaders.h"
 
 // Boost headers.
 #include "boost/filesystem.hpp"

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshaderregistry.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshaderregistry.cpp
@@ -53,6 +53,7 @@
 #include <iparamb2.h>
 #include <iparamm2.h>
 #include <maxtypes.h>
+#undef base_type
 
 // Boost headers.
 #include "boost/filesystem.hpp"

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshaderregistry.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshaderregistry.h
@@ -32,9 +32,10 @@
 #include "appleseedoslplugin/oslshadermetadata.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <iparamb2.h>
 #include <maxtypes.h>
-#undef base_type
+#include "_endmaxheaders.h"
 
 // Standard headers.
 #include <string>

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshaderregistry.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshaderregistry.h
@@ -34,6 +34,7 @@
 // 3ds Max headers.
 #include <iparamb2.h>
 #include <maxtypes.h>
+#undef base_type
 
 // Standard headers.
 #include <string>

--- a/src/appleseed-max-impl/appleseedoslplugin/osltexture.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/osltexture.cpp
@@ -46,7 +46,9 @@
 #include "renderer/api/utility.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <iparamm2.h>
+#include "_endmaxheaders.h"
 
 namespace asf = foundation;
 namespace asr = renderer;

--- a/src/appleseed-max-impl/appleseedoslplugin/osltexture.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/osltexture.h
@@ -39,10 +39,11 @@
 #include "appleseedoslplugin/oslshadermetadata.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <imtl.h>
 #include <iparamb2.h>
 #include <maxtypes.h>
-#undef base_type
+#include "_endmaxheaders.h"
 
 // Standard headers.
 #include <string>

--- a/src/appleseed-max-impl/appleseedplasticmtl/appleseedplasticmtl.cpp
+++ b/src/appleseed-max-impl/appleseedplasticmtl/appleseedplasticmtl.cpp
@@ -54,10 +54,12 @@
 #include "foundation/image/colorspace.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <color.h>
 #include <iparamm2.h>
 #include <stdmat.h>
 #include <strclass.h>
+#include "_endmaxheaders.h"
 
 // Standard headers.
 #include <string>

--- a/src/appleseed-max-impl/appleseedplasticmtl/appleseedplasticmtl.h
+++ b/src/appleseed-max-impl/appleseedplasticmtl/appleseedplasticmtl.h
@@ -39,6 +39,7 @@
 #include "foundation/utility/autoreleaseptr.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <color.h>
 #include <IMaterialBrowserEntryInfo.h>
 #include <IMtlRender_Compatibility.h>
@@ -48,7 +49,7 @@
 #include <maxtypes.h>
 #include <ref.h>
 #include <strbasic.h>
-#undef base_type
+#include "_endmaxheaders.h"
 
 // Forward declarations.
 namespace renderer  { class Material; }

--- a/src/appleseed-max-impl/appleseedrenderelement/appleseedrenderelement.cpp
+++ b/src/appleseed-max-impl/appleseedrenderelement/appleseedrenderelement.cpp
@@ -43,7 +43,9 @@
 #include "renderer/api/aov.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <iparamm2.h>
+#include "_endmaxheaders.h"
 
 // Standard headers.
 #include <string>

--- a/src/appleseed-max-impl/appleseedrenderelement/appleseedrenderelement.h
+++ b/src/appleseed-max-impl/appleseedrenderelement/appleseedrenderelement.h
@@ -35,9 +35,10 @@
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <iparamb2.h>
 #include <renderelements.h>
-#undef base_type
+#include "_endmaxheaders.h"
 
 // Forward declarations.
 namespace renderer

--- a/src/appleseed-max-impl/appleseedrenderelement/appleseedrenderelement.h
+++ b/src/appleseed-max-impl/appleseedrenderelement/appleseedrenderelement.h
@@ -37,6 +37,7 @@
 // 3ds Max headers.
 #include <iparamb2.h>
 #include <renderelements.h>
+#undef base_type
 
 // Forward declarations.
 namespace renderer

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
@@ -61,6 +61,7 @@
 #include "foundation/utility/searchpaths.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <assert1.h>
 #include <bitmap.h>
 #include <interactiverender.h>
@@ -68,6 +69,7 @@
 #include <notify.h>
 #include <pbbitmap.h>
 #include <renderelements.h>
+#include "_endmaxheaders.h"
 
 // Standard headers.
 #include <clocale>

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.h
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.h
@@ -39,11 +39,12 @@
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <iparamb2.h>
 #include <ITabDialog.h>
 #include <max.h>
 #include <render.h>
-#undef base_type
+#include "_endmaxheaders.h"
 
 // Standard headers.
 #include <vector>

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.cpp
@@ -44,10 +44,12 @@
 #include "foundation/core/appleseed.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <3dsmaxdlport.h>
 #include <assert1.h>
 #include <custcont.h>
 #include <iparamm2.h>
+#include "_endmaxheaders.h"
 
 // Windows headers.
 #include <shellapi.h>

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.h
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrendererparamdlg.h
@@ -35,7 +35,9 @@
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <render.h>
+#include "_endmaxheaders.h"
 
 // Forward declarations.
 class AppleseedRenderer;

--- a/src/appleseed-max-impl/appleseedrenderer/dialoglogtarget.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/dialoglogtarget.cpp
@@ -46,7 +46,9 @@
 #include "boost/thread/mutex.hpp"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <max.h>
+#include "_endmaxheaders.h"
 
 // Standard headers.
 #include <Richedit.h>

--- a/src/appleseed-max-impl/appleseedrenderer/dialoglogtarget.h
+++ b/src/appleseed-max-impl/appleseedrenderer/dialoglogtarget.h
@@ -39,6 +39,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#undef base_type
 
 typedef std::vector<std::string> StringVec;
 typedef foundation::LogMessage::Category MessageType;

--- a/src/appleseed-max-impl/appleseedrenderer/dialoglogtarget.h
+++ b/src/appleseed-max-impl/appleseedrenderer/dialoglogtarget.h
@@ -35,11 +35,12 @@
 #include "foundation/utility/log.h"
 
 // Standard headers.
+#include "_beginmaxheaders.h"
 #include <cstddef>
 #include <string>
 #include <utility>
 #include <vector>
-#undef base_type
+#include "_endmaxheaders.h"
 
 typedef std::vector<std::string> StringVec;
 typedef foundation::LogMessage::Category MessageType;

--- a/src/appleseed-max-impl/appleseedrenderer/maxsceneentities.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/maxsceneentities.cpp
@@ -37,7 +37,9 @@
 #include "foundation/utility/memory.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <object.h>
+#include "_endmaxheaders.h"
 
 
 //

--- a/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
@@ -502,6 +502,12 @@ namespace
         return medium_priority;
     }
 
+    bool motion_blur_enabled(INode* node, const TimeValue time)
+    {
+        const int ObjectMotionBlur = 1;
+        return node->GetMotBlurOnOff(time) && node->MotBlur() == ObjectMotionBlur;
+    }
+
     bool should_optimize_for_instancing(Object* object, const TimeValue time)
     {
         bool optimize_for_instancing = false;
@@ -776,7 +782,7 @@ namespace
             asf::Transformd::from_local_to_parent(
                 to_matrix4d(node->GetObjTMAfterWSM(time)));
 
-        if (should_optimize_for_instancing(object, time))
+        if (motion_blur_enabled(node, time) || should_optimize_for_instancing(object, time))
         {
             std::string assembly_name = wide_to_utf8(node->GetName());
             assembly_name = make_unique_name(assembly.assemblies(), assembly_name + "_assembly");
@@ -827,8 +833,7 @@ namespace
             object_assembly_instance->transform_sequence()
                 .set_transform(0.0, transform);
 
-            const int ObjectMotionBlur = 1;
-            if (node->GetMotBlurOnOff(time) && node->MotBlur() == ObjectMotionBlur)
+            if (motion_blur_enabled(node, time))
             {
                 bool is_animated = is_node_animated(node);
                 INode* parent_node = node->GetParentNode();

--- a/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
@@ -75,6 +75,7 @@
 #include "foundation/utility/searchpaths.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <assert1.h>
 #include <bitmap.h>
 #include <genlight.h>
@@ -89,6 +90,7 @@
 #include <Scene/IPhysicalCamera.h>
 #include <trig.h>
 #include <triobj.h>
+#include "_endmaxheaders.h"
 
 // Standard headers.
 #include <cstddef>
@@ -502,12 +504,6 @@ namespace
         return medium_priority;
     }
 
-    bool motion_blur_enabled(INode* node, const TimeValue time)
-    {
-        const int ObjectMotionBlur = 1;
-        return node->GetMotBlurOnOff(time) && node->MotBlur() == ObjectMotionBlur;
-    }
-
     bool should_optimize_for_instancing(Object* object, const TimeValue time)
     {
         bool optimize_for_instancing = false;
@@ -782,7 +778,7 @@ namespace
             asf::Transformd::from_local_to_parent(
                 to_matrix4d(node->GetObjTMAfterWSM(time)));
 
-        if (motion_blur_enabled(node, time) || should_optimize_for_instancing(object, time))
+        if (should_optimize_for_instancing(object, time))
         {
             std::string assembly_name = wide_to_utf8(node->GetName());
             assembly_name = make_unique_name(assembly.assemblies(), assembly_name + "_assembly");
@@ -833,7 +829,8 @@ namespace
             object_assembly_instance->transform_sequence()
                 .set_transform(0.0, transform);
 
-            if (motion_blur_enabled(node, time))
+            const int ObjectMotionBlur = 1;
+            if (node->GetMotBlurOnOff(time) && node->MotBlur() == ObjectMotionBlur)
             {
                 bool is_animated = is_node_animated(node);
                 INode* parent_node = node->GetParentNode();

--- a/src/appleseed-max-impl/appleseedrenderer/projectbuilder.h
+++ b/src/appleseed-max-impl/appleseedrenderer/projectbuilder.h
@@ -36,8 +36,10 @@
 #include "foundation/utility/autoreleaseptr.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <maxtypes.h>
 #include <render.h>
+#include "_endmaxheaders.h"
 
 // Standard headers.
 #include <vector>

--- a/src/appleseed-max-impl/appleseedrenderer/renderercontroller.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/renderercontroller.cpp
@@ -37,7 +37,9 @@
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <render.h>
+#include "_endmaxheaders.h"
 
 namespace asf = foundation;
 namespace asr = renderer;

--- a/src/appleseed-max-impl/appleseedrenderer/renderersettings.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/renderersettings.cpp
@@ -41,7 +41,9 @@
 #include "renderer/api/utility.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <ioapi.h>
+#include "_endmaxheaders.h"
 
 namespace asr = renderer;
 

--- a/src/appleseed-max-impl/appleseedrenderer/renderersettings.h
+++ b/src/appleseed-max-impl/appleseedrenderer/renderersettings.h
@@ -38,8 +38,10 @@
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <maxtypes.h>
 #include <strclass.h>
+#include "_endmaxheaders.h"
 
 // Standard headers.
 #include <string>

--- a/src/appleseed-max-impl/appleseedrenderer/tilecallback.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/tilecallback.cpp
@@ -44,8 +44,10 @@
 #include "foundation/platform/windows.h"    // include before 3ds Max headers
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <assert1.h>
 #include <bitmap.h>
+#include "_endmaxheaders.h"
 
 // Standard headers.
 #include <algorithm>

--- a/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
+++ b/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.cpp
@@ -56,11 +56,13 @@
 #include "foundation/utility/searchpaths.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <AssetManagement/AssetUser.h>
 #include <color.h>
 #include <iparamm2.h>
 #include <stdmat.h>
 #include <strclass.h>
+#include "_endmaxheaders.h"
 
 // Windows headers.
 #include <tchar.h>

--- a/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.h
+++ b/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.h
@@ -39,6 +39,7 @@
 #include "foundation/utility/autoreleaseptr.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <color.h>
 #include <IMaterialBrowserEntryInfo.h>
 #include <IMtlRender_Compatibility.h>
@@ -48,7 +49,7 @@
 #include <maxtypes.h>
 #include <ref.h>
 #include <strbasic.h>
-#undef base_type
+#include "_endmaxheaders.h"
 
 // Forward declarations.
 namespace renderer  { class Material; }

--- a/src/appleseed-max-impl/appleseedvolumemtl/appleseedvolumemtl.cpp
+++ b/src/appleseed-max-impl/appleseedvolumemtl/appleseedvolumemtl.cpp
@@ -52,11 +52,13 @@
 #include "foundation/utility/searchpaths.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <AssetManagement/AssetUser.h>
 #include <color.h>
 #include <iparamm2.h>
 #include <stdmat.h>
 #include <strclass.h>
+#include "_endmaxheaders.h"
 
 // Windows headers.
 #include <tchar.h>

--- a/src/appleseed-max-impl/appleseedvolumemtl/appleseedvolumemtl.h
+++ b/src/appleseed-max-impl/appleseedvolumemtl/appleseedvolumemtl.h
@@ -39,6 +39,7 @@
 #include "foundation/utility/autoreleaseptr.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <color.h>
 #include <IMaterialBrowserEntryInfo.h>
 #include <IMtlRender_Compatibility.h>
@@ -48,7 +49,7 @@
 #include <maxtypes.h>
 #include <ref.h>
 #include <strbasic.h>
-#undef base_type
+#include "_endmaxheaders.h"
 
 // Forward declarations.
 namespace renderer  { class Volume; }

--- a/src/appleseed-max-impl/builtinmapsupport.cpp
+++ b/src/appleseed-max-impl/builtinmapsupport.cpp
@@ -33,6 +33,7 @@
 #include "appleseedoslplugin/osltexture.h"
 #include "oslutils.h"
 #include "utilities.h"
+#include "_endmaxheaders.h"
 
 // Build options header.
 #include "renderer/api/buildoptions.h"
@@ -42,7 +43,9 @@
 #include "renderer/api/utility.h"
 
 // 3ds Max Headers.
+#include "_beginmaxheaders.h"
 #include <imtl.h>
+#include "_endmaxheaders.h"
 
 namespace asf = foundation;
 namespace asr = renderer;

--- a/src/appleseed-max-impl/builtinmapsupport.h
+++ b/src/appleseed-max-impl/builtinmapsupport.h
@@ -39,8 +39,10 @@
 #include "foundation/image/color.h"
 
 // 3ds Max Headers.
+#include "_beginmaxheaders.h"
 #include <color.h>
 #include <maxtypes.h>
+#include "_endmaxheaders.h"
 
 // Standard headers.
 #include <string>

--- a/src/appleseed-max-impl/bump/bumpparammapdlgproc.h
+++ b/src/appleseed-max-impl/bump/bumpparammapdlgproc.h
@@ -32,7 +32,9 @@
 #include "bump/resource.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <iparamm2.h>
+#include "_endmaxheaders.h"
 
 class BumpParamMapDlgProc
   : public ParamMap2UserDlgProc

--- a/src/appleseed-max-impl/iappleseedmtl.cpp
+++ b/src/appleseed-max-impl/iappleseedmtl.cpp
@@ -30,7 +30,9 @@
 #include "iappleseedmtl.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <maxtypes.h>
+#include "_endmaxheaders.h"
 
 Interface_ID IAppleseedMtl::interface_id()
 {

--- a/src/appleseed-max-impl/iappleseedmtl.h
+++ b/src/appleseed-max-impl/iappleseedmtl.h
@@ -36,7 +36,9 @@
 #include "foundation/utility/autoreleaseptr.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <baseinterface.h>
+#include "_endmaxheaders.h"
 
 // Forward declarations.
 namespace renderer  { class Assembly; }

--- a/src/appleseed-max-impl/logtarget.cpp
+++ b/src/appleseed-max-impl/logtarget.cpp
@@ -44,8 +44,10 @@
 #include "boost/thread/mutex.hpp"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <log.h>
 #include <max.h>
+#include "_endmaxheaders.h"
 
 // Standard headers.
 #include <string>

--- a/src/appleseed-max-impl/logtarget.h
+++ b/src/appleseed-max-impl/logtarget.h
@@ -36,6 +36,7 @@
 
 // Standard headers.
 #include <cstddef>
+#undef base_type
 
 class LogTarget
   : public foundation::ILogTarget

--- a/src/appleseed-max-impl/osloutputselectormap/osloutputselector.h
+++ b/src/appleseed-max-impl/osloutputselectormap/osloutputselector.h
@@ -36,6 +36,7 @@
 #include "foundation/utility/autoreleaseptr.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <IMaterialBrowserEntryInfo.h>
 #include <IMtlRender_Compatibility.h>
 #include <imtl.h>
@@ -44,7 +45,7 @@
 #include <istdplug.h>
 #include <maxtypes.h>
 #include <stdmat.h>
-#undef base_type
+#include "_endmaxheaders.h"
 
 class OSLOutputSelector
   : public Texmap

--- a/src/appleseed-max-impl/oslutils.cpp
+++ b/src/appleseed-max-impl/oslutils.cpp
@@ -47,12 +47,14 @@
 #include "foundation/utility/string.h"
 
 // 3ds Max Headers.
+#include "_beginmaxheaders.h"
 #include <bitmap.h>
 #include <imtl.h>
 #include <maxapi.h>
 #include <maxtypes.h>
 #include <stdmat.h>
 #include <iparamm2.h>
+#include "_endmaxheaders.h"
 
 namespace asf = foundation;
 namespace asr = renderer;

--- a/src/appleseed-max-impl/oslutils.h
+++ b/src/appleseed-max-impl/oslutils.h
@@ -37,7 +37,9 @@
 #include "foundation/math/vector.h"
 
 // 3ds Max Headers.
+#include "_beginmaxheaders.h"
 #include <maxtypes.h>
+#include "_endmaxheaders.h"
 
 // Standard headers.
 #include <string>

--- a/src/appleseed-max-impl/plugin.cpp
+++ b/src/appleseed-max-impl/plugin.cpp
@@ -60,8 +60,10 @@
 #include "main/allocator.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <iparamb2.h>
 #include <plugapi.h>
+#include "_endmaxheaders.h"
 
 // Windows headers.
 #include <tchar.h>

--- a/src/appleseed-max-impl/seexprutils.cpp
+++ b/src/appleseed-max-impl/seexprutils.cpp
@@ -39,9 +39,11 @@
 #include "foundation/utility/string.h"
 
 // 3ds Max Headers.
+#include "_beginmaxheaders.h"
 #include <assert1.h>
 #include <bitmap.h>
 #include <stdmat.h>
+#include "_endmaxheaders.h"
 
 namespace asf = foundation;
 namespace asr = renderer;

--- a/src/appleseed-max-impl/utilities.cpp
+++ b/src/appleseed-max-impl/utilities.cpp
@@ -50,6 +50,7 @@
 #include "foundation/utility/string.h"
 
 // 3ds Max Headers.
+#include "_beginmaxheaders.h"
 #include <AssetManagement/AssetUser.h>
 #include <assert1.h>
 #include <bitmap.h>
@@ -58,6 +59,7 @@
 #include <maxapi.h>
 #include <plugapi.h>
 #include <stdmat.h>
+#include "_endmaxheaders.h"
 
 // Windows headers.
 #include <Shlwapi.h>

--- a/src/appleseed-max-impl/utilities.h
+++ b/src/appleseed-max-impl/utilities.h
@@ -44,6 +44,7 @@
 #include "foundation/utility/autoreleaseptr.h"
 
 // 3ds Max headers.
+#include "_beginmaxheaders.h"
 #include <assert1.h>
 #include <color.h>
 #include <ioapi.h>
@@ -54,7 +55,7 @@
 #include <maxtypes.h>
 #include <point3.h>
 #include <point4.h>
-#undef base_type
+#include "_endmaxheaders.h"
 
 // Standard headers.
 #include <cstddef>

--- a/src/appleseed-max-impl/utilities.h
+++ b/src/appleseed-max-impl/utilities.h
@@ -54,6 +54,7 @@
 #include <maxtypes.h>
 #include <point3.h>
 #include <point4.h>
+#undef base_type
 
 // Standard headers.
 #include <cstddef>


### PR DESCRIPTION
This is quick PR that removes base_type macro from plugin files. It helps to prevent boost error message during compilation that started to appear in recent build.
