### PR TITLE
Bug fix for cut-off OSL materials parameter labels

### DIFF
--- a/src/appleseed-max-impl/appleseedoslplugin/oslparamdlg.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslparamdlg.cpp
@@ -5,7 +5,7 @@
 //
 // This software is released under the MIT license.
 //
-// Copyright (c) 2018 Sergo Pogosyan, The appleseedhq Organization
+// Copyright (c) 2018-2020 Sergo Pogosyan, The appleseedhq Organization
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -35,7 +35,6 @@
 #include "bump/bumpparammapdlgproc.h"
 #include "bump/resource.h"
 #include "main.h"
-#include "oslutils.h"
 #include "utilities.h"
 
 // 3ds Max headers.
@@ -151,7 +150,7 @@ namespace
         
         // Build root page.
         PageGroup root_page;
-        root_page.m_width = 217;
+        root_page.m_width = 247;
         for (auto& page : pages)
         {
             auto parent_name = page.first;
@@ -248,7 +247,7 @@ void OSLParamDlg::add_groupboxes(
             NULL,
             page.second.m_x,
             page.second.m_y,
-            page.second.m_width,
+            page.second.m_width - 20,
             page.second.m_height,
             0);
         
@@ -261,10 +260,10 @@ void OSLParamDlg::add_ui_parameter(
     const MaxParam&         max_param,
     PageGroupMap&           pages)
 {
-    const int Col2X = 85;
-    const int Col3X = 122;
-    const int Col4X = 159;
-    const int LabelWidth = 76;
+    const int Col2X = 95; 
+    const int Col3X = 132;
+    const int Col4X = 169;
+    const int LabelWidth = 86;
     const int EditWidth = 25;
     const int EditHeight = 10;
     const int TexButtonWidth = 84;
@@ -272,7 +271,7 @@ void OSLParamDlg::add_ui_parameter(
 
     int col1_x = 10;
     int y_pos = 5;
-    auto param_page = pages.find(max_param.m_page_name);
+    const auto param_page = pages.find(max_param.m_page_name);
     if (param_page != pages.end())
     {
         y_pos = param_page->second.m_y;
@@ -315,7 +314,7 @@ void OSLParamDlg::add_ui_parameter(
             break;
 
           case MaxParam::Color:
-            dialog_template.AddComponent((LPCSTR)"ColorSwatch", (LPCSTR)"Color", WS_VISIBLE | WS_TABSTOP, NULL, Col2X, y_pos, EditWidth, EditHeight, ctrl_id++);
+            dialog_template.AddComponent((LPCSTR)"ColorSwatch", (LPCSTR)"Color", WS_VISIBLE | WS_TABSTOP, NULL, Col2X, y_pos, EditWidth + 10, EditHeight, ctrl_id++);
             break;
 
           case MaxParam::String:
@@ -371,7 +370,7 @@ void OSLParamDlg::create_dialog()
         DS_SETFONT | WS_CHILD | WS_VISIBLE,
         0,
         0,
-        217,
+        227,
         dlg_height,
         (LPCSTR)"MS Sans Serif",
         8);
@@ -387,7 +386,7 @@ void OSLParamDlg::create_dialog()
             add_ui_parameter(dialogTemplate, osl_param.m_max_param, pages);
     }
 
-    std::wstring rollout_header(m_shader_info->m_max_shader_name + L" Parameters");
+    const std::wstring rollout_header(m_shader_info->m_max_shader_name + L" Parameters");
     
     m_pmap = CreateMParamMap2(
         m_osl_plugin->GetParamBlock(0),
@@ -401,8 +400,8 @@ void OSLParamDlg::create_dialog()
         0,
         new OSLParamMapDlgProc());
 
-    auto tn_vec = m_shader_info->find_param("Tn");
-    auto bump_normal = m_shader_info->find_maya_attribute("normalCamera");
+    const OSLParamInfo* tn_vec = m_shader_info->find_param("Tn");
+    const OSLParamInfo* bump_normal = m_shader_info->find_maya_attribute("normalCamera");
 
     if (!m_shader_info->m_is_texture &&
         (tn_vec != nullptr || bump_normal != nullptr))

--- a/src/appleseed-max-impl/appleseedoslplugin/oslparamdlg.cpp
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslparamdlg.cpp
@@ -260,7 +260,7 @@ void OSLParamDlg::add_ui_parameter(
     const MaxParam&         max_param,
     PageGroupMap&           pages)
 {
-    const int Col2X = 95; 
+    const int Col2X = 95;
     const int Col3X = 132;
     const int Col4X = 169;
     const int LabelWidth = 86;

--- a/src/appleseed-max-impl/appleseedoslplugin/oslparamdlg.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/oslparamdlg.h
@@ -61,8 +61,8 @@ struct PageGroup
     PageGroup*                  m_parent;
 
     PageGroup()
-      : m_y(0)
-      , m_x(0)
+      : m_x(0)
+      , m_y(0)
       , m_width(0)
       , m_height(0)
       , m_parent(nullptr)

--- a/src/appleseed-max-impl/appleseedoslplugin/templategenerator.h
+++ b/src/appleseed-max-impl/appleseedoslplugin/templategenerator.h
@@ -10,7 +10,7 @@ class DialogTemplate
   public:
 
     DialogTemplate(LPCSTR caption, DWORD style, int x, int y, int w, int h, 
-        LPCSTR font = NULL, WORD fontSize = 8)
+        LPCSTR font = nullptr, WORD fontSize = 8)
     {
         usedBufferLength = sizeof(DLGTEMPLATE);
         totalBufferLength = usedBufferLength;
@@ -19,7 +19,7 @@ class DialogTemplate
 
         dialogTemplate->style = style;
 
-        if (font != NULL)
+        if (font != nullptr)
         {
             dialogTemplate->style |= DS_SETFONT;
         }
@@ -39,7 +39,7 @@ class DialogTemplate
         // Add the dialog's caption to the template.
         AppendString(caption);
 
-        if (font != NULL)
+        if (font != nullptr)
         {
             AppendData(&fontSize, sizeof(WORD));
             AppendString(font);
@@ -176,7 +176,7 @@ class DialogTemplate
 
     void AlignData(int size)
     {
-        int paddingSize = usedBufferLength % size;
+        const int paddingSize = usedBufferLength % size;
 
         if (paddingSize != 0)
         {
@@ -187,7 +187,7 @@ class DialogTemplate
 
     void AppendString(LPCSTR string)
     {
-        int length = MultiByteToWideChar(CP_ACP, 0, string, -1, NULL, 0);
+        const int length = MultiByteToWideChar(CP_ACP, 0, string, -1, nullptr, 0);
 
         WCHAR* wideString = (WCHAR*)malloc(sizeof(WCHAR) * length);
         MultiByteToWideChar(CP_ACP, 0, string, -1, wideString, length);

--- a/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
+++ b/src/appleseed-max-impl/appleseedrenderer/projectbuilder.cpp
@@ -89,15 +89,12 @@
 #include <renderelements.h>
 #include <RendType.h>
 #include <Scene/IPhysicalCamera.h>
-#include <trig.h>
 #include <triobj.h>
 #include "appleseed-max-common/_endmaxheaders.h"
 
 // Standard headers.
 #include <cstddef>
 #include <cstdint>
-#include <limits>
-#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
- Fixes a bug (#361) causing cut-off parameter labels in the OSL shader UI
- Some code refactoring and clean-up

New layout of UI:
![osl_material_UI](https://user-images.githubusercontent.com/22252558/79096544-2b9bfa00-7d66-11ea-9dbe-fc5d35232c8f.PNG)
