### PR TITLE
Simplify project setup

### DIFF
--- a/src/appleseed-max-common/appleseed-max2017-common.vcxproj
+++ b/src/appleseed-max-common/appleseed-max2017-common.vcxproj
@@ -30,7 +30,6 @@
     <ProjectGuid>{44361726-ECBC-451E-8BB4-B49960BC9EB9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>appleseedmaxcommon</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">

--- a/src/appleseed-max-common/appleseed-max2017-common.vcxproj
+++ b/src/appleseed-max-common/appleseed-max2017-common.vcxproj
@@ -66,41 +66,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc140\ilmbase-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\openexr-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\oiio-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\osl-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\SeExpr-release\include;C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc140\ilmbase-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\openexr-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\oiio-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\osl-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\SeExpr-debug\include;C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <PreprocessorDefinitions>_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc140\ilmbase-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\openexr-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\oiio-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\osl-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\SeExpr-release\include;C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
-    <ClCompile>
-      <PreprocessorDefinitions>_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc140\ilmbase-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\openexr-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\oiio-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\osl-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\SeExpr-release\include;C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>false</EnableCOMDATFolding>
+      <OptimizeReferences>false</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/appleseed-max-common/appleseed-max2017-common.vcxproj
+++ b/src/appleseed-max-common/appleseed-max2017-common.vcxproj
@@ -30,6 +30,7 @@
     <ProjectGuid>{44361726-ECBC-451E-8BB4-B49960BC9EB9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>appleseedmaxcommon</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">

--- a/src/appleseed-max-common/appleseed-max2017-common.vcxproj
+++ b/src/appleseed-max-common/appleseed-max2017-common.vcxproj
@@ -33,58 +33,38 @@
     <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <ImportGroup Label="ExtensionSettings">
-  </ImportGroup>
-  <ImportGroup Label="Shared">
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="..\appleseed-max-debug.props" />
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\appleseed-max-release.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\appleseed-max-release.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
-    <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/src/appleseed-max-common/appleseed-max2018-common.vcxproj
+++ b/src/appleseed-max-common/appleseed-max2018-common.vcxproj
@@ -66,41 +66,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc140\ilmbase-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\openexr-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\oiio-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\osl-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\SeExpr-release\include;C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc140\ilmbase-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\openexr-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\oiio-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\osl-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\SeExpr-debug\include;C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <PreprocessorDefinitions>_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc140\ilmbase-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\openexr-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\oiio-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\osl-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\SeExpr-release\include;C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
-    <ClCompile>
-      <PreprocessorDefinitions>_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc140\ilmbase-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\openexr-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\oiio-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\osl-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\SeExpr-release\include;C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>false</EnableCOMDATFolding>
+      <OptimizeReferences>false</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/appleseed-max-common/appleseed-max2018-common.vcxproj
+++ b/src/appleseed-max-common/appleseed-max2018-common.vcxproj
@@ -30,7 +30,6 @@
     <ProjectGuid>{44361726-ECBC-451E-8BB4-B49960BC9EB9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>appleseedmaxcommon</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">

--- a/src/appleseed-max-common/appleseed-max2018-common.vcxproj
+++ b/src/appleseed-max-common/appleseed-max2018-common.vcxproj
@@ -30,6 +30,7 @@
     <ProjectGuid>{44361726-ECBC-451E-8BB4-B49960BC9EB9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>appleseedmaxcommon</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">

--- a/src/appleseed-max-common/appleseed-max2018-common.vcxproj
+++ b/src/appleseed-max-common/appleseed-max2018-common.vcxproj
@@ -33,58 +33,38 @@
     <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <ImportGroup Label="ExtensionSettings">
-  </ImportGroup>
-  <ImportGroup Label="Shared">
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="..\appleseed-max-debug.props" />
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\appleseed-max-release.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\appleseed-max-release.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
-    <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/src/appleseed-max-common/appleseed-max2019-common.vcxproj
+++ b/src/appleseed-max-common/appleseed-max2019-common.vcxproj
@@ -66,41 +66,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc140\ilmbase-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\openexr-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\oiio-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\osl-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\SeExpr-release\include;C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc140\ilmbase-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\openexr-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\oiio-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\osl-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\SeExpr-debug\include;C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc140\ilmbase-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\openexr-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\oiio-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\osl-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\SeExpr-debug\include;C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <PreprocessorDefinitions>_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc140\ilmbase-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\openexr-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\oiio-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\osl-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\SeExpr-release\include;C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
-    <ClCompile>
-      <PreprocessorDefinitions>_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc140\ilmbase-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\openexr-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\oiio-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\osl-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\SeExpr-release\include;C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>false</EnableCOMDATFolding>
+      <OptimizeReferences>false</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/appleseed-max-common/appleseed-max2019-common.vcxproj
+++ b/src/appleseed-max-common/appleseed-max2019-common.vcxproj
@@ -30,7 +30,6 @@
     <ProjectGuid>{44361726-ECBC-451E-8BB4-B49960BC9EB9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>appleseedmaxcommon</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">

--- a/src/appleseed-max-common/appleseed-max2019-common.vcxproj
+++ b/src/appleseed-max-common/appleseed-max2019-common.vcxproj
@@ -30,6 +30,7 @@
     <ProjectGuid>{44361726-ECBC-451E-8BB4-B49960BC9EB9}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>appleseedmaxcommon</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">

--- a/src/appleseed-max-common/appleseed-max2019-common.vcxproj
+++ b/src/appleseed-max-common/appleseed-max2019-common.vcxproj
@@ -33,58 +33,38 @@
     <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <ImportGroup Label="ExtensionSettings">
-  </ImportGroup>
-  <ImportGroup Label="Shared">
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="..\appleseed-max-debug.props" />
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\appleseed-max-release.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\appleseed-max-release.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
-    <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/src/appleseed-max-common/appleseed-max2020-common.vcxproj
+++ b/src/appleseed-max-common/appleseed-max2020-common.vcxproj
@@ -33,58 +33,38 @@
     <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <ImportGroup Label="ExtensionSettings">
-  </ImportGroup>
-  <ImportGroup Label="Shared">
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="..\appleseed-max-debug.props" />
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="..\appleseed-max-release.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\appleseed-max-release.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
-    <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/src/appleseed-max-common/appleseed-max2020-common.vcxproj
+++ b/src/appleseed-max-common/appleseed-max2020-common.vcxproj
@@ -66,41 +66,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc141\ilmbase-release\include;$(SolutionDir)..\..\windows-deps\stage\vc141\openexr-release\include;$(SolutionDir)..\..\windows-deps\stage\vc141\oiio-release\include;$(SolutionDir)..\..\windows-deps\stage\vc141\osl-release\include;$(SolutionDir)..\..\windows-deps\stage\vc141\SeExpr-release\include;C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc141\ilmbase-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc141\openexr-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc141\oiio-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc141\osl-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc141\SeExpr-debug\include;C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <PreprocessorDefinitions>_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc141\ilmbase-release\include;$(SolutionDir)..\..\windows-deps\stage\vc141\openexr-release\include;$(SolutionDir)..\..\windows-deps\stage\vc141\oiio-release\include;$(SolutionDir)..\..\windows-deps\stage\vc141\osl-release\include;$(SolutionDir)..\..\windows-deps\stage\vc141\SeExpr-release\include;C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
-    <ClCompile>
-      <PreprocessorDefinitions>_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc141\ilmbase-release\include;$(SolutionDir)..\..\windows-deps\stage\vc141\openexr-release\include;$(SolutionDir)..\..\windows-deps\stage\vc141\oiio-release\include;$(SolutionDir)..\..\windows-deps\stage\vc141\osl-release\include;$(SolutionDir)..\..\windows-deps\stage\vc141\SeExpr-release\include;C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>false</EnableCOMDATFolding>
+      <OptimizeReferences>false</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj
@@ -60,38 +60,8 @@
       <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\sandbox\max2017\$(Configuration)" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2017\Current" 2&gt;nul
-
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2017\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2017\Current\"
-
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2017\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2017\Current\"
-
-rmdir /S /Q "$(SolutionDir)..\sandbox\max2017\$(Configuration)\shaders" 2&gt;nul
-rmdir /S /Q "$(SolutionDir)..\sandbox\max2017\Current\shaders" 2&gt;nul
-
-mkdir "$(SolutionDir)..\sandbox\max2017\$(Configuration)\shaders\max\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2017\$(Configuration)\shaders\appleseed\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2017\Current\shaders\max\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2017\Current\shaders\appleseed\" 2&gt;nul
-
-del /Q "$(SolutionDir)..\sandbox\max2017\$(Configuration)\shaders\max\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2017\$(Configuration)\shaders\appleseed\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2017\Current\shaders\max\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2017\Current\shaders\appleseed\*.oso" 2&gt;nul
-
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\shaders\max\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\shaders\appleseed\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2017\Current\shaders\max\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2017\Current\shaders\appleseed\"</Command>
+      <Message>Moving output files...</Message>
+      <Command>post-build.cmd "$(SolutionDir)" "$(Configuration)" "$(TargetPath)" "$(TargetName)" "$(PlatformToolsetVersion)" "2017"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj
@@ -18,6 +18,7 @@
     <ProjectGuid>{62C41566-DBCB-49D3-943A-4DD53222269E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>appleseedmax</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
@@ -60,7 +61,7 @@
     </Link>
     <PostBuildEvent>
       <Message>Moving output files...</Message>
-      <Command>post-build.cmd "$(SolutionDir)" "$(Configuration)" "$(TargetPath)" "$(TargetName)" "$(PlatformToolsetVersion)" "2017"</Command>
+      <Command>post-build.cmd "$(SolutionDir)" "$(Configuration)" "$(TargetDir)" "$(TargetName)" "$(PlatformToolsetVersion)" "2017"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj
@@ -18,7 +18,6 @@
     <ProjectGuid>{62C41566-DBCB-49D3-943A-4DD53222269E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>appleseedmax</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">

--- a/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj
@@ -21,51 +21,34 @@
     <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="..\appleseed-max-debug.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\appleseed-max-release.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\appleseed-max-release.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
+  <PropertyGroup>
     <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>

--- a/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2017-impl.vcxproj
@@ -52,108 +52,12 @@
     <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  <ItemDefinitionGroup>
     <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc140\ilmbase-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\openexr-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\oiio-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\osl-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\SeExpr-debug\include;C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>
-      </DelayLoadDLLs>
-    </Link>
-    <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\sandbox\max2017\$(Configuration)" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2017\Current" 2&gt;nul
-
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2017\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2017\Current\"
-
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2017\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2017\Current\"
-
-rmdir /S /Q "$(SolutionDir)..\sandbox\max2017\$(Configuration)\shaders" 2&gt;nul
-rmdir /S /Q "$(SolutionDir)..\sandbox\max2017\Current\shaders" 2&gt;nul
-
-mkdir "$(SolutionDir)..\sandbox\max2017\$(Configuration)\shaders\max\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2017\$(Configuration)\shaders\appleseed\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2017\Current\shaders\max\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2017\Current\shaders\appleseed\" 2&gt;nul
-
-del /Q "$(SolutionDir)..\sandbox\max2017\$(Configuration)\shaders\max\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2017\$(Configuration)\shaders\appleseed\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2017\Current\shaders\max\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2017\Current\shaders\appleseed\*.oso" 2&gt;nul
-
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\shaders\max\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\shaders\appleseed\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2017\Current\shaders\max\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2017\Current\shaders\appleseed\"</Command>
-    </PostBuildEvent>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc140\ilmbase-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\openexr-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\oiio-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\osl-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\SeExpr-release\include;C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>
-      </DelayLoadDLLs>
-    </Link>
-    <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\sandbox\max2017\$(Configuration)" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2017\Current" 2&gt;nul
-
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2017\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2017\Current\"
-
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2017\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2017\Current\"
-
-rmdir /S /Q "$(SolutionDir)..\sandbox\max2017\$(Configuration)\shaders" 2&gt;nul
-rmdir /S /Q "$(SolutionDir)..\sandbox\max2017\Current\shaders" 2&gt;nul
-
-mkdir "$(SolutionDir)..\sandbox\max2017\$(Configuration)\shaders\max\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2017\$(Configuration)\shaders\appleseed\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2017\Current\shaders\max\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2017\Current\shaders\appleseed\" 2&gt;nul
-
-del /Q "$(SolutionDir)..\sandbox\max2017\$(Configuration)\shaders\max\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2017\$(Configuration)\shaders\appleseed\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2017\Current\shaders\max\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2017\Current\shaders\appleseed\*.oso" 2&gt;nul
-
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\shaders\max\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\shaders\appleseed\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2017\Current\shaders\max\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2017\Current\shaders\appleseed\"</Command>
-    </PostBuildEvent>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
-    <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc140\ilmbase-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\openexr-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\oiio-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\osl-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\SeExpr-release\include;C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>
-      </DelayLoadDLLs>
     </Link>
     <PostBuildEvent>
       <Command>mkdir "$(SolutionDir)..\sandbox\max2017\$(Configuration)" 2&gt;nul

--- a/src/appleseed-max-impl/appleseed-max2018-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2018-impl.vcxproj
@@ -52,103 +52,11 @@
     <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  <ItemDefinitionGroup>
     <ClCompile>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc140\ilmbase-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\openexr-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\oiio-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\osl-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\SeExpr-debug\include;C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>
-      </DelayLoadDLLs>
-    </Link>
-    <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2018\Current" 2&gt;nul
-
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\Current\"
-
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2018\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2018\Current\"
-
-rmdir /S /Q "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders" 2&gt;nul
-rmdir /S /Q "$(SolutionDir)..\sandbox\max2018\Current\shaders" 2&gt;nul
-
-mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\max\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\appleseed\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2018\Current\shaders\max\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2018\Current\shaders\appleseed\" 2&gt;nul
-
-del /Q "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\max\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\appleseed\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2018\Current\shaders\max\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2018\Current\shaders\appleseed\*.oso" 2&gt;nul
-
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\max\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\appleseed\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2018\Current\shaders\max\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2018\Current\shaders\appleseed\"</Command>
-    </PostBuildEvent>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc140\ilmbase-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\openexr-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\oiio-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\osl-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\SeExpr-release\include;C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>
-      </DelayLoadDLLs>
-    </Link>
-    <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2018\Current" 2&gt;nul
-
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\Current\"
-
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2018\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2018\Current\"
-
-rmdir /S /Q "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders" 2&gt;nul
-rmdir /S /Q "$(SolutionDir)..\sandbox\max2018\Current\shaders" 2&gt;nul
-
-mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\max\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\appleseed\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2018\Current\shaders\max\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2018\Current\shaders\appleseed\" 2&gt;nul
-
-del /Q "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\max\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\appleseed\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2018\Current\shaders\max\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2018\Current\shaders\appleseed\*.oso" 2&gt;nul
-
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\max\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\appleseed\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2018\Current\shaders\max\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2018\Current\shaders\appleseed\"</Command>
-    </PostBuildEvent>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
-    <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc140\ilmbase-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\openexr-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\oiio-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\osl-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\SeExpr-release\include;C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>

--- a/src/appleseed-max-impl/appleseed-max2018-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2018-impl.vcxproj
@@ -18,7 +18,6 @@
     <ProjectGuid>{62C41566-DBCB-49D3-943A-4DD53222269E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>appleseedmax</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">

--- a/src/appleseed-max-impl/appleseed-max2018-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2018-impl.vcxproj
@@ -21,51 +21,34 @@
     <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="..\appleseed-max-debug.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\appleseed-max-release.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\appleseed-max-release.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
+  <PropertyGroup>
     <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>

--- a/src/appleseed-max-impl/appleseed-max2018-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2018-impl.vcxproj
@@ -18,6 +18,7 @@
     <ProjectGuid>{62C41566-DBCB-49D3-943A-4DD53222269E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>appleseedmax</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
@@ -64,7 +65,7 @@
     </Link>
     <PostBuildEvent>
       <Message>Moving output files...</Message>
-      <Command>post-build.cmd "$(SolutionDir)" "$(Configuration)" "$(TargetPath)" "$(TargetName)" "$(PlatformToolsetVersion)" "2018"</Command>
+      <Command>post-build.cmd "$(SolutionDir)" "$(Configuration)" "$(TargetDir)" "$(TargetName)" "$(PlatformToolsetVersion)" "2018"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/appleseed-max-impl/appleseed-max2018-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2018-impl.vcxproj
@@ -64,38 +64,8 @@
       </DelayLoadDLLs>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2018\Current" 2&gt;nul
-
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\Current\"
-
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2018\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2018\Current\"
-
-rmdir /S /Q "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders" 2&gt;nul
-rmdir /S /Q "$(SolutionDir)..\sandbox\max2018\Current\shaders" 2&gt;nul
-
-mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\max\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\appleseed\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2018\Current\shaders\max\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2018\Current\shaders\appleseed\" 2&gt;nul
-
-del /Q "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\max\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\appleseed\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2018\Current\shaders\max\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2018\Current\shaders\appleseed\*.oso" 2&gt;nul
-
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\max\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\shaders\appleseed\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2018\Current\shaders\max\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2018\Current\shaders\appleseed\"</Command>
+      <Message>Moving output files...</Message>
+      <Command>post-build.cmd "$(SolutionDir)" "$(Configuration)" "$(TargetPath)" "$(TargetName)" "$(PlatformToolsetVersion)" "2018"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/appleseed-max-impl/appleseed-max2019-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2019-impl.vcxproj
@@ -18,6 +18,7 @@
     <ProjectGuid>{62C41566-DBCB-49D3-943A-4DD53222269E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>appleseedmax</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">

--- a/src/appleseed-max-impl/appleseed-max2019-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2019-impl.vcxproj
@@ -21,51 +21,34 @@
     <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="..\appleseed-max-debug.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\appleseed-max-release.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\appleseed-max-release.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
+  <PropertyGroup>
     <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
@@ -130,20 +113,17 @@ copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(Solut
       <Command>mkdir "$(SolutionDir)..\sandbox\max2019\$(Configuration)" 2&gt;nul
 mkdir "$(SolutionDir)..\sandbox\max2019\Current" 2&gt;nul
 
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2019\Current\"
+xcopy /D /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
+xcopy /D /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2019\Current\"
 
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2019\Current\"
+if not "$(Configuration)" == "Ship" xcopy /D /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
+if not "$(Configuration)" == "Ship" xcopy /D /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2019\Current\"
 
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2019\Current\"
+xcopy /D /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
+xcopy /D /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2019\Current\"
 
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2019\Current\"
-
-rmdir /S /Q "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders" 2&gt;nul
-rmdir /S /Q "$(SolutionDir)..\sandbox\max2019\Current\shaders" 2&gt;nul
+if not "$(Configuration)" == "Ship" xcopy /D /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
+if not "$(Configuration)" == "Ship" xcopy /D /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2019\Current\"
 
 mkdir "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\max\" 2&gt;nul
 mkdir "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\appleseed\" 2&gt;nul
@@ -155,10 +135,10 @@ del /Q "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\appleseed\*.os
 del /Q "$(SolutionDir)..\sandbox\max2019\Current\shaders\max\*.oso" 2&gt;nul
 del /Q "$(SolutionDir)..\sandbox\max2019\Current\shaders\appleseed\*.oso" 2&gt;nul
 
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\max\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\appleseed\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2019\Current\shaders\max\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2019\Current\shaders\appleseed\"</Command>
+xcopy /D /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\max\"
+xcopy /D /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\appleseed\"
+xcopy /D /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2019\Current\shaders\max\"
+xcopy /D /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2019\Current\shaders\appleseed\"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">

--- a/src/appleseed-max-impl/appleseed-max2019-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2019-impl.vcxproj
@@ -18,7 +18,6 @@
     <ProjectGuid>{62C41566-DBCB-49D3-943A-4DD53222269E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>appleseedmax</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">

--- a/src/appleseed-max-impl/appleseed-max2019-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2019-impl.vcxproj
@@ -52,105 +52,12 @@
     <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  <ItemDefinitionGroup>
     <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc140\ilmbase-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\openexr-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\oiio-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\osl-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc140\SeExpr-debug\include;C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>
-      </DelayLoadDLLs>
-    </Link>
-    <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\sandbox\max2019\$(Configuration)" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2019\Current" 2&gt;nul
-
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2019\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2019\Current\"
-
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2019\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2019\Current\"
-
-rmdir /S /Q "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders" 2&gt;nul
-rmdir /S /Q "$(SolutionDir)..\sandbox\max2019\Current\shaders" 2&gt;nul
-
-mkdir "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\max\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\appleseed\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2019\Current\shaders\max\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2019\Current\shaders\appleseed\" 2&gt;nul
-
-del /Q "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\max\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\appleseed\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2019\Current\shaders\max\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2019\Current\shaders\appleseed\*.oso" 2&gt;nul
-
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\max\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\appleseed\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2019\Current\shaders\max\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2019\Current\shaders\appleseed\"</Command>
-    </PostBuildEvent>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc140\ilmbase-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\openexr-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\oiio-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\osl-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\SeExpr-release\include;C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>
-      </DelayLoadDLLs>
-    </Link>
-    <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\sandbox\max2019\$(Configuration)" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2019\Current" 2&gt;nul
-
-xcopy /D /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-xcopy /D /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2019\Current\"
-
-if not "$(Configuration)" == "Ship" xcopy /D /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-if not "$(Configuration)" == "Ship" xcopy /D /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2019\Current\"
-
-xcopy /D /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-xcopy /D /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2019\Current\"
-
-if not "$(Configuration)" == "Ship" xcopy /D /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-if not "$(Configuration)" == "Ship" xcopy /D /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2019\Current\"
-
-mkdir "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\max\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\appleseed\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2019\Current\shaders\max\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2019\Current\shaders\appleseed\" 2&gt;nul
-
-del /Q "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\max\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\appleseed\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2019\Current\shaders\max\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2019\Current\shaders\appleseed\*.oso" 2&gt;nul
-
-xcopy /D /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\max\"
-xcopy /D /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\appleseed\"
-xcopy /D /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2019\Current\shaders\max\"
-xcopy /D /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2019\Current\shaders\appleseed\"</Command>
-    </PostBuildEvent>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
-    <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc140\ilmbase-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\openexr-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\oiio-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\osl-release\include;$(SolutionDir)..\..\windows-deps\stage\vc140\SeExpr-release\include;C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>
-      </DelayLoadDLLs>
     </Link>
     <PostBuildEvent>
       <Command>mkdir "$(SolutionDir)..\sandbox\max2019\$(Configuration)" 2&gt;nul

--- a/src/appleseed-max-impl/appleseed-max2019-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2019-impl.vcxproj
@@ -60,38 +60,8 @@
       <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\sandbox\max2019\$(Configuration)" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2019\Current" 2&gt;nul
-
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2019\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2019\Current\"
-
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2019\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2019\Current\"
-
-rmdir /S /Q "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders" 2&gt;nul
-rmdir /S /Q "$(SolutionDir)..\sandbox\max2019\Current\shaders" 2&gt;nul
-
-mkdir "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\max\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\appleseed\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2019\Current\shaders\max\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2019\Current\shaders\appleseed\" 2&gt;nul
-
-del /Q "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\max\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\appleseed\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2019\Current\shaders\max\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2019\Current\shaders\appleseed\*.oso" 2&gt;nul
-
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\max\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\shaders\appleseed\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2019\Current\shaders\max\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2019\Current\shaders\appleseed\"</Command>
+      <Message>Moving output files...</Message>
+      <Command>post-build.cmd "$(SolutionDir)" "$(Configuration)" "$(TargetDir)" "$(TargetName)" "$(PlatformToolsetVersion)" "2019"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/appleseed-max-impl/appleseed-max2020-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2020-impl.vcxproj
@@ -60,38 +60,8 @@
       <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc141\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc141;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\sandbox\max2020\$(Configuration)" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2020\Current" 2&gt;nul
-
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2020\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2020\Current\"
-
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2020\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2020\Current\"
-
-rmdir /S /Q "$(SolutionDir)..\sandbox\max2020\$(Configuration)\shaders" 2&gt;nul
-rmdir /S /Q "$(SolutionDir)..\sandbox\max2020\Current\shaders" 2&gt;nul
-
-mkdir "$(SolutionDir)..\sandbox\max2020\$(Configuration)\shaders\max\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2020\$(Configuration)\shaders\appleseed\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2020\Current\shaders\max\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2020\Current\shaders\appleseed\" 2&gt;nul
-
-del /Q "$(SolutionDir)..\sandbox\max2020\$(Configuration)\shaders\max\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2020\$(Configuration)\shaders\appleseed\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2020\Current\shaders\max\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2020\Current\shaders\appleseed\*.oso" 2&gt;nul
-
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\shaders\max\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\shaders\appleseed\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2020\Current\shaders\max\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2020\Current\shaders\appleseed\"</Command>
+      <Message>Moving output files...</Message>
+      <Command>post-build.cmd "$(SolutionDir)" "$(Configuration)" "$(TargetPath)" "$(TargetName)" "$(PlatformToolsetVersion)" "2020"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/appleseed-max-impl/appleseed-max2020-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2020-impl.vcxproj
@@ -52,108 +52,12 @@
     <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  <ItemDefinitionGroup>
     <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
       <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc141\ilmbase-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc141\openexr-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc141\oiio-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc141\osl-debug\include;$(SolutionDir)..\..\windows-deps\stage\vc141\SeExpr-debug\include;C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc141\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc141;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>
-      </DelayLoadDLLs>
-    </Link>
-    <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\sandbox\max2020\$(Configuration)" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2020\Current" 2&gt;nul
-
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2020\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2020\Current\"
-
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2020\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2020\Current\"
-
-rmdir /S /Q "$(SolutionDir)..\sandbox\max2020\$(Configuration)\shaders" 2&gt;nul
-rmdir /S /Q "$(SolutionDir)..\sandbox\max2020\Current\shaders" 2&gt;nul
-
-mkdir "$(SolutionDir)..\sandbox\max2020\$(Configuration)\shaders\max\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2020\$(Configuration)\shaders\appleseed\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2020\Current\shaders\max\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2020\Current\shaders\appleseed\" 2&gt;nul
-
-del /Q "$(SolutionDir)..\sandbox\max2020\$(Configuration)\shaders\max\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2020\$(Configuration)\shaders\appleseed\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2020\Current\shaders\max\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2020\Current\shaders\appleseed\*.oso" 2&gt;nul
-
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\shaders\max\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\shaders\appleseed\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2020\Current\shaders\max\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2020\Current\shaders\appleseed\"</Command>
-    </PostBuildEvent>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc141\ilmbase-release\include;$(SolutionDir)..\..\windows-deps\stage\vc141\openexr-release\include;$(SolutionDir)..\..\windows-deps\stage\vc141\oiio-release\include;$(SolutionDir)..\..\windows-deps\stage\vc141\osl-release\include;$(SolutionDir)..\..\windows-deps\stage\vc141\SeExpr-release\include;C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc141\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc141;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>
-      </DelayLoadDLLs>
-    </Link>
-    <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\sandbox\max2020\$(Configuration)" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2020\Current" 2&gt;nul
-
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2020\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2020\Current\"
-
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.dll" "$(SolutionDir)..\sandbox\max2020\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(SolutionDir)..\..\appleseed\sandbox\bin\vc$(PlatformToolsetVersion)\$(Configuration)\appleseed.pdb" "$(SolutionDir)..\sandbox\max2020\Current\"
-
-rmdir /S /Q "$(SolutionDir)..\sandbox\max2020\$(Configuration)\shaders" 2&gt;nul
-rmdir /S /Q "$(SolutionDir)..\sandbox\max2020\Current\shaders" 2&gt;nul
-
-mkdir "$(SolutionDir)..\sandbox\max2020\$(Configuration)\shaders\max\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2020\$(Configuration)\shaders\appleseed\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2020\Current\shaders\max\" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2020\Current\shaders\appleseed\" 2&gt;nul
-
-del /Q "$(SolutionDir)..\sandbox\max2020\$(Configuration)\shaders\max\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2020\$(Configuration)\shaders\appleseed\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2020\Current\shaders\max\*.oso" 2&gt;nul
-del /Q "$(SolutionDir)..\sandbox\max2020\Current\shaders\appleseed\*.oso" 2&gt;nul
-
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\shaders\max\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\shaders\appleseed\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\max\*.oso" "$(SolutionDir)..\sandbox\max2020\Current\shaders\max\"
-copy /Y "$(SolutionDir)..\..\appleseed\sandbox\shaders\appleseed\*.oso" "$(SolutionDir)..\sandbox\max2020\Current\shaders\appleseed\"</Command>
-    </PostBuildEvent>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
-    <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\..\windows-deps\stage\vc141\ilmbase-release\include;$(SolutionDir)..\..\windows-deps\stage\vc141\openexr-release\include;$(SolutionDir)..\..\windows-deps\stage\vc141\oiio-release\include;$(SolutionDir)..\..\windows-deps\stage\vc141\osl-release\include;$(SolutionDir)..\..\windows-deps\stage\vc141\SeExpr-release\include;C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc141\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc141;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>
-      </DelayLoadDLLs>
     </Link>
     <PostBuildEvent>
       <Command>mkdir "$(SolutionDir)..\sandbox\max2020\$(Configuration)" 2&gt;nul

--- a/src/appleseed-max-impl/appleseed-max2020-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2020-impl.vcxproj
@@ -21,51 +21,34 @@
     <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="..\appleseed-max-debug.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\appleseed-max-release.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\appleseed-max-release.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
+  <PropertyGroup>
     <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>

--- a/src/appleseed-max-impl/appleseed-max2020-impl.vcxproj
+++ b/src/appleseed-max-impl/appleseed-max2020-impl.vcxproj
@@ -61,7 +61,7 @@
     </Link>
     <PostBuildEvent>
       <Message>Moving output files...</Message>
-      <Command>post-build.cmd "$(SolutionDir)" "$(Configuration)" "$(TargetPath)" "$(TargetName)" "$(PlatformToolsetVersion)" "2020"</Command>
+      <Command>post-build.cmd "$(SolutionDir)" "$(Configuration)" "$(TargetDir)" "$(TargetName)" "$(PlatformToolsetVersion)" "2020"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/appleseed-max-impl/post-build.cmd
+++ b/src/appleseed-max-impl/post-build.cmd
@@ -1,0 +1,52 @@
+@echo off
+
+set solution=%~1
+set configuration=%~2
+set targetdir=%~3
+set targetname=%~4
+set toolset=%~5
+set maxversion=%~6
+
+set outdirBase=%solution%..\sandbox\max%maxversion%
+set outdirA=%outdirBase%\%configuration%
+set outdirB=%outdirBase%\Current
+set targetPath=%targetdir%%targetname%
+
+mkdir "%outdirA%" 2>nul
+mkdir "%outdirB%" 2>nul
+
+copy /Y "%targetPath%.dll" "%outdirA%\"
+copy /Y "%targetPath%.dll" "%outdirB%\"
+
+if not "%configuration%"=="Ship" (
+  copy /Y "%targetPath%.pdb" "%outdirA%\"
+  copy /Y "%targetPath%.pdb" "%outdirB%\"
+)
+
+set targetPath=%solution%\..\..\appleseed\sandbox\bin\vc%toolset%\%configuration%\appleseed
+copy /Y "%targetPath%.dll" "%outdirA%\"
+copy /Y "%targetPath%.dll" "%outdirB%\"
+
+if not "%configuration%"=="Ship" (
+  copy /Y "%targetPath%.pdb" "%outdirA%\"
+  copy /Y "%targetPath%.pdb" "%outdirB%\"
+)
+
+rmdir /S /Q "%outdirA%\shaders" 2>nul
+rmdir /S /Q "%outdirB%\shaders" 2>nul
+
+mkdir "%outdirA%\shaders\max\" 2>nul
+mkdir "%outdirA%\shaders\appleseed\" 2>nul
+mkdir "%outdirB%\shaders\max\" 2>nul
+mkdir "%outdirB%\shaders\appleseed\" 2>nul
+
+del /Q "%outdirA%\shaders\max\*.oso" 2>nul
+del /Q "%outdirA%\shaders\appleseed\*.oso" 2>nul
+del /Q "%outdirB%\shaders\max\*.oso" 2>nul
+del /Q "%outdirB%\shaders\appleseed\*.oso" 2>nul
+
+set shadersdir=%solution%..\..\appleseed\sandbox\shaders
+copy /Y "%shadersdir%\max\*.oso" "%outdirA%\shaders\max\"
+copy /Y "%shadersdir%\appleseed\*.oso" "%outdirA%\shaders\appleseed\"
+copy /Y "%shadersdir%\max\*.oso" "%outdirB%\shaders\max\"
+copy /Y "%shadersdir%\appleseed\*.oso" "%outdirB%\shaders\appleseed\"

--- a/src/appleseed-max/appleseed-max2017.vcxproj
+++ b/src/appleseed-max/appleseed-max2017.vcxproj
@@ -30,7 +30,6 @@
     <ProjectGuid>{F43B3C0E-2A72-4B30-9016-DEC6B022D135}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>appleseedmax</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">

--- a/src/appleseed-max/appleseed-max2017.vcxproj
+++ b/src/appleseed-max/appleseed-max2017.vcxproj
@@ -33,53 +33,34 @@
     <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="..\appleseed-max-debug.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\appleseed-max-release.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\appleseed-max-release.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-    <TargetExt>.dlr</TargetExt>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-    <TargetExt>.dlr</TargetExt>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
+  <PropertyGroup>
     <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <TargetExt>.dlr</TargetExt>

--- a/src/appleseed-max/appleseed-max2017.vcxproj
+++ b/src/appleseed-max/appleseed-max2017.vcxproj
@@ -30,6 +30,7 @@
     <ProjectGuid>{F43B3C0E-2A72-4B30-9016-DEC6B022D135}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>appleseedmax</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
@@ -73,7 +74,7 @@
     </Link>
     <PostBuildEvent>
       <Message>Moving output files...</Message>
-      <Command>post-build.cmd "$(SolutionDir)" "$(Configuration)" "$(TargetPath)" "$(TargetName)" "$(PlatformToolsetVersion)" "2017"</Command>
+      <Command>post-build.cmd "$(SolutionDir)" "$(Configuration)" "$(TargetDir)" "$(TargetName)" "$(PlatformToolsetVersion)" "2017"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/appleseed-max/appleseed-max2017.vcxproj
+++ b/src/appleseed-max/appleseed-max2017.vcxproj
@@ -73,14 +73,8 @@
       <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\sandbox\max2017\$(Configuration)" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2017\Current" 2&gt;nul
-
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2017\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2017\Current\"</Command>
+      <Message>Moving output files...</Message>
+      <Command>post-build.cmd "$(SolutionDir)" "$(Configuration)" "$(TargetPath)" "$(TargetName)" "$(PlatformToolsetVersion)" "2017"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/appleseed-max/appleseed-max2017.vcxproj
+++ b/src/appleseed-max/appleseed-max2017.vcxproj
@@ -65,60 +65,12 @@
     <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <TargetExt>.dlr</TargetExt>
   </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  <ItemDefinitionGroup>
     <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
       <AdditionalIncludeDirectories>C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>
-      </DelayLoadDLLs>
-    </Link>
-    <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\sandbox\max2017\$(Configuration)" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2017\Current" 2&gt;nul
-
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2017\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2017\Current\"</Command>
-    </PostBuildEvent>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
-      <AdditionalIncludeDirectories>C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>
-      </DelayLoadDLLs>
-    </Link>
-    <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\sandbox\max2017\$(Configuration)" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2017\Current" 2&gt;nul
-
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2017\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2017\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2017\Current\"</Command>
-    </PostBuildEvent>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
-    <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
-      <AdditionalIncludeDirectories>C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2017 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>
-      </DelayLoadDLLs>
     </Link>
     <PostBuildEvent>
       <Command>mkdir "$(SolutionDir)..\sandbox\max2017\$(Configuration)" 2&gt;nul

--- a/src/appleseed-max/appleseed-max2018.vcxproj
+++ b/src/appleseed-max/appleseed-max2018.vcxproj
@@ -30,7 +30,6 @@
     <ProjectGuid>{F43B3C0E-2A72-4B30-9016-DEC6B022D135}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>appleseedmax</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">

--- a/src/appleseed-max/appleseed-max2018.vcxproj
+++ b/src/appleseed-max/appleseed-max2018.vcxproj
@@ -33,53 +33,34 @@
     <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="..\appleseed-max-debug.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\appleseed-max-release.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\appleseed-max-release.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-    <TargetExt>.dlr</TargetExt>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-    <TargetExt>.dlr</TargetExt>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
+  <PropertyGroup>
     <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <TargetExt>.dlr</TargetExt>

--- a/src/appleseed-max/appleseed-max2018.vcxproj
+++ b/src/appleseed-max/appleseed-max2018.vcxproj
@@ -65,60 +65,12 @@
     <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <TargetExt>.dlr</TargetExt>
   </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  <ItemDefinitionGroup>
     <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
       <AdditionalIncludeDirectories>C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>
-      </DelayLoadDLLs>
-    </Link>
-    <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2018\Current" 2&gt;nul
-
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\Current\"</Command>
-    </PostBuildEvent>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
-      <AdditionalIncludeDirectories>C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>
-      </DelayLoadDLLs>
-    </Link>
-    <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2018\Current" 2&gt;nul
-
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\Current\"</Command>
-    </PostBuildEvent>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
-    <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
-      <AdditionalIncludeDirectories>C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>
-      </DelayLoadDLLs>
     </Link>
     <PostBuildEvent>
       <Command>mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)" 2&gt;nul

--- a/src/appleseed-max/appleseed-max2018.vcxproj
+++ b/src/appleseed-max/appleseed-max2018.vcxproj
@@ -73,14 +73,8 @@
       <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2018 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\sandbox\max2018\$(Configuration)" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2018\Current" 2&gt;nul
-
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2018\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2018\Current\"</Command>
+      <Message>Moving output files...</Message>
+      <Command>post-build.cmd "$(SolutionDir)" "$(Configuration)" "$(TargetPath)" "$(TargetName)" "$(PlatformToolsetVersion)" "2018"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/appleseed-max/appleseed-max2018.vcxproj
+++ b/src/appleseed-max/appleseed-max2018.vcxproj
@@ -30,6 +30,7 @@
     <ProjectGuid>{F43B3C0E-2A72-4B30-9016-DEC6B022D135}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>appleseedmax</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
@@ -73,7 +74,7 @@
     </Link>
     <PostBuildEvent>
       <Message>Moving output files...</Message>
-      <Command>post-build.cmd "$(SolutionDir)" "$(Configuration)" "$(TargetPath)" "$(TargetName)" "$(PlatformToolsetVersion)" "2018"</Command>
+      <Command>post-build.cmd "$(SolutionDir)" "$(Configuration)" "$(TargetDir)" "$(TargetName)" "$(PlatformToolsetVersion)" "2018"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/appleseed-max/appleseed-max2019.vcxproj
+++ b/src/appleseed-max/appleseed-max2019.vcxproj
@@ -30,7 +30,6 @@
     <ProjectGuid>{F43B3C0E-2A72-4B30-9016-DEC6B022D135}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>appleseedmax</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">

--- a/src/appleseed-max/appleseed-max2019.vcxproj
+++ b/src/appleseed-max/appleseed-max2019.vcxproj
@@ -33,53 +33,34 @@
     <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="..\appleseed-max-debug.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\appleseed-max-release.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\appleseed-max-release.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-    <TargetExt>.dlr</TargetExt>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-    <TargetExt>.dlr</TargetExt>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
+  <PropertyGroup>
     <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <TargetExt>.dlr</TargetExt>

--- a/src/appleseed-max/appleseed-max2019.vcxproj
+++ b/src/appleseed-max/appleseed-max2019.vcxproj
@@ -65,60 +65,12 @@
     <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <TargetExt>.dlr</TargetExt>
   </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  <ItemDefinitionGroup>
     <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
       <AdditionalIncludeDirectories>C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>
-      </DelayLoadDLLs>
-    </Link>
-    <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\sandbox\max2019\$(Configuration)" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2019\Current" 2&gt;nul
-
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2019\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2019\Current\"</Command>
-    </PostBuildEvent>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
-      <AdditionalIncludeDirectories>C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>
-      </DelayLoadDLLs>
-    </Link>
-    <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\sandbox\max2019\$(Configuration)" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2019\Current" 2&gt;nul
-
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2019\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2019\Current\"</Command>
-    </PostBuildEvent>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
-    <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
-      <AdditionalIncludeDirectories>C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>
-      </DelayLoadDLLs>
     </Link>
     <PostBuildEvent>
       <Command>mkdir "$(SolutionDir)..\sandbox\max2019\$(Configuration)" 2&gt;nul

--- a/src/appleseed-max/appleseed-max2019.vcxproj
+++ b/src/appleseed-max/appleseed-max2019.vcxproj
@@ -30,6 +30,7 @@
     <ProjectGuid>{F43B3C0E-2A72-4B30-9016-DEC6B022D135}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>appleseedmax</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">

--- a/src/appleseed-max/appleseed-max2019.vcxproj
+++ b/src/appleseed-max/appleseed-max2019.vcxproj
@@ -73,14 +73,8 @@
       <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2019 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc140\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc140;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\sandbox\max2019\$(Configuration)" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2019\Current" 2&gt;nul
-
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2019\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2019\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2019\Current\"</Command>
+      <Message>Moving output files...</Message>
+      <Command>post-build.cmd "$(SolutionDir)" "$(Configuration)" "$(TargetDir)" "$(TargetName)" "$(PlatformToolsetVersion)" "2019"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/appleseed-max/appleseed-max2020.vcxproj
+++ b/src/appleseed-max/appleseed-max2020.vcxproj
@@ -73,14 +73,8 @@
       <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc141\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc141;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\sandbox\max2020\$(Configuration)" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2020\Current" 2&gt;nul
-
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2020\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2020\Current\"</Command>
+      <Message>Moving output files...</Message>
+      <Command>post-build.cmd "$(SolutionDir)" "$(Configuration)" "$(TargetPath)" "$(TargetName)" "$(PlatformToolsetVersion)" "2020"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/appleseed-max/appleseed-max2020.vcxproj
+++ b/src/appleseed-max/appleseed-max2020.vcxproj
@@ -74,7 +74,7 @@
     </Link>
     <PostBuildEvent>
       <Message>Moving output files...</Message>
-      <Command>post-build.cmd "$(SolutionDir)" "$(Configuration)" "$(TargetPath)" "$(TargetName)" "$(PlatformToolsetVersion)" "2020"</Command>
+      <Command>post-build.cmd "$(SolutionDir)" "$(Configuration)" "$(TargetDir)" "$(TargetName)" "$(PlatformToolsetVersion)" "2020"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/appleseed-max/appleseed-max2020.vcxproj
+++ b/src/appleseed-max/appleseed-max2020.vcxproj
@@ -33,53 +33,34 @@
     <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="..\appleseed-max-debug.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\appleseed-max-release.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\appleseed-max-release.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-    <TargetExt>.dlr</TargetExt>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-    <TargetExt>.dlr</TargetExt>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
+  <PropertyGroup>
     <OutDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <TargetExt>.dlr</TargetExt>

--- a/src/appleseed-max/appleseed-max2020.vcxproj
+++ b/src/appleseed-max/appleseed-max2020.vcxproj
@@ -65,60 +65,12 @@
     <IntDir>$(SolutionDir)..\build\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <TargetExt>.dlr</TargetExt>
   </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  <ItemDefinitionGroup>
     <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
       <AdditionalIncludeDirectories>C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc141\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc141;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>
-      </DelayLoadDLLs>
-    </Link>
-    <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\sandbox\max2020\$(Configuration)" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2020\Current" 2&gt;nul
-
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2020\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2020\Current\"</Command>
-    </PostBuildEvent>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
-      <AdditionalIncludeDirectories>C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc141\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc141;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>
-      </DelayLoadDLLs>
-    </Link>
-    <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)..\sandbox\max2020\$(Configuration)" 2&gt;nul
-mkdir "$(SolutionDir)..\sandbox\max2020\Current" 2&gt;nul
-
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
-copy /Y "$(TargetPath)" "$(SolutionDir)..\sandbox\max2020\Current\"
-
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2020\$(Configuration)\"
-if not "$(Configuration)" == "Ship" copy /Y "$(TargetDir)\$(TargetName).pdb" "$(SolutionDir)..\sandbox\max2020\Current\"</Command>
-    </PostBuildEvent>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Ship|x64'">
-    <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
-      <AdditionalIncludeDirectories>C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-    </ClCompile>
-    <Link>
-      <AdditionalLibraryDirectories>C:\Program Files\Autodesk\3ds Max 2020 SDK\maxsdk\lib\x64\Release;$(SolutionDir)..\..\appleseed\sandbox\lib\vc141\$(ConfigurationName);$(SolutionDir)..\..\windows-deps\stage\vc141;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <DelayLoadDLLs>
-      </DelayLoadDLLs>
     </Link>
     <PostBuildEvent>
       <Command>mkdir "$(SolutionDir)..\sandbox\max2020\$(Configuration)" 2&gt;nul

--- a/src/appleseed-max/post-build.cmd
+++ b/src/appleseed-max/post-build.cmd
@@ -1,0 +1,24 @@
+@echo off
+
+set solution=%~1
+set configuration=%~2
+set targetdir=%~3
+set targetname=%~4
+set toolset=%~5
+set maxversion=%~6
+
+set outdirBase=%solution%..\sandbox\max%maxversion%
+set outdirA=%outdirBase%\%configuration%
+set outdirB=%outdirBase%\Current
+set targetPath=%targetdir%%targetname%
+
+mkdir "%outdirA%" 2>nul
+mkdir "%outdirB%" 2>nul
+
+copy /Y "%targetPath%.dlr" "%outdirA%\"
+copy /Y "%targetPath%.dlr" "%outdirB%\"
+
+if not "%configuration%"=="Ship" (
+  copy /Y "%targetPath%.pdb" "%outdirA%\"
+  copy /Y "%targetPath%.pdb" "%outdirB%\"
+)


### PR DESCRIPTION
Here's a suggested change to simplify maintenance of multiple VS projects.

## Main changes:
* Define most common properties first, specialize with conditions when necessary
* Use common post-build scripts
* Remove explicit windows platform specification (if needed it should be added to `.user` files)

Please note that while I've tried to maintain same behavior in all cases, I was unable to test all configurations (I don't have all SDKs). As such please take extra care to verify if it works as expected.