### PR TITLE
Fix partly visible Map buttons in legacy shader UI

### DIFF
--- a/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.rc
+++ b/src/appleseed-max-impl/appleseeddisneymtl/appleseeddisneymtl.rc
@@ -59,47 +59,47 @@ BEGIN
     CONTROL         "Base Color Map",IDC_TEXMAP_BASE_COLOR,"CustButton",WS_TABSTOP,101,6,109,10
     LTEXT           "Metallic:",IDC_LABEL_METALLIC,7,18,48,8
     CONTROL         "Metallic Edit",IDC_EDIT_METALLIC,"CustEdit",WS_TABSTOP,69,18,30,10
-    CONTROL         "Metallic Slider",IDC_SLIDER_METALLIC,"SliderControl",WS_TABSTOP,101,18,97,13
-    CONTROL         "Metallic Map",IDC_TEXMAP_METALLIC,"CustButton",WS_TABSTOP,200,18,10,10
+    CONTROL         "Metallic Slider",IDC_SLIDER_METALLIC,"SliderControl",WS_TABSTOP,101,18,79,13
+    CONTROL         "Metallic Map",IDC_TEXMAP_METALLIC,"CustButton",WS_TABSTOP,182,18,28,10
     LTEXT           "Specular:",IDC_LABEL_SPECULAR,7,30,48,8
     CONTROL         "Specular Edit",IDC_EDIT_SPECULAR,"CustEdit",WS_TABSTOP,69,30,30,10
-    CONTROL         "Specular Slider",IDC_SLIDER_SPECULAR,"SliderControl",WS_TABSTOP,101,30,97,13
-    CONTROL         "Specular Map",IDC_TEXMAP_SPECULAR,"CustButton",WS_TABSTOP,200,30,10,10
+    CONTROL         "Specular Slider",IDC_SLIDER_SPECULAR,"SliderControl",WS_TABSTOP,101,30,79,13
+    CONTROL         "Specular Map",IDC_TEXMAP_SPECULAR,"CustButton",WS_TABSTOP,182,30,28,10
     LTEXT           "Specular Tint:",IDC_LABEL_SPECULAR_TINT,7,42,48,8
     CONTROL         "Specular Tint Edit",IDC_EDIT_SPECULAR_TINT,"CustEdit",WS_TABSTOP,69,42,30,10
     CONTROL         "Specular Tint Slider",IDC_SLIDER_SPECULAR_TINT,
-                    "SliderControl",WS_TABSTOP,101,42,97,13
-    CONTROL         "Specular Tint Map",IDC_TEXMAP_SPECULAR_TINT,"CustButton",WS_TABSTOP,200,42,10,10
+                    "SliderControl",WS_TABSTOP,101,42,79,13
+    CONTROL         "Specular Tint Map",IDC_TEXMAP_SPECULAR_TINT,"CustButton",WS_TABSTOP,182,42,28,10
     LTEXT           "Roughness:",IDC_LABEL_ROUGHNESS,7,54,48,8
     CONTROL         "Roughness Edit",IDC_EDIT_ROUGHNESS,"CustEdit",WS_TABSTOP,69,54,30,10
-    CONTROL         "Roughness Slider",IDC_SLIDER_ROUGHNESS,"SliderControl",WS_TABSTOP,101,54,97,13
-    CONTROL         "Roughness Map",IDC_TEXMAP_ROUGHNESS,"CustButton",WS_TABSTOP,200,54,10,10
+    CONTROL         "Roughness Slider",IDC_SLIDER_ROUGHNESS,"SliderControl",WS_TABSTOP,101,54,79,13
+    CONTROL         "Roughness Map",IDC_TEXMAP_ROUGHNESS,"CustButton",WS_TABSTOP,182,54,28,10
     LTEXT           "Sheen:",IDC_LABEL_SHEEN,7,66,48,8
     CONTROL         "Sheen Edit",IDC_EDIT_SHEEN,"CustEdit",WS_TABSTOP,69,66,30,10
-    CONTROL         "Sheen Slider",IDC_SLIDER_SHEEN,"SliderControl",WS_TABSTOP,101,66,97,13
-    CONTROL         "Sheen Map",IDC_TEXMAP_SHEEN,"CustButton",WS_TABSTOP,200,66,10,10
+    CONTROL         "Sheen Slider",IDC_SLIDER_SHEEN,"SliderControl",WS_TABSTOP,101,66,79,13
+    CONTROL         "Sheen Map",IDC_TEXMAP_SHEEN,"CustButton",WS_TABSTOP,182,66,28,10
     LTEXT           "Sheen Tint:",IDC_LABEL_SHEEN_TINT,7,78,48,8
     CONTROL         "Sheen Tint Edit",IDC_EDIT_SHEEN_TINT,"CustEdit",WS_TABSTOP,69,78,30,10
-    CONTROL         "Sheen Tint Slider",IDC_SLIDER_SHEEN_TINT,"SliderControl",WS_TABSTOP,101,78,97,13
-    CONTROL         "Sheen Tint Map",IDC_TEXMAP_SHEEN_TINT,"CustButton",WS_TABSTOP,200,78,10,10
+    CONTROL         "Sheen Tint Slider",IDC_SLIDER_SHEEN_TINT,"SliderControl",WS_TABSTOP,101,78,79,13
+    CONTROL         "Sheen Tint Map",IDC_TEXMAP_SHEEN_TINT,"CustButton",WS_TABSTOP,182,78,28,10
     LTEXT           "Anisotropy:",IDC_LABEL_ANISOTROPY,7,90,48,8
     CONTROL         "Anisotropy Edit",IDC_EDIT_ANISOTROPY,"CustEdit",WS_TABSTOP,69,90,30,10
-    CONTROL         "Anisotropy Slider",IDC_SLIDER_ANISOTROPY,"SliderControl",WS_TABSTOP,101,90,97,13
-    CONTROL         "Anisotropy Map",IDC_TEXMAP_ANISOTROPY,"CustButton",WS_TABSTOP,200,90,10,10
+    CONTROL         "Anisotropy Slider",IDC_SLIDER_ANISOTROPY,"SliderControl",WS_TABSTOP,101,90,79,13
+    CONTROL         "Anisotropy Map",IDC_TEXMAP_ANISOTROPY,"CustButton",WS_TABSTOP,182,90,28,10
     LTEXT           "Clearcoat:",IDC_LABEL_CLEARCOAT,7,102,48,8
     CONTROL         "Clearcoat Edit",IDC_EDIT_CLEARCOAT,"CustEdit",WS_TABSTOP,69,102,30,10
-    CONTROL         "Clearcoat Slider",IDC_SLIDER_CLEARCOAT,"SliderControl",WS_TABSTOP,101,102,97,13
-    CONTROL         "Clearcoat Map",IDC_TEXMAP_CLEARCOAT,"CustButton",WS_TABSTOP,200,102,10,10
+    CONTROL         "Clearcoat Slider",IDC_SLIDER_CLEARCOAT,"SliderControl",WS_TABSTOP,101,102,79,13
+    CONTROL         "Clearcoat Map",IDC_TEXMAP_CLEARCOAT,"CustButton",WS_TABSTOP,182,102,28,10
     LTEXT           "Clearcoat Gloss:",IDC_LABEL_CLEARCOAT_GLOSS,7,114,56,8
     CONTROL         "Clearcoat Gloss Edit",IDC_EDIT_CLEARCOAT_GLOSS,"CustEdit",WS_TABSTOP,69,114,30,10
     CONTROL         "Clearcoat Gloss Slider",IDC_SLIDER_CLEARCOAT_GLOSS,
-                    "SliderControl",WS_TABSTOP,101,114,97,13
+                    "SliderControl",WS_TABSTOP,101,114,79,13
     CONTROL         "Clearcoat Gloss Map",IDC_TEXMAP_CLEARCOAT_GLOSS,
-                    "CustButton",WS_TABSTOP,200,114,10,10
+                    "CustButton",WS_TABSTOP,182,114,28,10
     LTEXT           "Alpha:",IDC_LABEL_ALPHA,7,126,48,8
     CONTROL         "Alpha Edit",IDC_EDIT_ALPHA,"CustEdit",WS_TABSTOP,69,126,30,10
-    CONTROL         "Alpha Slider",IDC_SLIDER_ALPHA,"SliderControl",WS_TABSTOP,101,126,97,13
-    CONTROL         "Alpha Map",IDC_TEXMAP_ALPHA,"CustButton",WS_TABSTOP,200,126,10,10
+    CONTROL         "Alpha Slider",IDC_SLIDER_ALPHA,"SliderControl",WS_TABSTOP,101,126,79,13
+    CONTROL         "Alpha Map",IDC_TEXMAP_ALPHA,"CustButton",WS_TABSTOP,182,126,28,10
 END
 
 
@@ -113,7 +113,7 @@ GUIDELINES DESIGNINFO
 BEGIN
     IDD_FORMVIEW_PARAMS, DIALOG
     BEGIN
-        VERTGUIDE, 198
+        VERTGUIDE, 180
         VERTGUIDE, 210
     END
 END

--- a/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.rc
+++ b/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.rc
@@ -58,41 +58,34 @@ BEGIN
     CONTROL         "Surface Color Swatch",IDC_SWATCH_SURFACE_COLOR,
                     "ColorSwatch",WS_TABSTOP,69,6,30,10
     CONTROL         "Surface Color Map",IDC_TEXMAP_SURFACE_COLOR,"CustButton",WS_TABSTOP,101,6,109,10
-
     LTEXT           "Reflection Tint:",IDC_LABEL_REFLECTION_TINT,7,18,48,8
     CONTROL         "Reflection Tint Swatch",IDC_SWATCH_REFLECTION_TINT,
                     "ColorSwatch",WS_TABSTOP,69,18,30,10
     CONTROL         "Reflection Tint Map",IDC_TEXMAP_REFLECTION_TINT,
                     "CustButton",WS_TABSTOP,101,18,109,10
-
     LTEXT           "Refraction Tint:",IDC_LABEL_REFRACTION_TINT,7,30,48,8
     CONTROL         "Refraction Tint Swatch",IDC_SWATCH_REFRACTION_TINT,
                     "ColorSwatch",WS_TABSTOP,69,30,30,10
     CONTROL         "Refraction Tint Map",IDC_TEXMAP_REFRACTION_TINT,
                     "CustButton",WS_TABSTOP,101,30,109,10
-
     LTEXT           "IOR:",IDC_LABEL_IOR,7,42,48,8
     CONTROL         "IOR Edit",IDC_EDIT_IOR,"CustEdit",WS_TABSTOP,69,42,30,10
-    CONTROL         "IOR Slider",IDC_SLIDER_IOR,"SliderControl",WS_TABSTOP,101,42,97,13
-
+    CONTROL         "IOR Slider",IDC_SLIDER_IOR,"SliderControl",WS_TABSTOP,101,42,79,13
     LTEXT           "Roughness:",IDC_LABEL_ROUGHNESS,7,54,55,8
     CONTROL         "Roughness Edit",IDC_EDIT_ROUGHNESS,"CustEdit",WS_TABSTOP,69,54,30,10
-    CONTROL         "Roughness Slider",IDC_SLIDER_ROUGHNESS,"SliderControl",WS_TABSTOP,101,54,97,13
-    CONTROL         "Roughness Map",IDC_TEXMAP_ROUGHNESS,"CustButton",WS_TABSTOP,200,54,10,10
-
+    CONTROL         "Roughness Slider",IDC_SLIDER_ROUGHNESS,"SliderControl",WS_TABSTOP,101,54,79,13
+    CONTROL         "Roughness Map",IDC_TEXMAP_ROUGHNESS,"CustButton",WS_TABSTOP,182,54,28,10
     LTEXT           "Anisotropy:",IDC_LABEL_ANISOTROPY,7,66,48,8
     CONTROL         "Anisotropy Edit",IDC_EDIT_ANISOTROPY,"CustEdit",WS_TABSTOP,69,66,30,10
-    CONTROL         "Anisotropy Slider",IDC_SLIDER_ANISOTROPY,"SliderControl",WS_TABSTOP,101,66,97,13
-    CONTROL         "Anisotropy Map",IDC_TEXMAP_ANISOTROPY,"CustButton",WS_TABSTOP,200,66,10,10
-
+    CONTROL         "Anisotropy Slider",IDC_SLIDER_ANISOTROPY,"SliderControl",WS_TABSTOP,101,66,79,13
+    CONTROL         "Anisotropy Map",IDC_TEXMAP_ANISOTROPY,"CustButton",WS_TABSTOP,182,66,28,10
     LTEXT           "Volume Color:",IDC_LABEL_VOLUME_COLOR,7,78,48,8
     CONTROL         "Volume Color Swatch",IDC_SWATCH_VOLUME_COLOR,
                     "ColorSwatch",WS_TABSTOP,69,78,30,10
     CONTROL         "Volume Color Map",IDC_TEXMAP_VOLUME_COLOR,"CustButton",WS_TABSTOP,101,78,109,10
-
     LTEXT           "Scale:",IDC_LABEL_SCALE,7,90,48,8
-    CONTROL         "Scale Edit",IDC_EDIT_SCALE,"CustEdit",WS_TABSTOP,69,90,30,10
-    CONTROL         "Scale Spinner",IDC_SPINNER_SCALE,"SpinnerControl",WS_TABSTOP,101,90,6,10
+    CONTROL         "Scale Edit",IDC_EDIT_SCALE,"CustEdit",WS_TABSTOP,69,90,25,10
+    CONTROL         "Scale Spinner",IDC_SPINNER_SCALE,"SpinnerControl",WS_TABSTOP,91,90,6,10
 END
 
 
@@ -106,7 +99,7 @@ GUIDELINES DESIGNINFO
 BEGIN
     IDD_FORMVIEW_PARAMS, DIALOG
     BEGIN
-        VERTGUIDE, 198
+        VERTGUIDE, 180
         VERTGUIDE, 210
     END
 END

--- a/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.rc
+++ b/src/appleseed-max-impl/appleseedlightmtl/appleseedlightmtl.rc
@@ -55,16 +55,16 @@ STYLE DS_SETFONT | WS_CHILD | WS_VISIBLE
 FONT 8, "MS Sans Serif", 0, 0, 0x1
 BEGIN
     LTEXT           "Light Color:",IDC_LABEL_LIGHT_COLOR,7,6,48,8
-    CONTROL         "Light Color Swatch",IDC_SWATCH_LIGHT_COLOR,"ColorSwatch",WS_TABSTOP,69,6,30,10
-    CONTROL         "Light Color Map",IDC_TEXMAP_LIGHT_COLOR,"CustButton",WS_TABSTOP,101,6,109,10
+    CONTROL         "Light Color Swatch",IDC_SWATCH_LIGHT_COLOR,"ColorSwatch",WS_TABSTOP,69,6,40,10
+    CONTROL         "Light Color Map",IDC_TEXMAP_LIGHT_COLOR,"CustButton",WS_TABSTOP,111,6,99,10
     LTEXT           "Light Power:",IDC_LABEL_LIGHT_POWER,7,18,48,8
     CONTROL         "Light Power Edit",IDC_EDIT_LIGHT_POWER,"CustEdit",WS_TABSTOP,69,18,30,10
     CONTROL         "Light Power Spinner",IDC_SPINNER_LIGHT_POWER,
                     "SpinnerControl",WS_TABSTOP,101,18,6,10
-    LTEXT           "Light Exposure:", IDC_LABEL_LIGHT_EXPOSURE,7,30,48,8
-    CONTROL         "Light Exposure Edit", IDC_EDIT_LIGHT_EXPOSURE, "CustEdit", WS_TABSTOP,69,30,30,10
-    CONTROL         "Light Exposure Spinner", IDC_SPINNER_LIGHT_EXPOSURE,
-                    "SpinnerControl", WS_TABSTOP,101,30,6,10
+    LTEXT           "Light Exposure:",IDC_LABEL_LIGHT_EXPOSURE,7,30,48,8
+    CONTROL         "Light Exposure Edit",IDC_EDIT_LIGHT_EXPOSURE,"CustEdit",WS_TABSTOP,69,30,30,10
+    CONTROL         "Light Exposure Spinner",IDC_SPINNER_LIGHT_EXPOSURE,
+                    "SpinnerControl",WS_TABSTOP,101,30,6,10
     LTEXT           "Emission Sides:",IDC_LABEL_EMISSION_SIDES,7,42,48,8
     CONTROL         "Front",IDC_BUTTON_EMISSION_FRONT,"CustButton",WS_TABSTOP,69,42,40,10
     CONTROL         "Back",IDC_BUTTON_EMISSION_BACK,"CustButton",WS_TABSTOP,111,42,40,10
@@ -113,6 +113,10 @@ BEGIN
     IDS_LIGHT_COLOR         "Light Color"
     IDS_TEXMAP_LIGHT_COLOR  "Light Color Texture Map"
     IDS_LIGHT_POWER         "Light Power"
+END
+
+STRINGTABLE
+BEGIN
     IDS_LIGHT_EXPOSURE      "Light Exposure"
 END
 

--- a/src/appleseed-max-impl/appleseedmetalmtl/appleseedmetalmtl.rc
+++ b/src/appleseed-max-impl/appleseedmetalmtl/appleseedmetalmtl.rc
@@ -66,20 +66,20 @@ BEGIN
     LTEXT           "Reflectance:",IDC_LABEL_REFLECTANCE,7,30,48,8
     CONTROL         "Reflectance Edit",IDC_EDIT_REFLECTANCE,"CustEdit",WS_TABSTOP,73,30,30,10
     CONTROL         "Reflectance Slider",IDC_SLIDER_REFLECTANCE,
-                    "SliderControl",WS_TABSTOP,106,30,92,13
-    CONTROL         "Reflectance Map",IDC_TEXMAP_REFLECTANCE,"CustButton",WS_TABSTOP,200,30,10,10
+                    "SliderControl",WS_TABSTOP,106,30,74,13
+    CONTROL         "Reflectance Map",IDC_TEXMAP_REFLECTANCE,"CustButton",WS_TABSTOP,182,30,28,10
     LTEXT           "Roughness:",IDC_LABEL_ROUGHNESS,7,42,48,8
     CONTROL         "Roughness Edit",IDC_EDIT_ROUGHNESS,"CustEdit",WS_TABSTOP,73,42,30,10
-    CONTROL         "Roughness Slider",IDC_SLIDER_ROUGHNESS,"SliderControl",WS_TABSTOP,106,42,92,13
-    CONTROL         "Roughness Map",IDC_TEXMAP_ROUGHNESS,"CustButton",WS_TABSTOP,200,42,10,10
+    CONTROL         "Roughness Slider",IDC_SLIDER_ROUGHNESS,"SliderControl",WS_TABSTOP,106,42,74,13
+    CONTROL         "Roughness Map",IDC_TEXMAP_ROUGHNESS,"CustButton",WS_TABSTOP,182,42,28,10
     LTEXT           "Anisotropy:",IDC_LABEL_ANISOTROPY,7,54,48,8
     CONTROL         "Anisotropy Edit",IDC_EDIT_ANISOTROPY,"CustEdit",WS_TABSTOP,73,54,30,10
-    CONTROL         "Anisotropy Slider",IDC_SLIDER_ANISOTROPY,"SliderControl",WS_TABSTOP,106,54,92,13
-    CONTROL         "Anisotropy Map",IDC_TEXMAP_ANISOTROPY,"CustButton",WS_TABSTOP,200,54,10,10
+    CONTROL         "Anisotropy Slider",IDC_SLIDER_ANISOTROPY,"SliderControl",WS_TABSTOP,106,54,74,13
+    CONTROL         "Anisotropy Map",IDC_TEXMAP_ANISOTROPY,"CustButton",WS_TABSTOP,182,54,28,10
     LTEXT           "Alpha:",IDC_LABEL_ALPHA,7,66,48,8
     CONTROL         "Alpha Edit",IDC_EDIT_ALPHA,"CustEdit",WS_TABSTOP,73,66,30,10
-    CONTROL         "Alpha Slider",IDC_SLIDER_ALPHA,"SliderControl",WS_TABSTOP,106,66,92,13
-    CONTROL         "Alpha Map",IDC_TEXMAP_ALPHA,"CustButton",WS_TABSTOP,200,66,10,10
+    CONTROL         "Alpha Slider",IDC_SLIDER_ALPHA,"SliderControl",WS_TABSTOP,106,66,74,13
+    CONTROL         "Alpha Map",IDC_TEXMAP_ALPHA,"CustButton",WS_TABSTOP,182,66,28,10
 END
 
 

--- a/src/appleseed-max-impl/appleseedplasticmtl/appleseedplasticmtl.rc
+++ b/src/appleseed-max-impl/appleseedplasticmtl/appleseedplasticmtl.rc
@@ -84,14 +84,14 @@ BEGIN
     CONTROL         "Diffuse Map",IDC_TEXMAP_DIFFUSE,"CustButton",WS_TABSTOP,106,6,104,10
     LTEXT           "Diffuse Weight:",IDC_LABEL_DIFFUSE_WEIGHT,7,18,65,8
     CONTROL         "Diffuse Edit",IDC_EDIT_DIFFUSE_WEIGHT,"CustEdit",WS_TABSTOP,73,18,30,10
-    CONTROL         "Diffuse Slider",IDC_SLIDER_DIFFUSE_WEIGHT,"SliderControl",WS_TABSTOP,106,18,92,13
+    CONTROL         "Diffuse Slider",IDC_SLIDER_DIFFUSE_WEIGHT,"SliderControl",WS_TABSTOP,106,18,74,13
     LTEXT           "Scattering:",IDC_LABEL_SCATTERING,7,30,65,8
     CONTROL         "Scattering Edit",IDC_EDIT_SCATTERING,"CustEdit",WS_TABSTOP,73,30,30,10
-    CONTROL         "Scattering Slider",IDC_SLIDER_SCATTERING,"SliderControl",WS_TABSTOP,106,30,92,13
+    CONTROL         "Scattering Slider",IDC_SLIDER_SCATTERING,"SliderControl",WS_TABSTOP,106,30,74,13
     LTEXT           "Alpha:",IDC_LABEL_ALPHA,7,42,48,8
     CONTROL         "Alpha Edit",IDC_EDIT_ALPHA,"CustEdit",WS_TABSTOP,73,42,30,10
-    CONTROL         "Alpha Slider",IDC_SLIDER_ALPHA,"SliderControl",WS_TABSTOP,106,42,92,13
-    CONTROL         "Alpha Map",IDC_TEXMAP_ALPHA,"CustButton",WS_TABSTOP,200,42,10,10
+    CONTROL         "Alpha Slider",IDC_SLIDER_ALPHA,"SliderControl",WS_TABSTOP,106,42,74,13
+    CONTROL         "Alpha Map",IDC_TEXMAP_ALPHA,"CustButton",WS_TABSTOP,182,42,28,10
 END
 
 

--- a/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.rc
+++ b/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.rc
@@ -64,19 +64,17 @@ BEGIN
                     "CustButton",WS_TABSTOP,101,18,109,10
     LTEXT           "Amount:",IDC_LABEL_SSS_AMOUNT,7,30,55,8
     CONTROL         "Amount Edit",IDC_EDIT_SSS_AMOUNT,"CustEdit",WS_TABSTOP,69,30,30,10
-    CONTROL         "Amount Slider",IDC_SLIDER_SSS_AMOUNT,"SliderControl",WS_TABSTOP,101,30,97,13
+    CONTROL         "Amount Slider",IDC_SLIDER_SSS_AMOUNT,"SliderControl",WS_TABSTOP,101,30,80,13
     LTEXT           "Scale:",IDC_LABEL_SSS_SCALE,7,42,48,8
-    CONTROL         "Scale Edit",IDC_EDIT_SSS_SCALE,"CustEdit",WS_TABSTOP,69,42,30,10
-    CONTROL         "Scale Spinner",IDC_SPINNER_SSS_SCALE,"SpinnerControl",WS_TABSTOP,101,42,6,10
+    CONTROL         "Scale Edit",IDC_EDIT_SSS_SCALE,"CustEdit",WS_TABSTOP,69,42,23,10
+    CONTROL         "Scale Spinner",IDC_SPINNER_SSS_SCALE,"SpinnerControl",WS_TABSTOP,91,42,6,10
     LTEXT           "IOR:",IDC_LABEL_SSS_IOR,7,54,48,8
     CONTROL         "IOR Edit",IDC_EDIT_SSS_IOR,"CustEdit",WS_TABSTOP,69,54,30,10
-    CONTROL         "IOR Slider",IDC_SLIDER_SSS_IOR,"SliderControl",WS_TABSTOP,101,54,97,13
+    CONTROL         "IOR Slider",IDC_SLIDER_SSS_IOR,"SliderControl",WS_TABSTOP,101,51,80,13
     LTEXT           "Alpha:",IDC_LABEL_ALPHA,7,66,48,8
     CONTROL         "Alpha Edit",IDC_EDIT_ALPHA,"CustEdit",WS_TABSTOP,69,66,30,10
-    CONTROL         "Alpha Slider",IDC_SLIDER_ALPHA,
-                    "SliderControl",WS_TABSTOP,101,66,97,13
-    CONTROL         "Alpha Map",IDC_TEXMAP_ALPHA,
-                    "CustButton",WS_TABSTOP,200,66,10,10
+    CONTROL         "Alpha Slider",IDC_SLIDER_ALPHA,"SliderControl",WS_TABSTOP,101,63,80,13
+    CONTROL         "Alpha Map",IDC_TEXMAP_ALPHA,"CustButton",WS_TABSTOP,183,66,27,10
 END
 
 IDD_FORMVIEW_SPECULAR_PARAMS DIALOGEX 0, 0, 217, 55
@@ -88,19 +86,19 @@ BEGIN
     CONTROL         "Color Map",IDC_TEXMAP_SPECULAR_COLOR,"CustButton",WS_TABSTOP,101,6,109,10
     LTEXT           "Amount:",IDC_LABEL_SPECULAR_AMOUNT,7,18,55,8
     CONTROL         "Amount Edit",IDC_EDIT_SPECULAR_AMOUNT,"CustEdit",WS_TABSTOP,69,18,30,10
-    CONTROL         "Amount Slider",IDC_SLIDER_SPECULAR_AMOUNT,"SliderControl",WS_TABSTOP,101,18,97,13
-    CONTROL         "Amount Map",IDC_TEXMAP_SPECULAR_AMOUNT,"CustButton",WS_TABSTOP,200,18,10,10
+    CONTROL         "Amount Slider",IDC_SLIDER_SPECULAR_AMOUNT,"SliderControl",WS_TABSTOP,101,15,80,13
+    CONTROL         "Amount Map",IDC_TEXMAP_SPECULAR_AMOUNT,"CustButton",WS_TABSTOP,183,18,27,10
     LTEXT           "Roughness:",IDC_LABEL_SPECULAR_ROUGHNESS,7,30,55,8
     CONTROL         "Roughness Edit",IDC_EDIT_SPECULAR_ROUGHNESS,"CustEdit",WS_TABSTOP,69,30,30,10
     CONTROL         "Roughness Slider",IDC_SLIDER_SPECULAR_ROUGHNESS,
-                    "SliderControl",WS_TABSTOP,101,30,97,13
-    CONTROL         "Roughness Map",IDC_TEXMAP_SPECULAR_ROUGHNESS,"CustButton",WS_TABSTOP,200,30,10,10
+                    "SliderControl",WS_TABSTOP,101,27,80,13
+    CONTROL         "Roughness Map",IDC_TEXMAP_SPECULAR_ROUGHNESS,"CustButton",WS_TABSTOP,183,30,27,10
     LTEXT           "Anisotropy:",IDC_LABEL_SPECULAR_ANISOTROPY,7,42,48,8
     CONTROL         "Anisotropy Edit",IDC_EDIT_SPECULAR_ANISOTROPY,"CustEdit",WS_TABSTOP,69,42,30,10
     CONTROL         "Anisotropy Slider",IDC_SLIDER_SPECULAR_ANISOTROPY,
-                    "SliderControl",WS_TABSTOP,101,42,97,13
+                    "SliderControl",WS_TABSTOP,101,39,80,13
     CONTROL         "Anisotropy Map",IDC_TEXMAP_SPECULAR_ANISOTROPY,
-                    "CustButton",WS_TABSTOP,200,42,10,10
+                    "CustButton",WS_TABSTOP,183,42,27,10
 END
 
 
@@ -115,13 +113,13 @@ BEGIN
     IDD_FORMVIEW_SSS_PARAMS, DIALOG
     BEGIN
         VERTGUIDE, 50
-        VERTGUIDE, 198
+        VERTGUIDE, 181
         VERTGUIDE, 210
     END
 
     IDD_FORMVIEW_SPECULAR_PARAMS, DIALOG
     BEGIN
-        VERTGUIDE, 198
+        VERTGUIDE, 181
         VERTGUIDE, 210
     END
 END
@@ -183,6 +181,10 @@ STRINGTABLE
 BEGIN
     IDS_SSS_SCALE           "Scale"
     IDS_SSS_IOR             "IOR"
+END
+
+STRINGTABLE
+BEGIN
     IDS_ALPHA               "Alpha"
 END
 


### PR DESCRIPTION
This fixes an regression issue (#320) where the node UI of appleseed legacy materials had partly visible map buttons only (see screenshots).

Before:
![appleseedDisney_bug](https://user-images.githubusercontent.com/22252558/65750858-01f4eb80-e112-11e9-9a75-3b8a575a12d6.PNG)

After fix:
![appleseed_Disney_fixed](https://user-images.githubusercontent.com/22252558/65750876-09b49000-e112-11e9-92cc-e4719ee55cf9.PNG)
