### PR TITLE
Fixes cut off labels in legacy shader UI

### DIFF
--- a/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.rc
+++ b/src/appleseed-max-impl/appleseedglassmtl/appleseedglassmtl.rc
@@ -1,5 +1,7 @@
 // Microsoft Visual C++ generated resource script.
 //
+#pragma code_page(65001)
+
 #include "resource.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
@@ -17,7 +19,6 @@
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
-#pragma code_page(1252)
 
 #ifdef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////
@@ -63,7 +64,7 @@ BEGIN
                     "ColorSwatch",WS_TABSTOP,69,18,30,10
     CONTROL         "Reflection Tint Map",IDC_TEXMAP_REFLECTION_TINT,
                     "CustButton",WS_TABSTOP,101,18,109,10
-    LTEXT           "Refraction Tint:",IDC_LABEL_REFRACTION_TINT,7,30,48,8
+    LTEXT           "Refraction Tint:",IDC_LABEL_REFRACTION_TINT,7,30,56,8
     CONTROL         "Refraction Tint Swatch",IDC_SWATCH_REFRACTION_TINT,
                     "ColorSwatch",WS_TABSTOP,69,30,30,10
     CONTROL         "Refraction Tint Map",IDC_TEXMAP_REFRACTION_TINT,

--- a/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.rc
+++ b/src/appleseed-max-impl/appleseedsssmtl/appleseedsssmtl.rc
@@ -1,5 +1,7 @@
 // Microsoft Visual C++ generated resource script.
 //
+#pragma code_page(65001)
+
 #include "resource.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
@@ -17,7 +19,6 @@
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
-#pragma code_page(1252)
 
 #ifdef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////
@@ -57,7 +58,7 @@ BEGIN
     LTEXT           "Color:",IDC_LABEL_SSS_COLOR,7,6,48,8
     CONTROL         "Color Swatch",IDC_SWATCH_SSS_COLOR,"ColorSwatch",WS_TABSTOP,69,6,30,10
     CONTROL         "Color Map",IDC_TEXMAP_SSS_COLOR,"CustButton",WS_TABSTOP,101,6,109,10
-    LTEXT           "Scattering Color:",IDC_LABEL_SSS_SCATTERING_COLOR,7,18,48,8
+    LTEXT           "Scattering Color:",IDC_LABEL_SSS_SCATTERING_COLOR,7,18,55,8
     CONTROL         "Scattering Color Swatch",IDC_SWATCH_SSS_SCATTERING_COLOR,
                     "ColorSwatch",WS_TABSTOP,69,18,30,10
     CONTROL         "Scattering Color Map",IDC_TEXMAP_SSS_SCATTERING_COLOR,


### PR DESCRIPTION
- Small fix for the cut-off `Scattering Color` & `Refraction Tint` labels 

Bug:
![Capture](https://user-images.githubusercontent.com/22252558/66990035-1e12f980-f0ce-11e9-8633-405e98f414a8.PNG)

Fixed:
![Capture1](https://user-images.githubusercontent.com/22252558/66990047-2408da80-f0ce-11e9-8f16-280fb7771ede.PNG)
