### PR TITLE
Change custom fixed width integer types to C++11 std ones

### DIFF
--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
@@ -56,7 +56,6 @@
 #include "foundation/image/image.h"
 #include "foundation/platform/system.h"
 #include "foundation/platform/thread.h"
-#include "foundation/platform/types.h"
 #include "foundation/utility/autoreleaseptr.h"
 #include "foundation/utility/kvpair.h"
 #include "foundation/utility/searchpaths.h"
@@ -75,6 +74,7 @@
 // Standard headers.
 #include <clocale>
 #include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <string>
 
@@ -2083,7 +2083,7 @@ namespace
         RendProgressCallback*   progress_cb)
     {
         // Number of rendered tiles, shared counter accessed atomically.
-        volatile asf::uint32 rendered_tile_count = 0;
+        volatile std::uint32_t rendered_tile_count = 0;
 
         // Create the renderer controller.
         const size_t total_tile_count =

--- a/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
@@ -72,7 +72,6 @@
 #include "foundation/math/scalar.h"
 #include "foundation/math/transform.h"
 #include "foundation/math/vector.h"
-#include "foundation/platform/types.h"
 #include "foundation/utility/containers/dictionary.h"
 #include "foundation/utility/iostreamop.h"
 #include "foundation/utility/searchpaths.h"
@@ -97,6 +96,7 @@
 
 // Standard headers.
 #include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <map>
 #include <sstream>
@@ -185,7 +185,7 @@ namespace
     {
         std::string                     m_name;                 // name of the appleseed object
         std::map<MtlID, std::string>    m_mtlid_to_slot_name;   // map a Max's material ID to an appleseed's material slot name
-        std::map<MtlID, asf::uint32>    m_mtlid_to_slot_index;  // map a Max's material ID to an appleseed's material slot index
+        std::map<MtlID, std::uint32_t>  m_mtlid_to_slot_index;  // map a Max's material ID to an appleseed's material slot index
     };
 
     asf::auto_release_ptr<asr::MeshObject> convert_mesh_object(
@@ -231,7 +231,7 @@ namespace
             const DWORD face_smgroup = face.getSmGroup();
             const MtlID face_mat = face.getMatID();
 
-            asf::uint32 normal_indices[3];
+            std::uint32_t normal_indices[3];
             if (face_smgroup == 0)
             {
                 // No smooth group for this face, check if face has explicit normals.
@@ -248,7 +248,7 @@ namespace
                         
                         const Point3& n = nspec->Normal(norm_index);
                         normal_indices[j] =
-                            static_cast<asf::uint32>(
+                            static_cast<std::uint32_t>(
                                 object->push_vertex_normal(
                                     asf::safe_normalize(asr::GVector3(n.x, n.y, n.z))));
                     }
@@ -258,8 +258,8 @@ namespace
                 {
                     // No explicit normals for this face, use face normal.
                     const Point3 n = normal_transform * mesh.getFaceNormal(i);
-                    const asf::uint32 normal_index =
-                        static_cast<asf::uint32>(
+                    const std::uint32_t normal_index =
+                        static_cast<std::uint32_t>(
                             object->push_vertex_normal(
                                 asf::safe_normalize(asr::GVector3(n.x, n.y, n.z))));
                     normal_indices[0] = normal_index;
@@ -278,7 +278,7 @@ namespace
                         // This vertex has a single normal.
                         const Point3& n = rvertex.rn.getNormal();
                         normal_indices[j] =
-                            static_cast<asf::uint32>(
+                            static_cast<std::uint32_t>(
                                 object->push_vertex_normal(
                                     asf::safe_normalize(asr::GVector3(n.x, n.y, n.z))));
                     }
@@ -293,7 +293,7 @@ namespace
                             {
                                 const Point3& n = rn.getNormal();
                                 normal_indices[j] =
-                                    static_cast<asf::uint32>(
+                                    static_cast<std::uint32_t>(
                                         object->push_vertex_normal(
                                             asf::safe_normalize(asr::GVector3(n.x, n.y, n.z))));
                                 break;
@@ -304,7 +304,7 @@ namespace
             }
 
             static_assert(
-                sizeof(DWORD) == sizeof(asf::uint32),
+                sizeof(DWORD) == sizeof(std::uint32_t),
                 "DWORD is expected to be 32-bit long");
 
             asr::Triangle triangle;
@@ -329,14 +329,14 @@ namespace
 
             // Assign to the triangle the material slot corresponding to the face's material ID,
             // creating a new material slot if necessary.
-            asf::uint32 slot_index;
+            std::uint32_t slot_index;
             const MtlID mtlid = face.getMatID();
             const auto it = object_info.m_mtlid_to_slot_index.find(mtlid);
             if (it == object_info.m_mtlid_to_slot_index.end())
             {
                 // Create a new material slot in the object.
                 const auto slot_name = "material_slot_" + asf::to_string(object->get_material_slot_count());
-                slot_index = static_cast<asf::uint32>(object->push_material_slot(slot_name.c_str()));
+                slot_index = static_cast<std::uint32_t>(object->push_material_slot(slot_name.c_str()));
                 object_info.m_mtlid_to_slot_name.insert(std::make_pair(mtlid, slot_name));
                 object_info.m_mtlid_to_slot_index.insert(std::make_pair(mtlid, slot_index));
             }

--- a/src/appleseed-max-impl/appleseedrenderer/renderercontroller.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/renderercontroller.cpp
@@ -45,7 +45,7 @@ namespace asr = renderer;
 
 RendererController::RendererController(
     RendProgressCallback*   progress_cb,
-    volatile asf::uint32*   rendered_tile_count,
+    volatile std::uint32_t* rendered_tile_count,
     const size_t            total_tile_count)
   : m_progress_cb(progress_cb)
   , m_rendered_tile_count(rendered_tile_count)

--- a/src/appleseed-max-impl/appleseedrenderer/renderercontroller.h
+++ b/src/appleseed-max-impl/appleseedrenderer/renderercontroller.h
@@ -34,11 +34,9 @@
 // appleseed.renderer headers.
 #include "renderer/api/rendering.h"
 
-// appleseed.foundation headers.
-#include "foundation/platform/types.h"
-
 // Standard headers.
 #include <cstddef>
+#include <cstdint>
 
 // Forward declarations.
 class RendProgressCallback;
@@ -49,7 +47,7 @@ class RendererController
   public:
     RendererController(
         RendProgressCallback*           progress_cb,
-        volatile foundation::uint32*    rendered_tile_count,
+        volatile std::uint32_t*         rendered_tile_count,
         const size_t                    total_tile_count);
 
     void on_rendering_begin() override;
@@ -60,7 +58,7 @@ class RendererController
 
   private:
     RendProgressCallback*               m_progress_cb;
-    volatile foundation::uint32*        m_rendered_tile_count;
+    volatile std::uint32_t*             m_rendered_tile_count;
     const size_t                        m_total_tile_count;
     Status                              m_status;
 };

--- a/src/appleseed-max-impl/appleseedrenderer/renderersettings.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/renderersettings.cpp
@@ -758,7 +758,7 @@ bool RendererSettings::save(ISave* isave) const
         isave->EndChunk();
 
         isave->BeginChunk(ChunkSettingsSystemTextureCacheSize);
-        success &= write<foundation::uint64>(isave, m_texture_cache_size);
+        success &= write<std::uint64_t>(isave, m_texture_cache_size);
         isave->EndChunk();
         
     isave->EndChunk();
@@ -1237,7 +1237,7 @@ IOResult RendererSettings::load_system_settings(ILoad* iload)
             break;
 
           case ChunkSettingsSystemTextureCacheSize:
-            result = read<foundation::uint64>(iload, &m_texture_cache_size);
+            result = read<std::uint64_t>(iload, &m_texture_cache_size);
             break;
         }
 

--- a/src/appleseed-max-impl/appleseedrenderer/renderersettings.h
+++ b/src/appleseed-max-impl/appleseedrenderer/renderersettings.h
@@ -190,7 +190,7 @@ class RendererSettings
     bool                        m_use_max_procedural_maps;
     DialogLogTarget::OpenMode   m_log_open_mode;
     bool                        m_log_material_editor_messages;
-    foundation::uint64          m_texture_cache_size;
+    std::uint64_t               m_texture_cache_size;
 
     // Apply these settings to a given project.
     void apply(renderer::Project& project) const;

--- a/src/appleseed-max-impl/appleseedrenderer/tilecallback.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/tilecallback.cpp
@@ -131,7 +131,7 @@ namespace
 
 TileCallback::TileCallback(
     Bitmap*                 bitmap,
-    volatile asf::uint32*   rendered_tile_count)
+    volatile std::uint32_t* rendered_tile_count)
   : m_bitmap(bitmap)
   , m_rendered_tile_count(rendered_tile_count)
 {

--- a/src/appleseed-max-impl/appleseedrenderer/tilecallback.h
+++ b/src/appleseed-max-impl/appleseedrenderer/tilecallback.h
@@ -36,10 +36,10 @@
 
 // appleseed.foundation headers.
 #include "foundation/image/tile.h"
-#include "foundation/platform/types.h"
 
 // Standard headers.
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 
 // Forward declarations.
@@ -52,7 +52,7 @@ class TileCallback
   public:
     TileCallback(
         Bitmap*                         bitmap,
-        volatile foundation::uint32*    rendered_tile_count);
+        volatile std::uint32_t*         rendered_tile_count);
 
     void release() override;
 
@@ -71,7 +71,7 @@ class TileCallback
 
   private:
     Bitmap*                             m_bitmap;
-    volatile foundation::uint32*        m_rendered_tile_count;
+    volatile std::uint32_t*             m_rendered_tile_count;
     std::unique_ptr<foundation::Tile>   m_float_tile_storage;
 
     void blit_tile(

--- a/src/appleseed-max-impl/utilities.cpp
+++ b/src/appleseed-max-impl/utilities.cpp
@@ -582,7 +582,7 @@ namespace
         {
         }
 
-        asf::uint64 compute_signature() const override
+        std::uint64_t compute_signature() const override
         {
             return asf::siphash24(m_texmap);
         }


### PR DESCRIPTION
- Changes obsolete appleseed-foundation custom fixed width integer types with C++11 compatible ones. 
Related to [https://github.com/appleseedhq/appleseed/pull/2743](url)