### PR TITLE
Fix issues in OSL plugin

### DIFF
--- a/src/appleseed-max-impl/appleseedoslplugin/oslparamdlg.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslparamdlg.cpp
@@ -74,6 +74,10 @@ namespace
                     for (int i = 0, e = desc->Count(); i < e; ++i)
                     {
                         const ParamDef param_def = desc->GetParamDef(desc->IndextoID(i));
+                        
+                        if (param_def.flags & P_OBSOLETE)
+                            continue;
+
                         if (param_def.ctrl_type == TYPE_SPINNER)
                         {
                             const int* ctrl_ids = param_def.ctrl_IDs;
@@ -278,7 +282,7 @@ void OSLParamDlg::add_ui_parameter(
     const std::string param_label = max_param.m_max_label_str + ":";
     dialog_template.AddStatic((LPCSTR)param_label.c_str(), WS_VISIBLE, NULL, col1_x, y_pos, LabelWidth, EditHeight, ctrl_id++);
     
-    if (max_param.m_has_constant)
+    if (max_param.m_is_constant)
     {
         switch (max_param.m_param_type)
         {
@@ -319,7 +323,7 @@ void OSLParamDlg::add_ui_parameter(
         }
     }
 
-    if (max_param.m_connectable)
+    if (max_param.m_is_connectable)
     {
         if (max_param.m_param_type == MaxParam::Closure)
         {
@@ -327,7 +331,7 @@ void OSLParamDlg::add_ui_parameter(
         }
         else
         {
-            const bool short_button = max_param.m_has_constant && 
+            const bool short_button = max_param.m_is_constant && 
                 (max_param.m_param_type == MaxParam::VectorParam || 
                     max_param.m_param_type == MaxParam::NormalParam ||
                     max_param.m_param_type == MaxParam::PointParam ||
@@ -338,7 +342,7 @@ void OSLParamDlg::add_ui_parameter(
             {
                 Texmap* tex_map = nullptr;
                 Interval iv;
-                m_osl_plugin->GetParamBlock(0)->GetValue(max_param.m_max_param_id + 1, 0, tex_map, iv);
+                m_osl_plugin->GetParamBlock(0)->GetValue(max_param.m_max_map_param_id, 0, tex_map, iv);
 
                 const char* label = tex_map != nullptr ? "M" : "";
 

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.cpp
@@ -238,15 +238,19 @@ OSLShaderInfo::OSLShaderInfo(
         {
             OSLParamInfo osl_param(q.get_param_info(i));
 
+            if (osl_param.m_widget == "null" && !osl_param.m_connectable)
+                continue;
+
             MaxParam& max_param = osl_param.m_max_param;
 
             max_param.m_osl_param_name = osl_param.m_param_name;
             max_param.m_max_label_str = osl_param.m_label;
-            max_param.m_connectable = osl_param.m_connectable;
+            max_param.m_is_connectable = osl_param.m_connectable;
             max_param.m_param_type = MaxParam::Unsupported;
             max_param.m_page_name = osl_param.m_page;
 
-            max_param.m_has_constant = osl_param.m_valid_default &&
+            max_param.m_is_constant =
+                osl_param.m_valid_default &&
                 osl_param.m_lock_geom &&
                 osl_param.m_widget != "null";
 

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.h
@@ -82,10 +82,11 @@ class MaxParam
     }
 
     ParamType       m_param_type;
-    bool            m_connectable;
-    bool            m_has_constant;
+    bool            m_is_connectable;
+    bool            m_is_constant;
     std::string     m_max_label_str;
     int             m_max_param_id;
+    int             m_max_map_param_id;
     int             m_max_ctrl_id;
     std::string     m_osl_param_name;
     std::string     m_page_name;

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshaderregistry.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshaderregistry.cpp
@@ -552,8 +552,8 @@ void OSLShaderRegistry::add_const_parameter(
         if (osl_param.m_has_default)
         {
             const float r = static_cast<float>(osl_param.m_default_value.at(0));
-            const float g = static_cast<float>(osl_param.m_default_value.at(0));
-            const float b = static_cast<float>(osl_param.m_default_value.at(0));
+            const float g = static_cast<float>(osl_param.m_default_value.at(1));
+            const float b = static_cast<float>(osl_param.m_default_value.at(2));
             def_val = Color(r, g, b);
         }
 

--- a/src/appleseed-max-impl/oslutils.cpp
+++ b/src/appleseed-max-impl/oslutils.cpp
@@ -597,11 +597,9 @@ void create_osl_shader(
     {
         const MaxParam& max_param = param_info.m_max_param;
         Texmap* texmap = nullptr;
-        if (max_param.m_connectable)
+        if (max_param.m_is_connectable)
         {
-            int texture_param_id = 
-                max_param.m_has_constant ? max_param.m_max_param_id + 1 : max_param.m_max_param_id;
-            param_block->GetValue(texture_param_id, time, texmap, FOREVER);
+            param_block->GetValue(max_param.m_max_map_param_id, time, texmap, FOREVER);
 
             if (texmap != nullptr)
             {
@@ -610,7 +608,7 @@ void create_osl_shader(
                   case MaxParam::Float:
                     {
                         const float constant_value = 
-                            max_param.m_has_constant ? param_block->GetFloat(max_param.m_max_param_id, time, FOREVER) : 1.0f;
+                            max_param.m_is_constant ? param_block->GetFloat(max_param.m_max_param_id, time, FOREVER) : 1.0f;
                         connect_float_texture(
                             shader_group,
                             layer_name,
@@ -623,7 +621,7 @@ void create_osl_shader(
                   case MaxParam::Color:
                     {
                         const Color constant_color = 
-                            max_param.m_has_constant ? param_block->GetColor(max_param.m_max_param_id, time, FOREVER) : Color(1.0, 1.0, 1.0);
+                            max_param.m_is_constant ? param_block->GetColor(max_param.m_max_param_id, time, FOREVER) : Color(1.0, 1.0, 1.0);
                         connect_color_texture(
                             shader_group,
                             layer_name,
@@ -653,10 +651,10 @@ void create_osl_shader(
             }
         }
 
-        if (max_param.m_connectable && max_param.m_param_type == MaxParam::Closure)
+        if (max_param.m_is_connectable && max_param.m_param_type == MaxParam::Closure)
         {
             Mtl* material = nullptr;
-            param_block->GetValue(max_param.m_max_param_id, time, material, FOREVER);
+            param_block->GetValue(max_param.m_max_map_param_id, time, material, FOREVER);
             if (material != nullptr && assembly != nullptr)
             {
                 connect_sub_mtl(
@@ -669,7 +667,7 @@ void create_osl_shader(
             }
         }
 
-        if (!max_param.m_connectable || texmap == nullptr)
+        if (!max_param.m_is_connectable || texmap == nullptr)
         {
             switch (max_param.m_param_type)
             {


### PR DESCRIPTION
Hi,
These are changes that fix some of the hidden issues OSL plugin:
1. Add Version information to the param block
2. Skip parameters with obsolete flag
3. Add separate variable to keep param ids for maps
4. Start bump parameters IDs with 0 (because they are in separate param block) This may potentially break current scenes but it worked on my tests.
5. Skip parameters with no widget and no connections (Don't remember where this came from but it sounds reasonable. I probably had a case where it failed to add the parameter)
6. Fix getting correct colors from OSL color default values.

Thanks for review!