### PR TITLE
Support as_deprecated and as_max_param_id OSL metadata

### DIFF
--- a/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.cpp
@@ -177,6 +177,9 @@ OSLParamInfo::OSLParamInfo(const asf::Dictionary& param_info)
         m_has_soft_max = metadata.get_value("softmax", m_soft_max_value);
         metadata.get_value("divider", m_divider);
 
+        if (!metadata.get_value("as_max_param_id", m_max_param_id))
+            m_max_param_id = -1;
+
         metadata.get_value("as_maya_attribute_name", m_maya_attribute_name);
         metadata.get_value("as_maya_attribute_connectable", m_connectable);
         m_max_hidden_attr = false;

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.cpp
@@ -108,6 +108,7 @@ OSLParamInfo::OSLParamInfo(const asf::Dictionary& param_info)
   : m_has_default(false)
   , m_divider(false)
   , m_lock_geom(true)
+  , m_deprecated(false)
 {
     m_param_name = param_info.get("name");
     m_param_type = param_info.get("type");
@@ -184,6 +185,8 @@ OSLParamInfo::OSLParamInfo(const asf::Dictionary& param_info)
         metadata.get_value("as_maya_attribute_connectable", m_connectable);
         m_max_hidden_attr = false;
         metadata.get_value("as_max_attribute_hidden", m_max_hidden_attr);
+
+        metadata.get_value("as_deprecated", m_deprecated);
     }
 }
 

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.cpp
@@ -108,12 +108,12 @@ OSLParamInfo::OSLParamInfo(const asf::Dictionary& param_info)
   : m_has_default(false)
   , m_divider(false)
   , m_lock_geom(true)
-  , m_deprecated(false)
+  , m_is_deprecated(false)
 {
     m_param_name = param_info.get("name");
     m_param_type = param_info.get("type");
     m_valid_default = param_info.get<bool>("validdefault");
-    m_connectable = true;
+    m_is_connectable = true;
 
     // todo: lots of refactoring possibilities here...
     if (m_valid_default)
@@ -182,11 +182,11 @@ OSLParamInfo::OSLParamInfo(const asf::Dictionary& param_info)
             m_max_param_id = -1;
 
         metadata.get_value("as_maya_attribute_name", m_maya_attribute_name);
-        metadata.get_value("as_maya_attribute_connectable", m_connectable);
+        metadata.get_value("as_maya_attribute_connectable", m_is_connectable);
         m_max_hidden_attr = false;
         metadata.get_value("as_max_attribute_hidden", m_max_hidden_attr);
 
-        metadata.get_value("as_deprecated", m_deprecated);
+        metadata.get_value("as_deprecated", m_is_deprecated);
     }
 }
 
@@ -244,14 +244,14 @@ OSLShaderInfo::OSLShaderInfo(
         {
             OSLParamInfo osl_param(q.get_param_info(i));
 
-            if (osl_param.m_widget == "null" && !osl_param.m_connectable)
+            if (osl_param.m_widget == "null" && !osl_param.m_is_connectable)
                 continue;
 
             MaxParam& max_param = osl_param.m_max_param;
 
             max_param.m_osl_param_name = osl_param.m_param_name;
             max_param.m_max_label_str = osl_param.m_label;
-            max_param.m_is_connectable = osl_param.m_connectable;
+            max_param.m_is_connectable = osl_param.m_is_connectable;
             max_param.m_param_type = MaxParam::Unsupported;
             max_param.m_page_name = osl_param.m_page;
 

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.h
@@ -170,6 +170,7 @@ class OSLParamInfo
     std::string m_maya_attribute_name;
     bool m_connectable;
     bool m_max_hidden_attr;
+    bool m_deprecated;
     int m_max_param_id;
     MaxParam m_max_param;
 };

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.h
@@ -168,9 +168,9 @@ class OSLParamInfo
     bool m_divider;
 
     std::string m_maya_attribute_name;
-    bool m_connectable;
+    bool m_is_connectable;
     bool m_max_hidden_attr;
-    bool m_deprecated;
+    bool m_is_deprecated;
     int m_max_param_id;
     MaxParam m_max_param;
 };

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.h
@@ -170,6 +170,7 @@ class OSLParamInfo
     std::string m_maya_attribute_name;
     bool m_connectable;
     bool m_max_hidden_attr;
+    int m_max_param_id;
     MaxParam m_max_param;
 };
 

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshaderregistry.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshaderregistry.cpp
@@ -549,6 +549,7 @@ void OSLShaderRegistry::add_const_parameter(
     int&                    string_id)
 {
     auto param_str = utf8_to_wide(max_param.m_osl_param_name);
+    int is_deprecated = osl_param.m_deprecated ? P_OBSOLETE : 0;
     if (max_param.m_param_type == MaxParam::Color)
     {
         Color def_val(0.0f, 0.0f, 0.0f);
@@ -566,7 +567,7 @@ void OSLShaderRegistry::add_const_parameter(
             param_id,
             param_str.c_str(),
             TYPE_RGBA,
-            P_ANIMATABLE,
+            P_ANIMATABLE | is_deprecated,
             string_id,
             p_default, def_val,
             p_ui, TYPE_COLORSWATCH, ctrl_id_1,
@@ -597,7 +598,7 @@ void OSLShaderRegistry::add_const_parameter(
             param_id,
             param_str.c_str(),
             TYPE_FLOAT,
-            P_ANIMATABLE,
+            P_ANIMATABLE | is_deprecated,
             string_id,
             p_default, def_val,
             p_range, min_val, max_val,
@@ -629,7 +630,7 @@ void OSLShaderRegistry::add_const_parameter(
             param_id,
             param_str.c_str(),
             TYPE_INT,
-            P_ANIMATABLE,
+            P_ANIMATABLE | is_deprecated,
             string_id,
             p_default, def_val,
             p_range, min_val, max_val,
@@ -650,7 +651,7 @@ void OSLShaderRegistry::add_const_parameter(
             param_id,
             param_str.c_str(),
             TYPE_INT,
-            0,
+            is_deprecated,
             string_id,
             p_default, def_val,
             p_ui, TYPE_SINGLECHEKBOX, ctrl_id_1,
@@ -670,7 +671,7 @@ void OSLShaderRegistry::add_const_parameter(
             param_id,
             param_str.c_str(),
             TYPE_INT,
-            0,
+            is_deprecated,
             string_id,
             p_ui, TYPE_INT_COMBOBOX, ctrl_id_1,
             0,
@@ -715,7 +716,7 @@ void OSLShaderRegistry::add_const_parameter(
             param_id,
             param_str.c_str(),
             TYPE_INT,
-            0,
+            is_deprecated,
             string_id,
             p_ui, TYPE_INT_COMBOBOX, ctrl_id_1,
             0,
@@ -767,7 +768,7 @@ void OSLShaderRegistry::add_const_parameter(
             param_id,
             param_str.c_str(),
             TYPE_POINT3,
-            P_ANIMATABLE,
+            P_ANIMATABLE | is_deprecated,
             string_id,
             p_default, def_val,
             p_range, -10.0f, 10.0f,
@@ -784,7 +785,7 @@ void OSLShaderRegistry::add_const_parameter(
             param_id,
             param_str.c_str(),
             TYPE_STRING,
-            0,
+            is_deprecated,
             string_id,
             p_ui, TYPE_EDITBOX, ctrl_id_1,
             p_end
@@ -802,6 +803,7 @@ void OSLShaderRegistry::add_input_parameter(
     const int               ctrl_id,
     const int               string_id)
 {
+    int is_deprecated = osl_param.m_deprecated ? P_OBSOLETE : 0;
     if (max_param.m_param_type == MaxParam::Closure)
     {
         auto param_str = utf8_to_wide(max_param.m_osl_param_name);
@@ -811,7 +813,7 @@ void OSLShaderRegistry::add_input_parameter(
             param_id,
             param_str.c_str(),
             TYPE_MTL,
-            0,
+            is_deprecated,
             string_id,
             p_ui, TYPE_MTLBUTTON, ctrl_id,
             p_accessor, &g_material_accessor,
@@ -840,7 +842,7 @@ void OSLShaderRegistry::add_input_parameter(
             param_id,
             param_str.c_str(),
             TYPE_TEXMAP,
-            flag,
+            flag | is_deprecated,
             string_id,
             p_ui, TYPE_TEXMAPBUTTON, ctrl_id,
             p_accessor, tex_accessor,

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshaderregistry.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshaderregistry.cpp
@@ -549,7 +549,7 @@ void OSLShaderRegistry::add_const_parameter(
     int&                    string_id)
 {
     auto param_str = utf8_to_wide(max_param.m_osl_param_name);
-    int is_deprecated = osl_param.m_deprecated ? P_OBSOLETE : 0;
+    const int deprecated_bit = osl_param.m_is_deprecated ? P_OBSOLETE : 0;
     if (max_param.m_param_type == MaxParam::Color)
     {
         Color def_val(0.0f, 0.0f, 0.0f);
@@ -567,7 +567,7 @@ void OSLShaderRegistry::add_const_parameter(
             param_id,
             param_str.c_str(),
             TYPE_RGBA,
-            P_ANIMATABLE | is_deprecated,
+            P_ANIMATABLE | deprecated_bit,
             string_id,
             p_default, def_val,
             p_ui, TYPE_COLORSWATCH, ctrl_id_1,
@@ -598,7 +598,7 @@ void OSLShaderRegistry::add_const_parameter(
             param_id,
             param_str.c_str(),
             TYPE_FLOAT,
-            P_ANIMATABLE | is_deprecated,
+            P_ANIMATABLE | deprecated_bit,
             string_id,
             p_default, def_val,
             p_range, min_val, max_val,
@@ -630,7 +630,7 @@ void OSLShaderRegistry::add_const_parameter(
             param_id,
             param_str.c_str(),
             TYPE_INT,
-            P_ANIMATABLE | is_deprecated,
+            P_ANIMATABLE | deprecated_bit,
             string_id,
             p_default, def_val,
             p_range, min_val, max_val,
@@ -651,7 +651,7 @@ void OSLShaderRegistry::add_const_parameter(
             param_id,
             param_str.c_str(),
             TYPE_INT,
-            is_deprecated,
+            deprecated_bit,
             string_id,
             p_default, def_val,
             p_ui, TYPE_SINGLECHEKBOX, ctrl_id_1,
@@ -671,7 +671,7 @@ void OSLShaderRegistry::add_const_parameter(
             param_id,
             param_str.c_str(),
             TYPE_INT,
-            is_deprecated,
+            deprecated_bit,
             string_id,
             p_ui, TYPE_INT_COMBOBOX, ctrl_id_1,
             0,
@@ -716,7 +716,7 @@ void OSLShaderRegistry::add_const_parameter(
             param_id,
             param_str.c_str(),
             TYPE_INT,
-            is_deprecated,
+            deprecated_bit,
             string_id,
             p_ui, TYPE_INT_COMBOBOX, ctrl_id_1,
             0,
@@ -768,7 +768,7 @@ void OSLShaderRegistry::add_const_parameter(
             param_id,
             param_str.c_str(),
             TYPE_POINT3,
-            P_ANIMATABLE | is_deprecated,
+            P_ANIMATABLE | deprecated_bit,
             string_id,
             p_default, def_val,
             p_range, -10.0f, 10.0f,
@@ -785,7 +785,7 @@ void OSLShaderRegistry::add_const_parameter(
             param_id,
             param_str.c_str(),
             TYPE_STRING,
-            is_deprecated,
+            deprecated_bit,
             string_id,
             p_ui, TYPE_EDITBOX, ctrl_id_1,
             p_end
@@ -803,7 +803,7 @@ void OSLShaderRegistry::add_input_parameter(
     const int               ctrl_id,
     const int               string_id)
 {
-    int is_deprecated = osl_param.m_deprecated ? P_OBSOLETE : 0;
+    const int deprecated_bit = osl_param.m_is_deprecated ? P_OBSOLETE : 0;
     if (max_param.m_param_type == MaxParam::Closure)
     {
         auto param_str = utf8_to_wide(max_param.m_osl_param_name);
@@ -813,7 +813,7 @@ void OSLShaderRegistry::add_input_parameter(
             param_id,
             param_str.c_str(),
             TYPE_MTL,
-            is_deprecated,
+            deprecated_bit,
             string_id,
             p_ui, TYPE_MTLBUTTON, ctrl_id,
             p_accessor, &g_material_accessor,
@@ -833,7 +833,7 @@ void OSLShaderRegistry::add_input_parameter(
              max_param.m_param_type == MaxParam::StringPopup ||
              max_param.m_param_type == MaxParam::IntMapper);
 
-        const int flag = short_button ? P_NO_AUTO_LABELS : 0;
+        const int auto_labels_bit = short_button ? P_NO_AUTO_LABELS : 0;
         PBAccessor* tex_accessor = &g_texture_accessor;
         if (short_button)
             tex_accessor = &g_texture_accessor_short;
@@ -842,7 +842,7 @@ void OSLShaderRegistry::add_input_parameter(
             param_id,
             param_str.c_str(),
             TYPE_TEXMAP,
-            flag | is_deprecated,
+            auto_labels_bit | deprecated_bit,
             string_id,
             p_ui, TYPE_TEXMAPBUTTON, ctrl_id,
             p_accessor, tex_accessor,

--- a/src/appleseed-max-impl/appleseedoslplugin/oslshaderregistry.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshaderregistry.cpp
@@ -440,6 +440,9 @@ void OSLShaderRegistry::create_class_descriptors()
         int string_id = 100;
         for (auto& param_info : shader.m_params)
         {
+            if (param_info.m_max_param_id != -1)
+                param_id = param_info.m_max_param_id;
+
             param_info.m_max_param.m_max_ctrl_id = ctrl_id++;
 
             if (param_info.m_max_param.m_is_constant)


### PR DESCRIPTION
This change should make it possible to add/remove/rearrange of parameters in OSL shaders and  still keep backward compatibility with 3ds max scenes saved with older shaders.