### PR TITLE
Add system and libraries information to render log

### DIFF
--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
@@ -2157,12 +2157,11 @@ int AppleseedRenderer::Render(
     if (!m_rend_params.inMtlEdit || m_settings.m_log_material_editor_messages)
     {
         create_log_window();
-        print_libraries_information();
-        print_libraries_features();
+        print_appleseed_library_information();
+        print_appleseed_library_features();
         print_third_party_libraries_information();
         asf::System::print_information(asr::global_logger());
     }
-
 
     if (renderer_settings.m_enable_noise_seed)
     {

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
@@ -54,6 +54,7 @@
 // appleseed.foundation headers.
 #include "foundation/image/canvasproperties.h"
 #include "foundation/image/image.h"
+#include "foundation/platform/system.h"
 #include "foundation/platform/thread.h"
 #include "foundation/platform/types.h"
 #include "foundation/utility/autoreleaseptr.h"
@@ -1072,9 +1073,6 @@ void AppleseedRendererPBlockAccessor::Set(
 
 AppleseedRendererClassDesc g_appleseed_renderer_classdesc;
 asf::auto_release_ptr<DialogLogTarget> g_dialog_log_target;
-#if MAX_RELEASE < 19000
-AppleseedRECompatible g_appleseed_renderelement_compatible;
-#endif
 AppleseedRendererPBlockAccessor g_pblock_accessor;
 
 ParamBlockDesc2 g_param_block_desc(
@@ -2157,7 +2155,14 @@ int AppleseedRenderer::Render(
     }
 
     if (!m_rend_params.inMtlEdit || m_settings.m_log_material_editor_messages)
+    {
         create_log_window();
+        print_libraries_information();
+        print_libraries_features();
+        print_third_party_libraries_information();
+        asf::System::print_information(asr::global_logger());
+    }
+
 
     if (renderer_settings.m_enable_noise_seed)
     {
@@ -2238,6 +2243,7 @@ int AppleseedRenderer::Render(
 
             if (progress_cb)
                 progress_cb->SetTitle(L"Rendering...");
+
             if (m_settings.m_low_priority_mode)
             {
                 asf::ProcessPriorityContext background_context(

--- a/src/appleseed-max-impl/utilities.cpp
+++ b/src/appleseed-max-impl/utilities.cpp
@@ -31,7 +31,6 @@
 
 // appleseed-max headers.
 #include "osloutputselectormap/osloutputselector.h"
-#include "version.h"
 
 // Build options header.
 #include "foundation/core/buildoptions.h"
@@ -78,7 +77,6 @@ const char* to_enabled_disabled(const bool value)
 
 void print_libraries_information()
 {
-    const auto verstr = PluginVersionString;
     RENDERER_LOG_INFO(
         "appleseed for Autodesk 3ds Max using %s version %s, %s configuration\n"
         "compiled on %s at %s using %s version %s\n"

--- a/src/appleseed-max-impl/utilities.cpp
+++ b/src/appleseed-max-impl/utilities.cpp
@@ -75,7 +75,7 @@ const char* to_enabled_disabled(const bool value)
     return value ? "enabled" : "disabled";
 }
 
-void print_libraries_information()
+void print_appleseed_library_information()
 {
     RENDERER_LOG_INFO(
         "appleseed for Autodesk 3ds Max using %s version %s, %s configuration\n"
@@ -93,35 +93,35 @@ void print_libraries_information()
         asf::Compiler::get_compiler_version());
 }
 
-void print_libraries_features()
+void print_appleseed_library_features()
 {
-        const bool WithDisneyMaterial =
-    #ifdef APPLESEED_WITH_DISNEY_MATERIAL
-            true;
-    #else
-            false;
-    #endif
+    const bool WithDisneyMaterial =
+#ifdef APPLESEED_WITH_DISNEY_MATERIAL
+        true;
+#else
+        false;
+#endif
 
-        const bool WithEmbree =
-    #ifdef APPLESEED_WITH_EMBREE
-            true;
-    #else
-            false;
-    #endif
+    const bool WithEmbree =
+#ifdef APPLESEED_WITH_EMBREE
+        true;
+#else
+        false;
+#endif
 
-        const bool WithSpectralSupport =
-    #ifdef APPLESEED_WITH_SPECTRAL_SUPPORT
-            true;
-    #else
-            false;
-    #endif
+    const bool WithSpectralSupport =
+#ifdef APPLESEED_WITH_SPECTRAL_SUPPORT
+        true;
+#else
+        false;
+#endif
 
-        const bool WithGPUSupport =
-    #ifdef APPLESEED_WITH_GPU
-            true;
-    #else
-            false;
-    #endif
+    const bool WithGPUSupport =
+#ifdef APPLESEED_WITH_GPU
+        true;
+#else
+        false;
+#endif
 
     RENDERER_LOG_INFO(
         "library features:\n"
@@ -146,12 +146,11 @@ void print_third_party_libraries_information()
         const asf::APIStringPair& version = versions[i];
         const char* lib_name = version.m_first.c_str();
         const char* lib_version = version.m_second.c_str();
-        const size_t lib_name_length = strlen(lib_name);
+        const size_t lib_name_length = std::strlen(lib_name);
         const std::string spacing(30 - lib_name_length, ' ');
         RENDERER_LOG_INFO("  %s%s%s", lib_name, spacing.c_str(), lib_version);
     }
 }
-
 
 void update_map_buttons(IParamMap2* param_map)
 {

--- a/src/appleseed-max-impl/utilities.cpp
+++ b/src/appleseed-max-impl/utilities.cpp
@@ -31,6 +31,7 @@
 
 // appleseed-max headers.
 #include "osloutputselectormap/osloutputselector.h"
+#include "version.h"
 
 // Build options header.
 #include "foundation/core/buildoptions.h"
@@ -41,6 +42,8 @@
 #include "renderer/api/texture.h"
 
 // appleseed.foundation headers.
+#include "foundation/core/appleseed.h"
+#include "foundation/core/thirdparties.h"
 #include "foundation/image/canvasproperties.h"
 #include "foundation/image/tile.h"
 #include "foundation/utility/searchpaths.h"
@@ -67,6 +70,90 @@
 
 namespace asf = foundation;
 namespace asr = renderer;
+
+const char* to_enabled_disabled(const bool value)
+{
+    return value ? "enabled" : "disabled";
+}
+
+void print_libraries_information()
+{
+    const auto verstr = PluginVersionString;
+    RENDERER_LOG_INFO(
+        "appleseed for Autodesk 3ds Max using %s version %s, %s configuration\n"
+        "compiled on %s at %s using %s version %s\n"
+        "copyright (c) 2010-2013 Francois Beaune, Jupiter Jazz Limited\n"
+        "copyright (c) 2014-2019 The appleseedhq Organization\n"
+        "this software is released under the MIT license (https://opensource.org/licenses/MIT).\n"
+        "visit https://appleseedhq.net/ for additional information and resources.",
+        asf::Appleseed::get_lib_name(),
+        asf::Appleseed::get_lib_version(),
+        asf::Appleseed::get_lib_configuration(),
+        asf::Appleseed::get_lib_compilation_date(),
+        asf::Appleseed::get_lib_compilation_time(),
+        asf::Compiler::get_compiler_name(),
+        asf::Compiler::get_compiler_version());
+}
+
+void print_libraries_features()
+{
+        const bool WithDisneyMaterial =
+    #ifdef APPLESEED_WITH_DISNEY_MATERIAL
+            true;
+    #else
+            false;
+    #endif
+
+        const bool WithEmbree =
+    #ifdef APPLESEED_WITH_EMBREE
+            true;
+    #else
+            false;
+    #endif
+
+        const bool WithSpectralSupport =
+    #ifdef APPLESEED_WITH_SPECTRAL_SUPPORT
+            true;
+    #else
+            false;
+    #endif
+
+        const bool WithGPUSupport =
+    #ifdef APPLESEED_WITH_GPU
+            true;
+    #else
+            false;
+    #endif
+
+    RENDERER_LOG_INFO(
+        "library features:\n"
+        "  Instruction sets              %s\n"
+        "  Disney material with SeExpr   %s\n"
+        "  Embree                        %s\n"
+        "  Spectral support              %s\n"
+        "  GPU support                   %s",
+        asf::Appleseed::get_lib_cpu_features(),
+        to_enabled_disabled(WithDisneyMaterial),
+        to_enabled_disabled(WithEmbree),
+        to_enabled_disabled(WithSpectralSupport),
+        to_enabled_disabled(WithGPUSupport));
+}
+
+void print_third_party_libraries_information()
+{
+    const asf::LibraryVersionArray versions = asf::ThirdParties::get_versions();
+    RENDERER_LOG_INFO("third party libraries:\n");
+    for (size_t i = 0, e = versions.size(); i < e; ++i)
+    {
+        const asf::APIStringPair& version = versions[i];
+        const char* lib_name = version.m_first.c_str();
+        const char* lib_version = version.m_second.c_str();
+        const size_t lib_name_length = strlen(lib_name);
+        const std::string spacing(30 - lib_name_length, ' ');
+        RENDERER_LOG_INFO("  %s%s%s", lib_name, spacing.c_str(), lib_version);
+    }
+}
+
 
 void update_map_buttons(IParamMap2* param_map)
 {

--- a/src/appleseed-max-impl/utilities.h
+++ b/src/appleseed-max-impl/utilities.h
@@ -74,6 +74,7 @@ class Texmap;
 
 void update_map_buttons(IParamMap2* param_map);
 
+
 //
 // Bitmap functions.
 //
@@ -128,17 +129,19 @@ std::string insert_procedural_texture_and_instance(
     renderer::ParamArray        texture_params = renderer::ParamArray(),
     renderer::ParamArray        texture_instance_params = renderer::ParamArray());
 
+
 //
 // Version information functions.
 //
 
-extern void print_libraries_information();
+void print_appleseed_library_information();
 
-extern void print_libraries_features();
+void print_appleseed_library_features();
 
-extern const char* to_enabled_disabled(const bool value);
+const char* to_enabled_disabled(const bool value);
 
-extern void print_third_party_libraries_information();
+void print_third_party_libraries_information();
+
 
 //
 // Implementation.

--- a/src/appleseed-max-impl/utilities.h
+++ b/src/appleseed-max-impl/utilities.h
@@ -74,7 +74,6 @@ class Texmap;
 
 void update_map_buttons(IParamMap2* param_map);
 
-
 //
 // Bitmap functions.
 //
@@ -129,6 +128,17 @@ std::string insert_procedural_texture_and_instance(
     renderer::ParamArray        texture_params = renderer::ParamArray(),
     renderer::ParamArray        texture_instance_params = renderer::ParamArray());
 
+//
+// Version information functions.
+//
+
+extern void print_libraries_information();
+
+extern void print_libraries_features();
+
+extern const char* to_enabled_disabled(const bool value);
+
+extern void print_third_party_libraries_information();
 
 //
 // Implementation.


### PR DESCRIPTION
- Adds detailed information in the render log about the system as well as the appleseed and 3rd. party libraries linked with the plugin (feature request #313).

The screenshot below shows a test output of the render log with the added information:
![Capture](https://user-images.githubusercontent.com/22252558/66669103-72961f00-ec5f-11e9-80ba-8b3bd0cd5eaf.PNG)
 
