### PR TITLE
Add Importon Tracing control to SPPM render settings

### DIFF
--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
@@ -1630,7 +1630,7 @@ ParamBlockDesc2 g_param_block_desc(
     ParamIdSPPMEnableImportons, L"enable_importons", TYPE_BOOL, P_TRANSIENT, 0,
         p_ui, ParamMapIdSPPM, TYPE_SINGLECHEKBOX, IDC_CHECK_SPPM_ENABLE_IMPORTONS,
         p_default, TRUE,
-        p_accessor, & g_pblock_accessor,
+        p_accessor, &g_pblock_accessor,
     p_end,
 
      // --- Parameters specifications for Post-Processing rollup ---

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.cpp
@@ -167,6 +167,7 @@ namespace
         ParamIdSPPMViewPhotonsRadius                    = 73,
         ParamIdSPPMEnableMaxRayIntensity                = 74,
         ParamIdSPPMMaxRayIntensity                      = 75,
+        ParamIdSPPMEnableImportons                      = 84,
 
         ParamIdEnableRenderStamp                        = 21,
         ParamIdRenderStampFormat                        = 22,
@@ -609,6 +610,10 @@ void AppleseedRendererPBlockAccessor::Get(
         v.f = settings.m_sppm_max_ray_intensity;
         break;
 
+      case ParamIdSPPMEnableImportons:
+        v.i = static_cast<int>(settings.m_sppm_enable_importons);
+        break;
+
       //
       // Post-Processing.
       //
@@ -994,6 +999,10 @@ void AppleseedRendererPBlockAccessor::Set(
         settings.m_sppm_max_ray_intensity = v.f;
         break;
 
+      case ParamIdSPPMEnableImportons:
+        settings.m_sppm_enable_importons = v.i > 0;
+        break;
+
       //
       // Postprocessing.
       //
@@ -1082,7 +1091,7 @@ ParamBlockDesc2 g_param_block_desc(
     0,                                          // ID of the localized name string
     &g_appleseed_renderer_classdesc,            // class descriptor
     P_AUTO_CONSTRUCT + 
-    P_AUTO_UI + 
+    P_AUTO_UI +
     P_MULTIMAP + 
     P_VERSION + 
     P_CALLSETS_ON_LOAD,                         // block flags
@@ -1579,7 +1588,7 @@ ParamBlockDesc2 g_param_block_desc(
     ParamIdSPPMRadianceEstimationMaxPhotons, L"max_photons_per_estimate", TYPE_INT, P_TRANSIENT, 0,
         p_ui, ParamMapIdSPPM, TYPE_SPINNER, EDITTYPE_POS_INT, IDC_TEXT_SPPM_RADIANCE_MAX_PHOTONS, IDC_SPINNER_SPPM_RADIANCE_MAX_PHOTONS, SPIN_AUTOSCALE,
         p_default, 100,
-        p_range, 8, 1000000000,
+        p_range, 8, 10000,
         p_accessor, &g_pblock_accessor,
     p_end,
 
@@ -1616,6 +1625,12 @@ ParamBlockDesc2 g_param_block_desc(
         p_default, 1.0f,
         p_range, 0.0f, 10000.0f,
         p_accessor, &g_pblock_accessor,
+    p_end,
+
+    ParamIdSPPMEnableImportons, L"enable_importons", TYPE_BOOL, P_TRANSIENT, 0,
+        p_ui, ParamMapIdSPPM, TYPE_SINGLECHEKBOX, IDC_CHECK_SPPM_ENABLE_IMPORTONS,
+        p_default, TRUE,
+        p_accessor, & g_pblock_accessor,
     p_end,
 
      // --- Parameters specifications for Post-Processing rollup ---

--- a/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.rc
+++ b/src/appleseed-max-impl/appleseedrenderer/appleseedrenderer.rc
@@ -280,7 +280,7 @@ BEGIN
                     "SpinnerControl",WS_TABSTOP,135,90,6,10
 END
 
-IDD_FORMVIEW_RENDERERPARAMS_SPPM DIALOGEX 0, 0, 200, 291
+IDD_FORMVIEW_RENDERERPARAMS_SPPM DIALOGEX 0, 0, 200, 301
 STYLE DS_SETFONT | WS_CHILD | WS_VISIBLE
 FONT 8, "MS Sans Serif", 0, 0, 0x1
 BEGIN
@@ -292,62 +292,64 @@ BEGIN
     CONTROL         "Image-Based Lighting",IDC_CHECK_SPPM_IMAGE_BASED_LIGHTING,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,53,84,10
     CONTROL         "Caustics",IDC_CHECK_SPPM_CAUSTICS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,105,53,43,10
-    GROUPBOX        "Photon Tracing",IDC_STATIC,0,69,199,84
-    CONTROL         "Max Bounces:",IDC_CHECK_SPPM_PT_BOUNCES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,81,58,10
-    CONTROL         "Max Ray Bounces",IDC_TEXT_SPPM_PT_BOUNCES,"CustEdit",WS_TABSTOP,106,80,16,10
+    GROUPBOX        "Photon Tracing",IDC_STATIC,0,67,199,97
+    CONTROL         "Max Bounces:",IDC_CHECK_SPPM_PT_BOUNCES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,93,58,10
+    CONTROL         "Max Ray Bounces",IDC_TEXT_SPPM_PT_BOUNCES,"CustEdit",WS_TABSTOP,106,92,16,10
     CONTROL         "Max Ray Bounces",IDC_SPINNER_SPPM_PT_BOUNCES,
-                    "SpinnerControl",WS_TABSTOP,125,80,6,10
-    LTEXT           "Russian Roulette Start Bounce:",IDC_STATIC_SPPM_PT_RR_MIN_PATH_LENGTH,4,96,100,8
+                    "SpinnerControl",WS_TABSTOP,125,92,6,10
+    LTEXT           "Russian Roulette Start Bounce:",IDC_STATIC_SPPM_PT_RR_MIN_PATH_LENGTH,4,108,100,8
     CONTROL         "Russian Roulette Start Bounce",IDC_TEXT_SPPM_PT_RR_MIN_PATH_LENGTH,
-                    "CustEdit",WS_TABSTOP,106,95,16,10
+                    "CustEdit",WS_TABSTOP,106,107,16,10
     CONTROL         "Russian Roulette Start Bounce",IDC_SPINNER_SPPM_PT_RR_MIN_PATH_LENGTH,
-                    "SpinnerControl",WS_TABSTOP,125,95,6,10
-    LTEXT           "Light Photons:",IDC_STATIC_SPPM_PT_LIGHT_PHOTONS,4,111,46,8
-    CONTROL         "Light Photons",IDC_TEXT_SPPM_PT_LIGHT_PHOTONS,"CustEdit",WS_TABSTOP,106,110,37,10
+                    "SpinnerControl",WS_TABSTOP,125,107,6,10
+    LTEXT           "Light Photons:",IDC_STATIC_SPPM_PT_LIGHT_PHOTONS,4,123,46,8
+    CONTROL         "Light Photons",IDC_TEXT_SPPM_PT_LIGHT_PHOTONS,"CustEdit",WS_TABSTOP,106,122,37,10
     CONTROL         "Light Photons",IDC_SPINNER_SPPM_PT_LIGHT_PHOTONS,
-                    "SpinnerControl",WS_TABSTOP,145,110,6,10
-    LTEXT           "Environment Photons:",IDC_STATIC_SPPM_PT_ENVIRONMENT_PHOTONS,4,126,70,8
+                    "SpinnerControl",WS_TABSTOP,145,122,6,10
+    LTEXT           "Environment Photons:",IDC_STATIC_SPPM_PT_ENVIRONMENT_PHOTONS,4,138,70,8
     CONTROL         "Environment Photons",IDC_TEXT_SPPM_PT_ENVIRONMENT_PHOTONS,
-                    "CustEdit",WS_TABSTOP,106,125,37,10
+                    "CustEdit",WS_TABSTOP,106,137,37,10
     CONTROL         "Environment Photons",IDC_SPINNER_SPPM_PT_ENVIRONMENT_PHOTONS,
-                    "SpinnerControl",WS_TABSTOP,145,125,6,10
-    CONTROL         "Max Bounces:",IDC_CHECK_SPPM_RADIANCE_BOUNCES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,171,58,10
+                    "SpinnerControl",WS_TABSTOP,145,137,6,10
+    CONTROL         "Max Bounces:",IDC_CHECK_SPPM_RADIANCE_BOUNCES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,180,58,10
     CONTROL         "Max Ray Bounces",IDC_TEXT_SPPM_RADIANCE_BOUNCES,
-                    "CustEdit",WS_TABSTOP,106,170,16,10
+                    "CustEdit",WS_TABSTOP,106,179,16,10
     CONTROL         "Max Ray Bounces",IDC_SPINNER_SPPM_RADIANCE_BOUNCES,
-                    "SpinnerControl",WS_TABSTOP,125,170,6,10
-    LTEXT           "Russian Roulette Start Bounce:",IDC_STATIC_SPPM_RADIANCE_RR_MIN_PATH_LENGTH,4,185,100,8
+                    "SpinnerControl",WS_TABSTOP,125,179,6,10
+    LTEXT           "Russian Roulette Start Bounce:",IDC_STATIC_SPPM_RADIANCE_RR_MIN_PATH_LENGTH,4,194,100,8
     CONTROL         "Russian Roulette Start Bounce",IDC_TEXT_SPPM_RADIANCE_RR_MIN_PATH_LENGTH,
-                    "CustEdit",WS_TABSTOP,106,185,16,10
+                    "CustEdit",WS_TABSTOP,106,194,16,10
     CONTROL         "Russian Roulette Start Bounce",IDC_SPINNER_SPPM_RADIANCE_RR_MIN_PATH_LENGTH,
-                    "SpinnerControl",WS_TABSTOP,125,185,6,10
-    LTEXT           "Initial Radius:",IDC_STATIC_SPPM_RADIANCE_INITIAL_RADIUS,4,200,43,8
+                    "SpinnerControl",WS_TABSTOP,125,194,6,10
+    LTEXT           "Initial Radius:",IDC_STATIC_SPPM_RADIANCE_INITIAL_RADIUS,4,208,43,8
     CONTROL         "Initial Search Radius",IDC_TEXT_SPPM_RADIANCE_INITIAL_RADIUS,
-                    "CustEdit",WS_TABSTOP,106,199,18,10
+                    "CustEdit",WS_TABSTOP,106,208,18,10
     CONTROL         "Initial Search Radius",IDC_SPINNER_SPPM_RADIANCE_INITIAL_RADIUS,
-                    "SpinnerControl",WS_TABSTOP,125,199,6,10
-    LTEXT           "Max Photons:",IDC_STATIC_SPPM_RADIANCE_MAX_PHOTONS,4,214,44,8
+                    "SpinnerControl",WS_TABSTOP,125,208,6,10
+    LTEXT           "Max Photons:",IDC_STATIC_SPPM_RADIANCE_MAX_PHOTONS,4,222,44,8
     CONTROL         "Max Photons",IDC_TEXT_SPPM_RADIANCE_MAX_PHOTONS,
-                    "CustEdit",WS_TABSTOP,106,214,16,10
+                    "CustEdit",WS_TABSTOP,106,223,16,10
     CONTROL         "Max Photons",IDC_SPINNER_SPPM_RADIANCE_MAX_PHOTONS,
-                    "SpinnerControl",WS_TABSTOP,125,214,6,10
-    LTEXT           "Alpha:",IDC_STATIC_SPPM_RADIANCE_ALPHA,4,229,21,8
-    CONTROL         "Alpha",IDC_TEXT_SPPM_RADIANCE_ALPHA,"CustEdit",WS_TABSTOP,106,229,18,10
-    CONTROL         "Alpha",IDC_SPINNER_SPPM_RADIANCE_ALPHA,"SpinnerControl",WS_TABSTOP,125,229,6,10
-    GROUPBOX        "Radiance  Estimation",IDC_STATIC,0,158,199,84
-    CONTROL         "Visualize Photons",IDC_CHECK_SPPM_VIEW_PHOTONS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,260,71,10
-    GROUPBOX        "Debug Options",IDC_STATIC,0,247,199,41
-    LTEXT           "Initial View Radius:",IDC_STATIC_SPPM_VIEW_PHOTONS_RADIUS,4,275,60,8
+                    "SpinnerControl",WS_TABSTOP,125,223,6,10
+    LTEXT           "Alpha:",IDC_STATIC_SPPM_RADIANCE_ALPHA,4,237,21,8
+    CONTROL         "Alpha",IDC_TEXT_SPPM_RADIANCE_ALPHA,"CustEdit",WS_TABSTOP,106,238,18,10
+    CONTROL         "Alpha",IDC_SPINNER_SPPM_RADIANCE_ALPHA,"SpinnerControl",WS_TABSTOP,125,238,6,10
+    GROUPBOX        "Radiance  Estimation",IDC_STATIC,0,167,199,86
+    CONTROL         "Visualize Photons",IDC_CHECK_SPPM_VIEW_PHOTONS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,268,71,10
+    GROUPBOX        "Debug Options",IDC_STATIC,0,257,199,41
+    LTEXT           "Initial View Radius:",IDC_STATIC_SPPM_VIEW_PHOTONS_RADIUS,4,287,60,8
     CONTROL         "Initial View Radius",IDC_TEXT_SPPM_VIEW_PHOTONS_RADIUS,
-                    "CustEdit",WS_TABSTOP,106,274,18,10
+                    "CustEdit",WS_TABSTOP,106,280,18,10
     CONTROL         "Initial View Radius",IDC_SPINNER_SPPM_VIEW_PHOTONS_RADIUS,
-                    "SpinnerControl",WS_TABSTOP,125,274,6,10
+                    "SpinnerControl",WS_TABSTOP,125,280,6,10
     CONTROL         "Max Ray Intensity:",IDC_CHECK_SPPM_MAX_RAY_INTENSITY,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,140,74,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,152,74,10
     CONTROL         "Max Ray Intensity",IDC_TEXT_SPPM_MAX_RAY_INTENSITY,
-                    "CustEdit",WS_TABSTOP,106,140,18,10
+                    "CustEdit",WS_TABSTOP,106,152,18,10
     CONTROL         "Max Ray Intensity",IDC_SPINNER_SPPM_MAX_RAY_INTENSITY,
-                    "SpinnerControl",WS_TABSTOP,125,140,6,10
+                    "SpinnerControl",WS_TABSTOP,125,152,6,10
+    CONTROL         "Enable Importons",IDC_CHECK_SPPM_ENABLE_IMPORTONS,
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,79,71,10
 END
 
 
@@ -399,7 +401,7 @@ BEGIN
 
     IDD_FORMVIEW_RENDERERPARAMS_SPPM, DIALOG
     BEGIN
-        BOTTOMMARGIN, 288
+        BOTTOMMARGIN, 298
     END
 END
 #endif    // APSTUDIO_INVOKED

--- a/src/appleseed-max-impl/appleseedrenderer/renderersettings.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/renderersettings.cpp
@@ -119,6 +119,7 @@ namespace
             m_sppm_view_photons_radius = 0.05f;
             m_sppm_max_ray_intensity_set = false;
             m_sppm_max_ray_intensity = 1.0f;
+            m_sppm_enable_importons = true;
 
             m_output_mode = OutputMode::RenderOnly;
             m_scale_multiplier = 1.0f;
@@ -322,6 +323,7 @@ void RendererSettings::apply_common_settings(asr::Project& project, const char* 
     params.insert_path("sppm.alpha", m_sppm_radiance_estimation_alpha);
     params.insert_path("sppm.view_photons", m_sppm_view_photons);
     params.insert_path("sppm.view_photons_radius", m_sppm_view_photons_radius);
+    params.insert_path("sppm.enable_importons", m_sppm_enable_importons);
 
     params.insert_path("use_embree", m_enable_embree);
     params.insert_path("texture_store.max_size", m_texture_cache_size * 1024 * 1024);

--- a/src/appleseed-max-impl/appleseedrenderer/renderersettings.h
+++ b/src/appleseed-max-impl/appleseedrenderer/renderersettings.h
@@ -143,6 +143,7 @@ class RendererSettings
     float                       m_sppm_view_photons_radius;
     bool                        m_sppm_max_ray_intensity_set;
     float                       m_sppm_max_ray_intensity;
+    bool                        m_sppm_enable_importons;
 
     //
     // Output.

--- a/src/appleseed-max-impl/appleseedrenderer/resource.h
+++ b/src/appleseed-max-impl/appleseedrenderer/resource.h
@@ -128,6 +128,12 @@
 #define IDC_TEXT_MATERIAL_PREVIEW_QUALITY               450
 #define IDC_SPINNER_MATERIAL_PREVIEW_QUALITY            451
 #define IDC_STATIC_MATERIAL_PREVIEW_QUALITY             452
+#define IDC_STATIC_LIGHTING                             453
+#define IDC_STATIC_OVERRIDE_MATERIAL                    454
+#define IDC_BUTTON_OVERRIDE_MATERIAL                    455
+#define IDC_CHECK_OVERRIDE_MATERIAL                     456
+#define IDC_CHECK_OVERRIDE_MATERIAL_SKIP_LIGHTS         457
+#define IDC_CHECK_OVERRIDE_MATERIAL_SKIP_GLASS          458
 #define IDD_FORMVIEW_RENDERERPARAMS_SYSTEM              500
 #define IDC_TEXT_RENDERINGTHREADS                       501
 #define IDC_SPINNER_RENDERINGTHREADS                    502
@@ -220,13 +226,7 @@
 #define IDC_SPINNER_SPPM_MAX_RAY_INTENSITY              944
 #define IDC_TEXT_SPPM_MAX_RAY_INTENSITY                 945
 #define IDC_STATIC_SPPM_MAX_RAY_INTENSITY               946
-
-#define IDC_STATIC_LIGHTING                             453
-#define IDC_STATIC_OVERRIDE_MATERIAL                    454
-#define IDC_BUTTON_OVERRIDE_MATERIAL                    455
-#define IDC_CHECK_OVERRIDE_MATERIAL                     456
-#define IDC_CHECK_OVERRIDE_MATERIAL_SKIP_LIGHTS         457
-#define IDC_CHECK_OVERRIDE_MATERIAL_SKIP_GLASS          458
+#define IDC_CHECK_SPPM_ENABLE_IMPORTONS                 947
 
 // Next default values for new objects
 // 
@@ -234,7 +234,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        111
 #define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1043
+#define _APS_NEXT_CONTROL_VALUE         1044
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif


### PR DESCRIPTION
- Adds a checkbox to enable/disable Importon Tracing in the SPPM render settings (default is enabled)
