### PR TITLE
Fix interactive render crash on cancel

### DIFF
--- a/src/appleseed-max-impl/appleseedinteractive/interactivesession.cpp
+++ b/src/appleseed-max-impl/appleseedinteractive/interactivesession.cpp
@@ -70,12 +70,11 @@ void InteractiveSession::render_thread()
         m_renderer_controller.get());
 
     // Create the master renderer.
-    asf::SearchPaths search_paths;
     std::unique_ptr<asr::MasterRenderer> renderer(
         new asr::MasterRenderer(
             *m_project,
             m_project->configurations().get_by_name("interactive")->get_inherited_parameters(),
-            search_paths,   // don't pass a temporary because MasterRenderer only holds a const reference to the search paths
+            m_search_paths,
             &m_tile_callback));
 
     // Render the frame.

--- a/src/appleseed-max-impl/appleseedinteractive/interactivesession.cpp
+++ b/src/appleseed-max-impl/appleseedinteractive/interactivesession.cpp
@@ -39,9 +39,6 @@
 #include "renderer/api/project.h"
 #include "renderer/api/rendering.h"
 
-// appleseed.foundation headers.
-#include "foundation/utility/searchpaths.h"
-
 namespace asf = foundation;
 namespace asr = renderer;
 

--- a/src/appleseed-max-impl/appleseedinteractive/interactivesession.h
+++ b/src/appleseed-max-impl/appleseedinteractive/interactivesession.h
@@ -45,6 +45,8 @@
 // Forward declarations.
 namespace renderer { class Camera; }
 namespace renderer { class Project; }
+namespace foundation { class SearchPaths; }
+
 class Bitmap;
 class IIRenderMgr;
 
@@ -72,6 +74,7 @@ class InteractiveSession
     IIRenderMgr*                                    m_iirender_mgr;
     renderer::Project*                              m_project;
     RendererSettings                                m_renderer_settings;
+    foundation::SearchPaths                         m_search_paths;
 
     void render_thread();
 };

--- a/src/appleseed-max-impl/appleseedinteractive/interactivesession.h
+++ b/src/appleseed-max-impl/appleseedinteractive/interactivesession.h
@@ -43,9 +43,9 @@
 #include <thread>
 
 // Forward declarations.
-namespace renderer { class Camera; }
-namespace renderer { class Project; }
 namespace foundation { class SearchPaths; }
+namespace renderer   { class Camera; }
+namespace renderer   { class Project; }
 
 class Bitmap;
 class IIRenderMgr;
@@ -73,8 +73,8 @@ class InteractiveSession
     Bitmap*                                         m_bitmap;
     IIRenderMgr*                                    m_iirender_mgr;
     renderer::Project*                              m_project;
-    RendererSettings                                m_renderer_settings;
     foundation::SearchPaths                         m_search_paths;
+    RendererSettings                                m_renderer_settings;
 
     void render_thread();
 };

--- a/src/appleseed-max-impl/appleseedinteractive/interactivesession.h
+++ b/src/appleseed-max-impl/appleseedinteractive/interactivesession.h
@@ -37,13 +37,13 @@
 
 // appleseed.foundation headers.
 #include "foundation/utility/autoreleaseptr.h"
+#include "foundation/utility/searchpaths.h"
 
 // Standard headers.
 #include <memory>
 #include <thread>
 
 // Forward declarations.
-namespace foundation { class SearchPaths; }
 namespace renderer   { class Camera; }
 namespace renderer   { class Project; }
 


### PR DESCRIPTION
This should fix #341 
Reference to destructed local variable `search_paths` was kept in `MasterRenderer` class.