### PR TITLE
Fix OSL parameter bugs

### DIFF
--- a/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslshadermetadata.cpp
@@ -244,7 +244,9 @@ OSLShaderInfo::OSLShaderInfo(
         {
             OSLParamInfo osl_param(q.get_param_info(i));
 
-            if (osl_param.m_widget == "null" && !osl_param.m_is_connectable)
+            if (osl_param.m_widget == "null" && 
+                !osl_param.m_is_connectable && 
+                !osl_param.m_is_output)
                 continue;
 
             MaxParam& max_param = osl_param.m_max_param;

--- a/src/appleseed-max-impl/oslutils.cpp
+++ b/src/appleseed-max-impl/oslutils.cpp
@@ -597,7 +597,7 @@ void create_osl_shader(
     {
         const MaxParam& max_param = param_info.m_max_param;
         Texmap* texmap = nullptr;
-        if (max_param.m_is_connectable)
+        if (max_param.m_is_connectable && max_param.m_param_type != MaxParam::Closure)
         {
             param_block->GetValue(max_param.m_max_map_param_id, time, texmap, FOREVER);
 
@@ -667,7 +667,7 @@ void create_osl_shader(
             }
         }
 
-        if (!max_param.m_is_connectable || texmap == nullptr)
+        if (max_param.m_is_constant)
         {
             switch (max_param.m_param_type)
             {


### PR DESCRIPTION
Hi,
This PR fixes two bugs in OSL plugin:
1. Ouput parameter were skipped due to their usual metadata `widget="null"`. Bug was introduced with recent changes
2. Shader parameters that were marked as connectible and didn't have actual connection (texture in our case) didn't get their default values properly. Now it's fixed by skipping that kind of parameters altogether in `create_osl_shader` function.

Thanks,
Sergo.