### PR TITLE
Introduce alpha parameter to SSS material

### DIFF
--- a/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.h
+++ b/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.h
@@ -154,9 +154,11 @@ private:
     Texmap*         m_sss_color_texmap;
     Color           m_sss_scattering_color;
     Texmap*         m_sss_scattering_color_texmap;
+    Texmap*         m_alpha_texmap;
     float           m_sss_amount;
     float           m_sss_scale;
     float           m_sss_ior;
+    float           m_alpha;
     Color           m_specular_color;
     Texmap*         m_specular_color_texmap;
     float           m_specular_amount;

--- a/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.rc
+++ b/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.rc
@@ -50,7 +50,7 @@ END
 // Dialog
 //
 
-IDD_FORMVIEW_SSS_PARAMS DIALOGEX 0, 0, 217, 67
+IDD_FORMVIEW_SSS_PARAMS DIALOGEX 0, 0, 217, 79
 STYLE DS_SETFONT | WS_CHILD | WS_VISIBLE
 FONT 8, "MS Sans Serif", 0, 0, 0x1
 BEGIN
@@ -71,6 +71,12 @@ BEGIN
     LTEXT           "IOR:",IDC_LABEL_SSS_IOR,7,54,48,8
     CONTROL         "IOR Edit",IDC_EDIT_SSS_IOR,"CustEdit",WS_TABSTOP,69,54,30,10
     CONTROL         "IOR Slider",IDC_SLIDER_SSS_IOR,"SliderControl",WS_TABSTOP,101,54,97,13
+    LTEXT           "Alpha:",IDC_LABEL_ALPHA,7,66,48,8
+    CONTROL         "Alpha Edit",IDC_EDIT_ALPHA,"CustEdit",WS_TABSTOP,69,66,30,10
+    CONTROL         "Alpha Slider",IDC_SLIDER_ALPHA,
+                    "SliderControl",WS_TABSTOP,101,66,97,13
+    CONTROL         "Alpha Map",IDC_TEXMAP_ALPHA,
+                    "CustButton",WS_TABSTOP,200,66,10,10
 END
 
 IDD_FORMVIEW_SPECULAR_PARAMS DIALOGEX 0, 0, 217, 55
@@ -177,6 +183,7 @@ STRINGTABLE
 BEGIN
     IDS_SSS_SCALE           "Scale"
     IDS_SSS_IOR             "IOR"
+    IDS_ALPHA               "Alpha"
 END
 
 STRINGTABLE

--- a/src/appleseed-max-impl/appleseedsssmtl/resource.h
+++ b/src/appleseed-max-impl/appleseedsssmtl/resource.h
@@ -32,6 +32,13 @@
 #define IDC_SLIDER_SSS_IOR                  5052
 #define IDS_SSS_IOR                         5053
 
+#define IDC_LABEL_ALPHA                     5060
+#define IDC_EDIT_ALPHA                      5061
+#define IDC_SLIDER_ALPHA                    5062
+#define IDC_TEXMAP_ALPHA                    5063
+#define IDS_ALPHA                           5064
+#define IDS_TEXMAP_ALPHA                    5065
+
 #define IDD_FORMVIEW_SPECULAR_PARAMS        6000
 #define IDS_FORMVIEW_SPECULAR_PARAMS_TITLE  6001
 


### PR DESCRIPTION
Here's a PR for this issue https://github.com/appleseedhq/appleseed-max/issues/14

It seems to work fine, but I have two questions:
1. Where should it be located in UI? At the moment it's in SSS tab, whereas it applies to both SSS and Specular, which might be misleading. However a separate tab for single map seems excessive. Maybe it should be added to bump tab? Though in that case it would need to be removed from Disney material tab. I'm not sure what is the best approach here.
2. It does not work well with appleseed texture map, whereas it works fine with native Max bitmap node. Is it expected?